### PR TITLE
feat: integrate wsc virtual room field on calendar module 

### DIFF
--- a/src/view/editor/parts/editor-virtual-room.test.tsx
+++ b/src/view/editor/parts/editor-virtual-room.test.tsx
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import React from 'react';
+
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
+import { screen } from '@testing-library/react';
+
+import { EditorVirtualRoom } from './editor-virtual-room';
+import * as shell from '../../../carbonio-ui-commons/test/mocks/carbonio-shell-ui';
+import { setupTest } from '../../../carbonio-ui-commons/test/test-setup';
+import { reducers } from '../../../store/redux';
+
+const store = configureStore({ reducer: combineReducers(reducers) });
+
+const chatsIntegrationDataTestId = 'chats-room-component';
+const wscIntegrationDataTestId = 'wsc-room-component';
+
+const FakeChatsIntegrationComponent = jest.fn(
+	(): React.JSX.Element => <div data-testid={chatsIntegrationDataTestId} />
+);
+
+const FakeWscIntegrationComponent = jest.fn(
+	(): React.JSX.Element => <div data-testid={wscIntegrationDataTestId} />
+);
+
+describe('Editor virtual rooms', () => {
+	test('If only ChatsRoomSelector is available, it should be rendered', () => {
+		jest
+			.spyOn(shell, 'useIntegratedComponent')
+			.mockReturnValueOnce([FakeChatsIntegrationComponent, true]);
+		jest
+			.spyOn(shell, 'useIntegratedComponent')
+			.mockReturnValueOnce([FakeWscIntegrationComponent, false]);
+		setupTest(<EditorVirtualRoom editorId={'editorId'} />, { store });
+
+		expect(screen.getByTestId(chatsIntegrationDataTestId)).toBeInTheDocument();
+	});
+
+	test('If only WscRoomSelector is available, it should be rendered', () => {
+		jest
+			.spyOn(shell, 'useIntegratedComponent')
+			.mockReturnValueOnce([FakeChatsIntegrationComponent, false]);
+		jest
+			.spyOn(shell, 'useIntegratedComponent')
+			.mockReturnValueOnce([FakeWscIntegrationComponent, true]);
+		setupTest(<EditorVirtualRoom editorId={'editorId'} />, { store });
+
+		expect(screen.getByTestId(wscIntegrationDataTestId)).toBeInTheDocument();
+	});
+
+	test('If ChatsRoomSelector and WscRoomSelector are both available, only ChatsRoomSelector should be rendered', () => {
+		jest
+			.spyOn(shell, 'useIntegratedComponent')
+			.mockReturnValueOnce([FakeChatsIntegrationComponent, true]);
+		jest
+			.spyOn(shell, 'useIntegratedComponent')
+			.mockReturnValueOnce([FakeWscIntegrationComponent, true]);
+		setupTest(<EditorVirtualRoom editorId={'editorId'} />, { store });
+
+		expect(screen.getByTestId(chatsIntegrationDataTestId)).toBeInTheDocument();
+	});
+
+	test('If ChatsRoomSelector and WscRoomSelector are both unavailable, nothing should be rendered', () => {
+		jest
+			.spyOn(shell, 'useIntegratedComponent')
+			.mockReturnValueOnce([FakeChatsIntegrationComponent, false]);
+		jest
+			.spyOn(shell, 'useIntegratedComponent')
+			.mockReturnValueOnce([FakeWscIntegrationComponent, false]);
+		setupTest(<EditorVirtualRoom editorId={'editorId'} />, { store });
+
+		expect(screen.queryByTestId(chatsIntegrationDataTestId)).not.toBeInTheDocument();
+		expect(screen.queryByTestId(wscIntegrationDataTestId)).not.toBeInTheDocument();
+	});
+});

--- a/src/view/editor/parts/editor-virtual-room.test.tsx
+++ b/src/view/editor/parts/editor-virtual-room.test.tsx
@@ -27,50 +27,39 @@ const FakeWscIntegrationComponent = jest.fn(
 	(): React.JSX.Element => <div data-testid={wscIntegrationDataTestId} />
 );
 
+const spyUseIntegratedIntegration = (chatsIsEnabled: boolean, wscIsEnabled: boolean): void => {
+	jest.spyOn(shell, 'useIntegratedComponent').mockImplementation((id: string) => {
+		if (id === 'room-selector') return [FakeChatsIntegrationComponent, chatsIsEnabled];
+		if (id === 'wsc-room-selector') return [FakeWscIntegrationComponent, wscIsEnabled];
+		return [jest.fn(), false];
+	});
+};
+
 describe('Editor virtual rooms', () => {
 	test('If only ChatsRoomSelector is available, it should be rendered', () => {
-		jest
-			.spyOn(shell, 'useIntegratedComponent')
-			.mockReturnValueOnce([FakeChatsIntegrationComponent, true]);
-		jest
-			.spyOn(shell, 'useIntegratedComponent')
-			.mockReturnValueOnce([FakeWscIntegrationComponent, false]);
+		spyUseIntegratedIntegration(true, false);
 		setupTest(<EditorVirtualRoom editorId={'editorId'} />, { store });
 
 		expect(screen.getByTestId(chatsIntegrationDataTestId)).toBeInTheDocument();
 	});
 
 	test('If only WscRoomSelector is available, it should be rendered', () => {
-		jest
-			.spyOn(shell, 'useIntegratedComponent')
-			.mockReturnValueOnce([FakeChatsIntegrationComponent, false]);
-		jest
-			.spyOn(shell, 'useIntegratedComponent')
-			.mockReturnValueOnce([FakeWscIntegrationComponent, true]);
+		spyUseIntegratedIntegration(false, true);
 		setupTest(<EditorVirtualRoom editorId={'editorId'} />, { store });
 
 		expect(screen.getByTestId(wscIntegrationDataTestId)).toBeInTheDocument();
 	});
 
 	test('If ChatsRoomSelector and WscRoomSelector are both available, only ChatsRoomSelector should be rendered', () => {
-		jest
-			.spyOn(shell, 'useIntegratedComponent')
-			.mockReturnValueOnce([FakeChatsIntegrationComponent, true]);
-		jest
-			.spyOn(shell, 'useIntegratedComponent')
-			.mockReturnValueOnce([FakeWscIntegrationComponent, true]);
+		spyUseIntegratedIntegration(true, true);
 		setupTest(<EditorVirtualRoom editorId={'editorId'} />, { store });
 
 		expect(screen.getByTestId(chatsIntegrationDataTestId)).toBeInTheDocument();
+		expect(screen.queryByTestId(wscIntegrationDataTestId)).not.toBeInTheDocument();
 	});
 
 	test('If ChatsRoomSelector and WscRoomSelector are both unavailable, nothing should be rendered', () => {
-		jest
-			.spyOn(shell, 'useIntegratedComponent')
-			.mockReturnValueOnce([FakeChatsIntegrationComponent, false]);
-		jest
-			.spyOn(shell, 'useIntegratedComponent')
-			.mockReturnValueOnce([FakeWscIntegrationComponent, false]);
+		spyUseIntegratedIntegration(false, false);
 		setupTest(<EditorVirtualRoom editorId={'editorId'} />, { store });
 
 		expect(screen.queryByTestId(chatsIntegrationDataTestId)).not.toBeInTheDocument();

--- a/src/view/editor/parts/editor-virtual-room.tsx
+++ b/src/view/editor/parts/editor-virtual-room.tsx
@@ -3,8 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
+
 import React, { ReactElement, useCallback } from 'react';
 
 import { Row } from '@zextras/carbonio-design-system';
@@ -13,24 +12,35 @@ import { useIntegratedComponent } from '@zextras/carbonio-shell-ui';
 import { useAppDispatch, useAppSelector } from '../../../store/redux/hooks';
 import { selectEditorDisabled, selectEditorRoom } from '../../../store/selectors/editor';
 import { editEditorRoom } from '../../../store/slices/editor-slice';
+import { Room } from '../../../types/editor';
 
 export const EditorVirtualRoom = ({ editorId }: { editorId: string }): ReactElement | null => {
-	const [RoomSelector, isRoomAvailable] = useIntegratedComponent('room-selector');
+	const [ChatsRoomSelector, isRoomAvailable] = useIntegratedComponent('room-selector');
+	const [WscRoomSelector, isWscRoomAvailable] = useIntegratedComponent('wsc-room-selector');
+
 	const room = useAppSelector(selectEditorRoom(editorId));
 	const disabled = useAppSelector(selectEditorDisabled(editorId));
 
 	const dispatch = useAppDispatch();
 
 	const onChange = useCallback(
-		(roomData) => {
+		(roomData: Room) => {
 			dispatch(editEditorRoom({ id: editorId, room: roomData }));
 		},
 		[dispatch, editorId]
 	);
 
-	return isRoomAvailable ? (
+	return isRoomAvailable || isWscRoomAvailable ? (
 		<Row height="fit" width="fill" padding={{ top: 'large' }}>
-			<RoomSelector onChange={onChange} defaultValue={room} disabled={disabled?.virtualRoom} />
+			{isRoomAvailable ? (
+				<ChatsRoomSelector
+					onChange={onChange}
+					defaultValue={room}
+					disabled={disabled?.virtualRoom}
+				/>
+			) : (
+				<WscRoomSelector onChange={onChange} defaultValue={room} disabled={disabled?.virtualRoom} />
+			)}
 		</Row>
 	) : null;
 };

--- a/src/view/event-summary-view/virtual-room-row.tsx
+++ b/src/view/event-summary-view/virtual-room-row.tsx
@@ -5,8 +5,9 @@
  */
 import React, { ReactElement, useMemo } from 'react';
 
-import { Icon, Padding, Row, Text } from '@zextras/carbonio-design-system';
+import { Icon, Padding, Row, Text, Tooltip } from '@zextras/carbonio-design-system';
 import { find } from 'lodash';
+import { useTranslation } from 'react-i18next';
 
 import { CRB_XPROPS, CRB_XPARAMS } from '../../constants/xprops';
 import { XPropProps } from '../../types/store/invite';
@@ -18,26 +19,32 @@ export const VirtualRoomRow = ({
 	xprop: XPropProps;
 	showIcon?: boolean;
 }): ReactElement | null => {
+	const [t] = useTranslation();
+	const tooltipLabel = t('appointment.virtualRoom.displayerLink', 'Join the virtual room');
+
 	const room = useMemo(() => find(xprop, ['name', CRB_XPROPS.MEETING_ROOM]), [xprop]);
+
 	if (room) {
 		const roomName = find(room.xparam, ['name', CRB_XPARAMS.ROOM_NAME])?.value;
 		const roomLink = find(room.xparam, ['name', CRB_XPARAMS.ROOM_LINK])?.value;
 		return (
 			<Row width="fill" mainAlignment="flex-start" padding={{ top: 'small' }}>
-				<Row takeAvailableSpace mainAlignment="flex-start">
-					{showIcon && (
-						<Padding right="small">
-							<Icon icon="VideoOutline" size="medium" />
-						</Padding>
-					)}
-					<Row takeAvailableSpace mainAlignment="flex-start">
-						<Text color="gray1" size="small">
-							<a href={roomLink} target="_blank" rel="noreferrer">
-								{roomName}
-							</a>
-						</Text>
+				<Tooltip label={tooltipLabel}>
+					<Row mainAlignment="flex-start">
+						{showIcon && (
+							<Padding right="small">
+								<Icon icon="VideoOutline" size="medium" />
+							</Padding>
+						)}
+						<Row takeAvailableSpace mainAlignment="flex-start">
+							<Text color="gray1" size="small">
+								<a href={roomLink} target="_blank" rel="noreferrer">
+									{roomName}
+								</a>
+							</Text>
+						</Row>
 					</Row>
-				</Row>
+				</Tooltip>
 			</Row>
 		);
 	}

--- a/src/view/event-summary-view/virtual-room-row.tsx
+++ b/src/view/event-summary-view/virtual-room-row.tsx
@@ -27,7 +27,7 @@ export const VirtualRoomRow = ({
 				<Row takeAvailableSpace mainAlignment="flex-start">
 					{showIcon && (
 						<Padding right="small">
-							<Icon icon="TeamOutline" size="medium" />
+							<Icon icon="VideoOutline" size="medium" />
 						</Padding>
 					)}
 					<Row takeAvailableSpace mainAlignment="flex-start">


### PR DESCRIPTION
This PR modifies the logic that handles the selection of a virtual room based on the presence of integrations with the Chats and Workstream Collaboration modules.
	•	If only Chats is present, the virtual room selection will continue to use the Chats integration.
	•	If only WSC is present, the system will use the WSC integration for virtual room selection.
	•	If both Chats and WSC are present, the Chats integration will be used by default.

This change ensures proper handling of the WSC module integration where applicable, while maintaining backward compatibility with the Chats module.

Issue reference: https://zextras.atlassian.net/browse/WSC-1715

- [x] Test this code on a VM with both Chats and Workstream Collaboration