### PR TITLE
feat: remove redundant 'Share calendar' option in calendar's contextual menu

### DIFF
--- a/src/hooks/use-calendar-actions.test.ts
+++ b/src/hooks/use-calendar-actions.test.ts
@@ -179,7 +179,7 @@ describe('use calendar actions', () => {
 			expect(result.current).toStrictEqual([]);
 		});
 	});
-	test('main account calendar folder has 7 actions', () => {
+	test('main account calendar folder has 6 actions', () => {
 		const calendarItem = {
 			name: 'calendar',
 			id: FOLDERS.CALENDAR,
@@ -202,18 +202,17 @@ describe('use calendar actions', () => {
 			initialProps: [calendarItem]
 		});
 
-		expect(result.current.length).toBe(7);
+		expect(result.current.length).toBe(6);
 		expect(result.current).toStrictEqual([
 			expect.objectContaining({ id: FOLDER_ACTIONS.NEW }),
 			expect.objectContaining({ id: FOLDER_ACTIONS.EDIT }),
-			expect.objectContaining({ id: FOLDER_ACTIONS.SHARE }),
 			expect.objectContaining({ id: FOLDER_ACTIONS.SHARE_URL }),
 			expect.objectContaining({ id: FOLDER_ACTIONS.FIND_SHARES }),
 			expect.objectContaining({ id: FOLDER_ACTIONS.EXPORT_ICS }),
 			expect.objectContaining({ id: FOLDER_ACTIONS.UPLOAD })
 		]);
 	});
-	test('shared account calendar has 6 actions', () => {
+	test('shared account calendar has 5 actions', () => {
 		const calendarItem = {
 			name: 'calendar',
 			id: `${randomUUID}:${FOLDERS.CALENDAR}`,
@@ -233,11 +232,10 @@ describe('use calendar actions', () => {
 			initialProps: [calendarItem]
 		});
 
-		expect(result.current.length).toBe(6);
+		expect(result.current.length).toBe(5);
 		expect(result.current).toStrictEqual([
 			expect.objectContaining({ id: FOLDER_ACTIONS.NEW }),
 			expect.objectContaining({ id: FOLDER_ACTIONS.EDIT }),
-			expect.objectContaining({ id: FOLDER_ACTIONS.SHARE }),
 			expect.objectContaining({ id: FOLDER_ACTIONS.SHARE_URL }),
 			expect.objectContaining({ id: FOLDER_ACTIONS.EXPORT_ICS }),
 			expect.objectContaining({ id: FOLDER_ACTIONS.UPLOAD })
@@ -373,12 +371,11 @@ describe('use calendar actions', () => {
 				initialProps: [customItem]
 			});
 
-			expect(result.current.length).toBe(8);
+			expect(result.current.length).toBe(7);
 			expect(result.current).toStrictEqual([
 				expect.objectContaining({ id: FOLDER_ACTIONS.NEW }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.EDIT }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.DELETE }),
-				expect.objectContaining({ id: FOLDER_ACTIONS.SHARE }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.SHARE_URL }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.FIND_SHARES }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.EXPORT_ICS }),
@@ -406,12 +403,11 @@ describe('use calendar actions', () => {
 				initialProps: [trashedItem]
 			});
 
-			expect(result.current.length).toBe(7);
+			expect(result.current.length).toBe(6);
 			expect(result.current).toStrictEqual([
 				expect.objectContaining({ id: FOLDER_ACTIONS.NEW }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.EDIT }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.DELETE }),
-				expect.objectContaining({ id: FOLDER_ACTIONS.SHARE }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.SHARE_URL }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.EXPORT_ICS }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.UPLOAD })
@@ -419,7 +415,7 @@ describe('use calendar actions', () => {
 		});
 	});
 	describe('nested custom folder', () => {
-		test('in main account has 9 actions', () => {
+		test('in main account has 8 actions', () => {
 			const customNestedItem = {
 				name: 'custom nested folder',
 				id: '153',
@@ -461,20 +457,19 @@ describe('use calendar actions', () => {
 				initialProps: [customNestedItem]
 			});
 
-			expect(result.current.length).toBe(9);
+			expect(result.current.length).toBe(8);
 			expect(result.current).toStrictEqual([
 				expect.objectContaining({ id: FOLDER_ACTIONS.NEW }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.MOVE_TO_ROOT }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.EDIT }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.DELETE }),
-				expect.objectContaining({ id: FOLDER_ACTIONS.SHARE }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.SHARE_URL }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.FIND_SHARES }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.EXPORT_ICS }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.UPLOAD })
 			]);
 		});
-		test('in shared account has 8 actions', () => {
+		test('in shared account has 7 actions', () => {
 			const customNestedItem = {
 				name: 'custom folder',
 				id: `${randomUUID}:154`,
@@ -495,13 +490,12 @@ describe('use calendar actions', () => {
 				initialProps: [customNestedItem]
 			});
 
-			expect(result.current.length).toBe(8);
+			expect(result.current.length).toBe(7);
 			expect(result.current).toStrictEqual([
 				expect.objectContaining({ id: FOLDER_ACTIONS.NEW }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.MOVE_TO_ROOT }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.EDIT }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.DELETE }),
-				expect.objectContaining({ id: FOLDER_ACTIONS.SHARE }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.SHARE_URL }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.EXPORT_ICS }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.UPLOAD })
@@ -574,7 +568,7 @@ describe('use calendar actions', () => {
 	});
 
 	describe('link folder with admin or manager permission', () => {
-		test('in main account has 7 actions', () => {
+		test('in main account has 6 actions', () => {
 			const linkItem = {
 				name: 'link folder',
 				id: `${randomUUID}:154`,
@@ -598,18 +592,17 @@ describe('use calendar actions', () => {
 				initialProps: [linkItem]
 			});
 
-			expect(result.current.length).toBe(7);
+			expect(result.current.length).toBe(6);
 			expect(result.current).toStrictEqual([
 				expect.objectContaining({ id: FOLDER_ACTIONS.NEW }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.EDIT }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.DELETE }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.REMOVE_FROM_LIST }),
-				expect.objectContaining({ id: FOLDER_ACTIONS.SHARE }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.FIND_SHARES }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.SHARES_INFO })
 			]);
 		});
-		test('in shared account has 6 actions', () => {
+		test('in shared account has 5 actions', () => {
 			const linkItem = {
 				name: 'link folder',
 				id: `${randomUUID}:154`,
@@ -632,41 +625,23 @@ describe('use calendar actions', () => {
 			const { result } = setupHook(useCalendarActions, {
 				initialProps: [linkItem]
 			});
-			expect(result.current.length).toBe(6);
+			expect(result.current.length).toBe(5);
 			expect(result.current).toStrictEqual([
 				expect.objectContaining({ id: FOLDER_ACTIONS.NEW }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.EDIT }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.DELETE }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.REMOVE_FROM_LIST }),
-				expect.objectContaining({ id: FOLDER_ACTIONS.SHARE }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.SHARES_INFO })
 			]);
 		});
 	});
 
 	describe('nested folder in link folder with admin or manager permission', () => {
-		test('in main account has 6 actions', () => {
+		test('in main account has 5 actions', () => {
 			setupFoldersStore(mainFolder, { [mainChildFolder.id]: mainChildFolder });
 
 			const { result } = setupHook(useCalendarActions, {
 				initialProps: [mainChildFolder]
-			});
-
-			expect(result.current.length).toBe(6);
-			expect(result.current).toStrictEqual([
-				expect.objectContaining({ id: FOLDER_ACTIONS.NEW }),
-				expect.objectContaining({ id: FOLDER_ACTIONS.EDIT }),
-				expect.objectContaining({ id: FOLDER_ACTIONS.DELETE }),
-				expect.objectContaining({ id: FOLDER_ACTIONS.SHARE }),
-				expect.objectContaining({ id: FOLDER_ACTIONS.SHARE_URL }),
-				expect.objectContaining({ id: FOLDER_ACTIONS.FIND_SHARES })
-			]);
-		});
-
-		test('in shared account has 5 actions', () => {
-			setupFoldersStore();
-			const { result } = setupHook(useCalendarActions, {
-				initialProps: [sharedChildFolder]
 			});
 
 			expect(result.current.length).toBe(5);
@@ -674,7 +649,22 @@ describe('use calendar actions', () => {
 				expect.objectContaining({ id: FOLDER_ACTIONS.NEW }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.EDIT }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.DELETE }),
-				expect.objectContaining({ id: FOLDER_ACTIONS.SHARE }),
+				expect.objectContaining({ id: FOLDER_ACTIONS.SHARE_URL }),
+				expect.objectContaining({ id: FOLDER_ACTIONS.FIND_SHARES })
+			]);
+		});
+
+		test('in shared account has 4 actions', () => {
+			setupFoldersStore();
+			const { result } = setupHook(useCalendarActions, {
+				initialProps: [sharedChildFolder]
+			});
+
+			expect(result.current.length).toBe(4);
+			expect(result.current).toStrictEqual([
+				expect.objectContaining({ id: FOLDER_ACTIONS.NEW }),
+				expect.objectContaining({ id: FOLDER_ACTIONS.EDIT }),
+				expect.objectContaining({ id: FOLDER_ACTIONS.DELETE }),
 				expect.objectContaining({ id: FOLDER_ACTIONS.SHARE_URL })
 			]);
 		});

--- a/src/hooks/use-calendar-actions.tsx
+++ b/src/hooks/use-calendar-actions.tsx
@@ -46,7 +46,6 @@ export const useCalendarActions = (
 		editCalendarItem({ createModal, item }),
 		deleteCalendarItem({ createModal, item }),
 		removeFromListItem({ item, createSnackbar }),
-		shareCalendarItem({ createModal, item }),
 		shareCalendarUrlItem({ createModal, item }),
 		findSharesItem({ createModal, item }),
 		sharesInfoItem({ item, createModal }),


### PR DESCRIPTION
Refs: IRIS-5136