### PR TITLE
fix: moved appointment need action icon to the left

### DIFF
--- a/src/view/reminder/appointment-reminder-item.tsx
+++ b/src/view/reminder/appointment-reminder-item.tsx
@@ -109,7 +109,12 @@ export const AppointmentReminderItem: FC<ApptReminderCardProps> = ({
 					{locationUrl && (
 						<Row>
 							<Text>
-								<a target="_blank" href={locationUrl} rel="noreferrer">
+								<a
+									target="_blank"
+									href={locationUrl}
+									rel="noreferrer"
+									onClick={(e): void => e.stopPropagation()}
+								>
 									{locationUrl}
 								</a>
 							</Text>


### PR DESCRIPTION
Moved appointment need action icon on the left, before title