### PR TITLE
fix: editor wrapper for board context

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -19,7 +19,7 @@ const LazyCalendarView = lazy(() =>
 	import(/* webpackChunkName: "calendar-view" */ './view/calendar/calendar-view')
 );
 const LazyEditorView = lazy(() =>
-	import(/* webpackChunkName: "calendar-edit" */ './view/event-panel-edit/event-edit-panel')
+	import(/* webpackChunkName: "calendar-edit" */ './view/event-panel-edit/board-edit-panel')
 );
 const LazySettingsView = lazy(() =>
 	import(/* webpackChunkName: "settings-view" */ './settings/settings-view')
@@ -79,7 +79,7 @@ export default function App() {
 					label: 'New Appointment',
 					icon: 'CalendarOutline',
 					click: () => {
-						getBridgedFunctions().addBoard('/', { isBoard: true });
+						getBridgedFunctions().addBoard('/');
 					}
 				},
 				secondaryItems: []

--- a/src/view/calendar/calendar-component.jsx
+++ b/src/view/calendar/calendar-component.jsx
@@ -172,8 +172,7 @@ export default function CalendarComponent() {
 
 	const handleSelect = (e) => {
 		addBoard(`/edit?id=new&start=${new Date(e.start).getTime()}&end=${new Date(e.end).getTime()}`, {
-			app: CALENDAR_APP_ID,
-			isBoard: true
+			app: CALENDAR_APP_ID
 		});
 	};
 	const onEventDrop = useCallback(

--- a/src/view/event-panel-edit/board-edit-panel.jsx
+++ b/src/view/event-panel-edit/board-edit-panel.jsx
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React, { useMemo } from 'react';
+import { useBoardConfig } from '@zextras/carbonio-shell-ui';
+import EventEditPanel from './event-edit-panel';
+
+const BoardEditPanel = () => {
+	const context = useBoardConfig();
+	const boardContext = useMemo(() => ({ ...context, isBoard: true }), [context]);
+	return <EventEditPanel boardContext={boardContext} />;
+};
+export default BoardEditPanel;

--- a/src/view/event-panel-edit/event-edit-panel.jsx
+++ b/src/view/event-panel-edit/event-edit-panel.jsx
@@ -127,7 +127,7 @@ const Header = ({ title, expanded, setExpanded }) => {
 	);
 };
 
-const EventEditPanel = () => {
+const EventEditPanel = ({ boardContext }) => {
 	const { calendarId, apptId, ridZ } = useParams();
 	const calendar = useSelector((s) => selectCalendar(s, calendarId));
 	const appointment = useSelector((s) => selectAppointment(s, apptId));
@@ -139,7 +139,6 @@ const EventEditPanel = () => {
 	}, [appointment, calendar, inst]);
 	const [title, setTitle] = useState(null);
 	const [expanded, setExpanded] = useState(false);
-	const boardContext = useBoardConfig();
 	const updateAppTime = useQueryParam('updateTime');
 	const selectedStartTime = useQueryParam('start');
 	const selectedEndTime = useQueryParam('end');


### PR DESCRIPTION
Created a component wrapper to manage board context avoiding to specify props inside context