### PR TITLE
C0-1395 - preserve participation status while modifying appointment

### DIFF
--- a/src/normalizations/normalize-editor.ts
+++ b/src/normalizations/normalize-editor.ts
@@ -66,7 +66,8 @@ const getAttendees = (attendees: any[], role: string): any[] =>
 				label: at?.d,
 				lastName: undefined,
 				isGroup: at.isGroup,
-				exp: at.exp
+				exp: at.exp,
+				ptst: at?.ptst
 			},
 			isNil
 		)

--- a/src/normalizations/normalize-soap-message-from-editor.test.ts
+++ b/src/normalizations/normalize-soap-message-from-editor.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../carbonio-ui-commons/test/mocks/accounts/fakeAccounts';
 import { generateEditor } from '../commons/editor-generator';
 import { getIdentityItems } from '../commons/get-identity-items';
+import mockedData from '../test/generators';
 
 const mainAccount = createFakeIdentity();
 const identity = createFakeIdentity();
@@ -50,6 +51,55 @@ const addressPrefKey = 'zimbraPrefFromAddress';
 describe('normalize soap message from editor', () => {
 	describe('when the user is the organizer ', () => {
 		describe('and the appointment is inside his calendar ', () => {
+			test('when one of the attendee has changed appointment status(ptst), the ptst should be preserved in normalization', () => {
+				const userAccount = getMockedAccountItem({ identity1: mainAccount });
+				shell.getUserAccount.mockImplementation(() => userAccount);
+
+				const attendees = [
+					{
+						email: 'test@gmail.com',
+						fullName: 'test',
+						id: '1',
+						label: 'test',
+						ptst: 'AC'
+					}
+				];
+
+				const optionalAttendees = [
+					{
+						email: 'i_am_optional@gmail.com',
+						fullName: 'test',
+						id: '1',
+						label: 'test',
+						ptst: 'AC'
+					}
+				];
+
+				const folder = {
+					absFolderPath: '/Test',
+					id: '5',
+					l: '1',
+					name: 'Test',
+					view: 'appointment'
+				};
+				const event = mockedData.getEvent({ resource: { organizer: undefined, calendar: folder } });
+				const invite = mockedData.getInvite({
+					event
+				});
+
+				const editor = generateEditor({
+					context: {
+						attendees,
+						optionalAttendees,
+						folders: {},
+						dispatch: jest.fn(),
+						calendar: mainAccountEditorFolder
+					},
+					invite
+				});
+				const body = normalizeSoapMessageFromEditor(editor);
+				expect(body.m.inv.comp[0].at[0].ptst).toEqual('AC');
+			});
 			describe('and he is not using identities ', () => {
 				test('there wont be a sentBy parameter', () => {
 					const userAccount = getMockedAccountItem({ identity1: mainAccount, identity2: identity });

--- a/src/normalizations/normalize-soap-message-from-editor.ts
+++ b/src/normalizations/normalize-soap-message-from-editor.ts
@@ -290,7 +290,7 @@ const generateInvite = (editorData: Editor): any => {
 			a: c?.email ?? c?.label,
 			d: c?.firstName && c?.lastname ? `${c.firstName} ${c.lastname}` : c.label,
 			role: PARTICIPANT_ROLE.REQUIRED,
-			ptst: 'NE',
+			ptst: c?.ptst ?? 'NE',
 			rsvp: '1'
 		}))
 	);
@@ -300,7 +300,7 @@ const generateInvite = (editorData: Editor): any => {
 				a: c?.email ?? c?.label,
 				d: c.firstName && c.lastname ? `${c.firstName} ${c.lastname}` : c.label,
 				role: PARTICIPANT_ROLE.OPTIONAL,
-				ptst: 'NE',
+				ptst: c?.ptst ?? 'NE',
 				rsvp: '1'
 			}))
 		);

--- a/src/normalizations/normalize-soap-message-from-editor.ts
+++ b/src/normalizations/normalize-soap-message-from-editor.ts
@@ -278,36 +278,42 @@ const generateMp = (msg: Editor): { ct: string; mp: Array<{ ct: string; content:
 			]
 });
 
-const generateInvite = (editorData: Editor): any => {
+const generateInvite = (editor: Editor): any => {
 	const at = [];
 	const organizer = getOrganizer({
-		calendar: editorData?.calendar,
-		sender: editorData.sender,
-		organizer: editorData.organizer
+		calendar: editor?.calendar,
+		sender: editor.sender,
+		organizer: editor.organizer
 	});
 	at.push(
-		...editorData.attendees.map((c: any) => ({
-			a: c?.email ?? c?.label,
-			d: c?.firstName && c?.lastname ? `${c.firstName} ${c.lastname}` : c.label,
+		...editor.attendees.map((attendee: any) => ({
+			a: attendee?.email ?? attendee?.label,
+			d:
+				attendee?.firstName && attendee?.lastname
+					? `${attendee.firstName} ${attendee.lastname}`
+					: attendee.label,
 			role: PARTICIPANT_ROLE.REQUIRED,
-			ptst: c?.ptst ?? 'NE',
+			ptst: attendee?.ptst ?? 'NE',
 			rsvp: '1'
 		}))
 	);
-	editorData?.optionalAttendees &&
+	editor?.optionalAttendees &&
 		at.push(
-			...editorData.optionalAttendees.map((c: any) => ({
-				a: c?.email ?? c?.label,
-				d: c.firstName && c.lastname ? `${c.firstName} ${c.lastname}` : c.label,
+			...editor.optionalAttendees.map((optionalAttendee: any) => ({
+				a: optionalAttendee?.email ?? optionalAttendee?.label,
+				d:
+					optionalAttendee.firstName && optionalAttendee.lastname
+						? `${optionalAttendee.firstName} ${optionalAttendee.lastname}`
+						: optionalAttendee.label,
 				role: PARTICIPANT_ROLE.OPTIONAL,
-				ptst: c?.ptst ?? 'NE',
+				ptst: optionalAttendee?.ptst ?? 'NE',
 				rsvp: '1'
 			}))
 		);
 
-	editorData?.meetingRoom &&
+	editor?.meetingRoom &&
 		at.push(
-			...editorData.meetingRoom.map((c) => ({
+			...editor.meetingRoom.map((c) => ({
 				a: c?.email,
 				d: c.label,
 				role: PARTICIPANT_ROLE.NON_PARTICIPANT,
@@ -318,9 +324,9 @@ const generateInvite = (editorData: Editor): any => {
 			}))
 		);
 
-	editorData?.equipment &&
+	editor?.equipment &&
 		at.push(
-			...editorData.equipment.map((c) => ({
+			...editor.equipment.map((c) => ({
 				a: c?.email,
 				d: c.label,
 				role: PARTICIPANT_ROLE.NON_PARTICIPANT,
@@ -335,17 +341,17 @@ const generateInvite = (editorData: Editor): any => {
 		comp: [
 			{
 				alarm:
-					editorData?.reminder && editorData?.reminder !== '0'
+					editor?.reminder && editor?.reminder !== '0'
 						? [
 								{
 									action: 'DISPLAY',
 									trigger: {
-										rel: setAlarmValue(editorData.reminder)
+										rel: setAlarmValue(editor.reminder)
 									}
 								}
 							]
 						: undefined,
-				xprop: editorData?.room
+				xprop: editor?.room
 					? [
 							{
 								name: CRB_XPROPS.MEETING_ROOM,
@@ -353,21 +359,21 @@ const generateInvite = (editorData: Editor): any => {
 								xparam: [
 									{
 										name: CRB_XPARAMS.ROOM_LINK,
-										value: editorData.room.link
+										value: editor.room.link
 									},
 									{
 										name: CRB_XPARAMS.ROOM_NAME,
-										value: editorData.room.label
+										value: editor.room.label
 									}
 								]
 							}
 						]
 					: undefined,
 				at,
-				allDay: editorData.allDay ? '1' : '0',
-				fb: editorData.freeBusy,
-				loc: editorData.location,
-				name: editorData.title,
+				allDay: editor.allDay ? '1' : '0',
+				fb: editor.freeBusy,
+				loc: editor.location,
+				name: editor.title,
 				or: omitBy(
 					{
 						a: organizer.email,
@@ -377,26 +383,26 @@ const generateInvite = (editorData: Editor): any => {
 					isNil
 				),
 				recur:
-					(editorData?.isInstance && editorData?.isSeries) || editorData?.isException
+					(editor?.isInstance && editor?.isSeries) || editor?.isException
 						? undefined
-						: editorData?.recur,
+						: editor?.recur,
 				status: 'CONF',
 				s: setResourceDate({
-					time: editorData.start,
-					allDay: editorData?.allDay,
-					timezone: editorData?.timezone
+					time: editor.start,
+					allDay: editor?.allDay,
+					timezone: editor?.timezone
 				}),
 				e: setResourceDate({
-					time: editorData.end,
-					allDay: editorData?.allDay,
-					timezone: editorData?.timezone
+					time: editor.end,
+					allDay: editor?.allDay,
+					timezone: editor?.timezone
 				}),
-				exceptId: editorData.exceptId,
-				class: editorData.class,
-				draft: editorData.draft ? 1 : 0
+				exceptId: editor.exceptId,
+				class: editor.class,
+				draft: editor.draft ? 1 : 0
 			}
 		],
-		uid: editorData.uid
+		uid: editor.uid
 	};
 };
 


### PR DESCRIPTION
PRs:
https://github.com/zextras/carbonio-mailbox/pull/588 
Modifying Calendar event now resets Attendee's Participation Status(psts) to Need Action (NE) in both single instances and series or recursive.

https://github.com/zextras/carbonio-calendars-ui/pull/491 
Preserve the participation status of attendees while making modifications to appointments(both single instances and series or recursive)

