### PR TITLE
feat: enable drag and drop of contacts in editor

### DIFF
--- a/src/view/editor/parts/editor-attendees.tsx
+++ b/src/view/editor/parts/editor-attendees.tsx
@@ -224,6 +224,7 @@ export const EditorAttendees = ({ editorId }: EditorAttendeesProps): ReactElemen
 								onChange={onChange}
 								defaultValue={defaultValue}
 								disabled={disabled?.attendees}
+								dragAndDropEnabled
 							/>
 						) : (
 							<ChipInput
@@ -273,6 +274,7 @@ export const EditorAttendees = ({ editorId }: EditorAttendeesProps): ReactElemen
 								placeholder={t('label.optionals', 'Optionals')}
 								onChange={onOptionalsChange}
 								defaultValue={optionalAttendees}
+								dragAndDropEnabled
 								disabled={disabled?.optionalAttendees}
 							/>
 						) : (

--- a/src/view/editor/parts/editor-dropzone.tsx
+++ b/src/view/editor/parts/editor-dropzone.tsx
@@ -3,13 +3,15 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { map } from 'lodash';
 import React, { DragEvent, ReactElement, ReactNode, useCallback, useMemo, useState } from 'react';
+
 import { Container } from '@zextras/carbonio-design-system';
-import { useAppDispatch } from '../../../store/redux/hooks';
-import { editEditorAttachments } from '../../../store/slices/editor-slice';
+import { map } from 'lodash';
+
 import { addAttachments } from './editor-attachments-button';
 import { DropZoneAttachment } from './editor-dropzone-attachments';
+import { useAppDispatch } from '../../../store/redux/hooks';
+import { editEditorAttachments } from '../../../store/slices/editor-slice';
 
 type DropzoneProps = {
 	editorId: string;
@@ -23,6 +25,11 @@ export const EditorDropZone = ({ editorId, children }: DropzoneProps): ReactElem
 	const dispatch = useAppDispatch();
 
 	const onDragOver = useCallback((event: DragEvent): void => {
+		const eventType = event?.dataTransfer?.types;
+		if (eventType?.includes('contact')) {
+			setDropZoneEnable(false);
+			return;
+		}
 		event.preventDefault();
 		setDropZoneEnable(true);
 	}, []);


### PR DESCRIPTION
- added props to editor to enable the drag and drop of chips
- disabled editor dropzone when a contact is being dragged