### PR TITLE
[CO-1488] use copy as a fallback of move if move is not available in actions-buttons

### DIFF
--- a/src/view/event-panel-view/actions-buttons.tsx
+++ b/src/view/event-panel-view/actions-buttons.tsx
@@ -49,7 +49,7 @@ function getPreferredAction(
 		if (edit && !edit.disabled) {
 			return edit;
 		}
-		return move;
+		return move ?? copy;
 	}
 	if (edit && !edit.disabled) {
 		return edit;

--- a/src/view/event-panel-view/tests/actions-buttons.test.tsx
+++ b/src/view/event-panel-view/tests/actions-buttons.test.tsx
@@ -159,6 +159,32 @@ describe('actions-buttons instance primary action', () => {
 		expect(screen.getByTestId('icon: move')).toBeVisible();
 	});
 
+	test('primary instance action for attendee is copy if edit and move are not available', () => {
+		const store = configureStore({
+			reducer: combineReducers(reducers),
+			preloadedState: {}
+		});
+
+		const event = {
+			...mockedData.getEvent(),
+			resource: {
+				...mockedData.getEvent().resource,
+				iAmOrganizer: false
+			}
+		};
+
+		setupTest(
+			<ActionButtons
+				actions={instanceActions.filter(
+					(a) => a.id !== EVENT_ACTIONS.EDIT && a.id !== EVENT_ACTIONS.MOVE
+				)}
+				event={event}
+			/>,
+			{ store }
+		);
+		expect(screen.getByTestId('icon: copy')).toBeVisible();
+	});
+
 	test('primary instance action for shared is edit (if available)', () => {
 		const store = configureStore({
 			reducer: combineReducers(reducers),


### PR DESCRIPTION
Fixes a bug introduced with https://github.com/zextras/carbonio-calendars-ui/pull/545