### PR TITLE
fix: appointment icons aligned to the left

### DIFF
--- a/src/view/calendar/custom-event-component.tsx
+++ b/src/view/calendar/custom-event-component.tsx
@@ -122,7 +122,7 @@ const CustomEventComponent = ({ event, tags, title }: CustomEventComponentProps)
 				event.resource?.participationStatus === 'NE' && (
 					<Tooltip placement="top" label={t('event.action.needs_action', 'Needs action')}>
 						<Row style={{ padding: 'none' }} mainAlignment="center">
-							<Padding right="small">
+							<Padding right="extrasmall">
 								<NeedActionIcon icon="CalendarWarning" color="primary" />
 							</Padding>
 						</Row>
@@ -171,7 +171,7 @@ const CustomEventComponent = ({ event, tags, title }: CustomEventComponentProps)
 					event.resource?.participationStatus === 'NE' && (
 						<Tooltip placement="top" label={t('event.action.needs_action', 'Needs action')}>
 							<Row style={{ padding: 'none' }} mainAlignment="center">
-								<Padding right="small">
+								<Padding right="extrasmall">
 									<NeedActionIcon icon="CalendarWarning" color="primary" />
 								</Padding>
 							</Row>

--- a/src/view/calendar/custom-event.tsx
+++ b/src/view/calendar/custom-event.tsx
@@ -167,10 +167,9 @@ const CustomEvent = ({ event, title }: CustomEventProps): ReactElement => {
 							crossAlignment="center"
 							mainAlignment="flex-start"
 						>
-							<MemoCustomEventComponent tags={tags} event={event} title={title} />
 							{event.resource.class === 'PRI' && (
 								<Tooltip label={t('label.private', 'Private')} placement="top">
-									<Row padding={{ left: 'extrasmall' }}>
+									<Row padding={{ right: 'extrasmall' }}>
 										<Icon color="currentColor" icon="Lock" style={{ minWidth: '1rem' }} />
 									</Row>
 								</Tooltip>
@@ -183,11 +182,12 @@ const CustomEvent = ({ event, title }: CustomEventProps): ReactElement => {
 									)}
 									placement="bottom"
 								>
-									<Row padding={{ left: 'extrasmall' }}>
+									<Row padding={{ right: 'extrasmall' }}>
 										<Icon color="error" icon="AlertCircleOutline" style={{ minWidth: '1rem' }} />
 									</Row>
 								</Tooltip>
 							)}
+							<MemoCustomEventComponent tags={tags} event={event} title={title} />
 						</Container>
 						{!event.allDay && (
 							<Tooltip label={title} placement="top" disabled={event.resource.class === 'PRI'}>


### PR DESCRIPTION
All icons related to the appointment preview are not aligned to the left