### PR TITLE
fix: restore the list of available calendars when moving an appointment

### DIFF
--- a/src/view/move/move-modal.tsx
+++ b/src/view/move/move-modal.tsx
@@ -95,12 +95,14 @@ export const MoveModal = ({
 						return [
 							...acc,
 							{
+								divider: true
+							},
+							{
 								...item,
 								label: item.name,
 								items: folders,
 								onClick: () => setFolderDestination(item),
 								open: !!input.length,
-								divider: true,
 								background: folderDestination.id === item.id ? 'highlight' : undefined
 							}
 						];
@@ -116,16 +118,17 @@ export const MoveModal = ({
 	);
 
 	const nestedData = useMemo(
-		() => [
-			{
-				id: FOLDERS.USER_ROOT,
-				label: getFolderTranslatedName(FOLDERS.USER_ROOT, 'Root'),
-				level: 0,
-				open: true,
-				items: nestFilteredFolders(folders, '1', filterFromInput),
-				background: folderDestination.id === '1' ? 'highlight' : undefined
-			} as AccordionItemType
-		],
+		() =>
+			[
+				{
+					id: FOLDERS.USER_ROOT,
+					label: getFolderTranslatedName(FOLDERS.USER_ROOT, 'Root'),
+					level: 0,
+					open: true,
+					items: nestFilteredFolders(folders, '1', filterFromInput),
+					background: folderDestination.id === '1' ? 'highlight' : undefined
+				}
+			] as AccordionItemType[],
 		[filterFromInput, folderDestination.id, folders, nestFilteredFolders]
 	);
 

--- a/src/view/move/new-calendar-modal.tsx
+++ b/src/view/move/new-calendar-modal.tsx
@@ -240,7 +240,6 @@ export const NewModal = ({ onClose, toggleModal, event, action }: NewModalProps)
 			<Select
 				label={'Select color'}
 				onChange={(value): void => {
-					console.log('*** value', value);
 					// setSelectedColor
 				}}
 				items={colors}

--- a/translations/en.json
+++ b/translations/en.json
@@ -415,6 +415,8 @@
             "set_new_time_message": "Do you want to set a new time for the missed appointment? If you click OK, all the other reminders will be automatically dismissed."
         },
         "never": "Never",
+        "second_before": "{{count}} second before",
+        "second_before_plural": "",
         "week_before": "{{count}} week before",
         "week_before_plural": "{{count}} weeks before"
     },


### PR DESCRIPTION
HOTFIX: IRIS-3281