### PR TITLE
fix: [CO-1974] allow deleting appointments with no organizer

### DIFF
--- a/src/store/actions/move-appointment-to-trash.ts
+++ b/src/store/actions/move-appointment-to-trash.ts
@@ -127,7 +127,7 @@ function createMessageForDelete({
 	newMessage: string;
 	inst: InstanceExceptionId;
 }): { e: any; su: string; mp: MessagePart } {
-	const hasValidOrganizer = invite?.organizer?.a && invite?.organizer?.d;
+	const hasValidOrganizer = invite?.organizer?.a;
 	const organizer = hasValidOrganizer
 		? [
 				{

--- a/src/store/actions/move-appointment-to-trash.ts
+++ b/src/store/actions/move-appointment-to-trash.ts
@@ -127,13 +127,16 @@ function createMessageForDelete({
 	newMessage: string;
 	inst: InstanceExceptionId;
 }): { e: any; su: string; mp: MessagePart } {
-	const organizer = [
-		{
-			a: invite?.organizer?.a,
-			p: invite?.organizer?.d,
-			t: 'f'
-		}
-	];
+	const hasValidOrganizer = invite?.organizer?.a && invite?.organizer?.d;
+	const organizer = hasValidOrganizer
+		? [
+				{
+					a: invite?.organizer?.a,
+					p: invite?.organizer?.d,
+					t: 'f'
+				}
+			]
+		: [];
 	const participants = invite.neverSent
 		? organizer
 		: (getParticipants(Object.entries(invite?.participants).flatMap(([_, value]) => value)).concat(

--- a/src/store/actions/tests/move-appointment-to-trash.test.ts
+++ b/src/store/actions/tests/move-appointment-to-trash.test.ts
@@ -48,25 +48,26 @@ const generateMockState = ({
 });
 
 describe('moveAppointmentToTrash', () => {
+	const moveAppointmentToTrashParam = {
+		inviteId: defaultInviteId,
+		t: mockTFunction,
+		isOrganizer: true,
+		deleteSingleInstance: true,
+		inst: { d: '20230102T100000Z', tz: 'America/New_York' },
+		s: 123,
+		newMessage: '',
+		ridZ: '',
+		recur: false,
+		isRecurrent: true,
+		id: defaultInviteId
+	};
 	it('should call CancelAppointmentRequest with organizer when invite has valid organizer', async () => {
 		const mockDispatch = jest.fn();
 		const mockState = generateMockState({});
 		const mockGetState = jest.fn(() => mockState as RootState);
 		const mockRejectWithValue = jest.fn();
 
-		const thunk = moveAppointmentToTrash({
-			inviteId: defaultInviteId,
-			t: mockTFunction,
-			isOrganizer: true,
-			deleteSingleInstance: true,
-			inst: { d: '20230102T100000Z', tz: 'America/New_York' },
-			s: 123,
-			newMessage: '',
-			ridZ: '',
-			recur: false,
-			isRecurrent: true,
-			id: defaultInviteId
-		});
+		const thunk = moveAppointmentToTrash(moveAppointmentToTrashParam);
 
 		const cancelAppointmentAPIInterceptor = createSoapAPIInterceptor('CancelAppointment', {});
 
@@ -96,32 +97,19 @@ describe('moveAppointmentToTrash', () => {
 
 	it('should call CancelAppointmentRequest with empty organizer when invite has no organizer', async () => {
 		const mockStateWithNoOrganizer: Partial<RootState> = generateMockState({
-			organizer: {} as InviteOrganizer
+			organizer: {} as InviteOrganizer // No valid organizer
 		});
 		const mockDispatch = jest.fn();
 		const mockGetState = jest.fn(() => mockStateWithNoOrganizer as RootState);
 
-		const inviteId = 'test-invite-id';
-		const thunk = moveAppointmentToTrash({
-			inviteId,
-			t: mockTFunction,
-			isOrganizer: true,
-			deleteSingleInstance: true,
-			inst: { d: '20230102T100000Z', tz: 'America/New_York' },
-			s: 123,
-			newMessage: '',
-			ridZ: '',
-			recur: false,
-			isRecurrent: true,
-			id: inviteId
-		});
+		const thunk = moveAppointmentToTrash(moveAppointmentToTrashParam);
 
 		const cancelAppointmentAPIInterceptor = createSoapAPIInterceptor('CancelAppointment', {});
 		await thunk(mockDispatch, mockGetState, undefined);
 		const request = await cancelAppointmentAPIInterceptor;
 		expect(request).toEqual(
 			expect.objectContaining({
-				id: inviteId,
+				id: defaultInviteId,
 				m: expect.objectContaining({
 					e: [
 						{

--- a/src/store/actions/tests/move-appointment-to-trash.test.ts
+++ b/src/store/actions/tests/move-appointment-to-trash.test.ts
@@ -4,57 +4,58 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { cancelAppointmentRequest } from '../../../soap/cancel-appointment-request';
+import { createSoapAPIInterceptor } from '../../../carbonio-ui-commons/test/mocks/network/msw/create-api-interceptor';
 import mockedData from '../../../test/generators';
-import { InviteOrganizer } from '../../../types/store/invite';
+import { InviteOrganizer, InviteParticipant } from '../../../types/store/invite';
 import { setupTMock } from '../../../utils/tests';
 import { RootState } from '../../redux';
 import { moveAppointmentToTrash } from '../move-appointment-to-trash';
 
-jest.mock('../../../soap/cancel-appointment-request');
-
 const mockTFunction = setupTMock();
 
-const mockCancelAppointmentRequest = cancelAppointmentRequest as jest.MockedFunction<
-	typeof cancelAppointmentRequest
->;
+const defaultOrganizer: InviteOrganizer = {
+	a: 'organizer@test.com',
+	d: 'Test Organizer',
+	url: 'https://test.com'
+};
+
+const defaultInviteId = 'test-invite-id';
+
+const defaultParticipant: InviteParticipant = {
+	email: 'participant1@test.com',
+	name: 'Participant 1',
+	isOptional: false,
+	response: 'TE'
+};
+
+const generateMockState = ({
+	organizer = defaultOrganizer
+}: {
+	organizer?: InviteOrganizer;
+}): Partial<RootState> => ({
+	invites: {
+		invites: {
+			'test-invite-id': {
+				...mockedData.getInvite(),
+				organizer,
+				participants: {
+					AC: [defaultParticipant]
+				}
+			}
+		},
+		status: ''
+	}
+});
 
 describe('moveAppointmentToTrash', () => {
 	it('should call CancelAppointmentRequest with organizer when invite has valid organizer', async () => {
-		const mockState: Partial<RootState> = {
-			invites: {
-				invites: {
-					'test-invite-id': {
-						...mockedData.getInvite(),
-						// Valid organizer
-						organizer: {
-							a: 'organizer@test.com',
-							d: 'Test Organizer',
-							url: ''
-						},
-						participants: {
-							AC: [
-								{
-									email: 'participant1@test.com',
-									name: 'Participant 1',
-									isOptional: false,
-									response: 'TE'
-								}
-							]
-						}
-					}
-				},
-				status: ''
-			}
-		};
-
 		const mockDispatch = jest.fn();
+		const mockState = generateMockState({});
 		const mockGetState = jest.fn(() => mockState as RootState);
 		const mockRejectWithValue = jest.fn();
 
-		const inviteId = 'test-invite-id';
 		const thunk = moveAppointmentToTrash({
-			inviteId,
+			inviteId: defaultInviteId,
 			t: mockTFunction,
 			isOrganizer: true,
 			deleteSingleInstance: true,
@@ -64,57 +65,41 @@ describe('moveAppointmentToTrash', () => {
 			ridZ: '',
 			recur: false,
 			isRecurrent: true,
-			id: inviteId
+			id: defaultInviteId
 		});
+
+		const cancelAppointmentAPIInterceptor = createSoapAPIInterceptor('CancelAppointment', {});
 
 		await thunk(mockDispatch, mockGetState, { rejectWithValue: mockRejectWithValue });
 
-		expect(mockCancelAppointmentRequest).toHaveBeenCalledWith({
-			deleteSingleInstance: true,
-			id: inviteId,
-			inst: { d: '20230102T100000Z', tz: 'America/New_York' },
-			isOrganizer: true,
-			m: expect.objectContaining({
-				e: expect.arrayContaining([
-					// Should include organizer
-					expect.objectContaining({
-						a: 'organizer@test.com',
-						p: 'Test Organizer',
-						t: 'f'
-					}),
-					// Should include regular participant
-					expect.objectContaining({
-						a: 'participant1@test.com',
-						p: 'Participant 1',
-						t: 't'
-					})
-				]),
-				su: expect.stringContaining('Cancelled:'),
-				mp: expect.objectContaining({
-					ct: 'multipart/alternative',
-					mp: expect.any(Array)
+		const request = await cancelAppointmentAPIInterceptor;
+		expect(request).toEqual(
+			expect.objectContaining({
+				id: defaultInviteId,
+				m: expect.objectContaining({
+					e: [
+						{
+							a: defaultParticipant.email,
+							p: defaultParticipant.name,
+							t: 't'
+						},
+						{
+							a: 'organizer@test.com',
+							p: 'Test Organizer',
+							t: 'f'
+						}
+					]
 				})
-			}),
-			s: 123
-		});
+			})
+		);
 	});
 
 	it('should call CancelAppointmentRequest with empty organizer when invite has no organizer', async () => {
-		const mockState: Partial<RootState> = {
-			invites: {
-				invites: {
-					'test-invite-id': {
-						...mockedData.getInvite(),
-						organizer: {} as InviteOrganizer, // No valid organizer
-						participants: {}
-					}
-				},
-				status: ''
-			}
-		};
-
+		const mockStateWithNoOrganizer: Partial<RootState> = generateMockState({
+			organizer: {} as InviteOrganizer
+		});
 		const mockDispatch = jest.fn();
-		const mockGetState = jest.fn(() => mockState as RootState);
+		const mockGetState = jest.fn(() => mockStateWithNoOrganizer as RootState);
 
 		const inviteId = 'test-invite-id';
 		const thunk = moveAppointmentToTrash({
@@ -131,26 +116,22 @@ describe('moveAppointmentToTrash', () => {
 			id: inviteId
 		});
 
+		const cancelAppointmentAPIInterceptor = createSoapAPIInterceptor('CancelAppointment', {});
 		await thunk(mockDispatch, mockGetState, undefined);
-
-		expect(mockCancelAppointmentRequest).toHaveBeenCalledWith({
-			deleteSingleInstance: true,
-			id: inviteId,
-			inst: { d: '20230102T100000Z', tz: 'America/New_York' },
-			isOrganizer: true,
-			m: expect.objectContaining({
-				e: expect.not.arrayContaining([
-					expect.objectContaining({
-						t: 'f'
-					})
-				]),
-				su: expect.stringContaining('Cancelled:'),
-				mp: expect.objectContaining({
-					ct: 'multipart/alternative',
-					mp: expect.any(Array)
+		const request = await cancelAppointmentAPIInterceptor;
+		expect(request).toEqual(
+			expect.objectContaining({
+				id: inviteId,
+				m: expect.objectContaining({
+					e: [
+						{
+							a: defaultParticipant.email,
+							p: defaultParticipant.name,
+							t: 't'
+						}
+					]
 				})
-			}),
-			s: 123
-		});
+			})
+		);
 	});
 });

--- a/src/store/actions/tests/move-appointment-to-trash.test.ts
+++ b/src/store/actions/tests/move-appointment-to-trash.test.ts
@@ -1,0 +1,97 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import {
+	cancelAppointmentRequest,
+	CancelAppointmentReturnType
+} from '../../../soap/cancel-appointment-request';
+import mockedData from '../../../test/generators';
+import { InviteOrganizer } from '../../../types/store/invite';
+import { setupTMock } from '../../../utils/tests';
+import { RootState } from '../../redux';
+import { moveAppointmentToTrash } from '../move-appointment-to-trash';
+
+jest.mock('../../../soap/cancel-appointment-request');
+
+const mockCancelAppointmentRequest = cancelAppointmentRequest as jest.MockedFunction<
+	typeof cancelAppointmentRequest
+>;
+
+describe('moveAppointmentToTrash', () => {
+	const mockTFunction = setupTMock();
+
+	it('should call CancelAppointmentRequest with empty organizer when invite has no organizer', async () => {
+		const mockState: Partial<RootState> = {
+			invites: {
+				invites: {
+					'test-invite-id': {
+						...mockedData.getInvite(),
+						organizer: {} as InviteOrganizer, // No organizer
+						participants: {
+							AC: [
+								{
+									email: 'participant1@test.com',
+									name: 'Participant 1',
+									isOptional: false,
+									response: 'TE'
+								}
+							]
+						}
+					}
+				},
+				status: ''
+			}
+		};
+
+		const mockResponse: CancelAppointmentReturnType = {
+			Fault: undefined,
+			error: false,
+			m: undefined
+		};
+
+		mockCancelAppointmentRequest.mockResolvedValue(mockResponse);
+
+		const mockDispatch = jest.fn();
+		const mockGetState = jest.fn(() => mockState as RootState);
+
+		const inviteId = 'test-invite-id';
+		const thunk = moveAppointmentToTrash({
+			inviteId,
+			t: mockTFunction,
+			isOrganizer: true,
+			deleteSingleInstance: true,
+			inst: { d: '20230102T100000Z', tz: 'America/New_York' },
+			s: 123456789,
+			newMessage: '',
+			ridZ: '',
+			recur: false,
+			isRecurrent: true,
+			id: inviteId
+		});
+
+		await thunk(mockDispatch, mockGetState, undefined);
+
+		expect(mockCancelAppointmentRequest).toHaveBeenCalledWith({
+			deleteSingleInstance: true,
+			id: inviteId,
+			inst: { d: '20230102T100000Z', tz: 'America/New_York' },
+			isOrganizer: true,
+			m: expect.objectContaining({
+				e: expect.not.arrayContaining([
+					expect.objectContaining({
+						t: 'f'
+					})
+				]),
+				su: expect.stringContaining('Cancelled:'),
+				mp: expect.objectContaining({
+					ct: 'multipart/alternative',
+					mp: expect.any(Array)
+				})
+			}),
+			s: 123456789
+		});
+	});
+});

--- a/src/store/actions/tests/move-appointment-to-trash.test.ts
+++ b/src/store/actions/tests/move-appointment-to-trash.test.ts
@@ -97,6 +97,7 @@ describe('moveAppointmentToTrash', () => {
 
 	it('should call CancelAppointmentRequest with empty organizer when invite has no organizer', async () => {
 		const mockStateWithNoOrganizer: Partial<RootState> = generateMockState({
+			// TODO: see CO-1885 The type of organizer is not correct in this case the organizer can be undefined
 			organizer: {} as InviteOrganizer // No valid organizer
 		});
 		const mockDispatch = jest.fn();

--- a/src/store/actions/tests/move-appointment-to-trash.test.ts
+++ b/src/store/actions/tests/move-appointment-to-trash.test.ts
@@ -4,10 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import {
-	cancelAppointmentRequest,
-	CancelAppointmentReturnType
-} from '../../../soap/cancel-appointment-request';
+import { cancelAppointmentRequest } from '../../../soap/cancel-appointment-request';
 import mockedData from '../../../test/generators';
 import { InviteOrganizer } from '../../../types/store/invite';
 import { setupTMock } from '../../../utils/tests';
@@ -16,20 +13,25 @@ import { moveAppointmentToTrash } from '../move-appointment-to-trash';
 
 jest.mock('../../../soap/cancel-appointment-request');
 
+const mockTFunction = setupTMock();
+
 const mockCancelAppointmentRequest = cancelAppointmentRequest as jest.MockedFunction<
 	typeof cancelAppointmentRequest
 >;
 
 describe('moveAppointmentToTrash', () => {
-	const mockTFunction = setupTMock();
-
-	it('should call CancelAppointmentRequest with empty organizer when invite has no organizer', async () => {
+	it('should call CancelAppointmentRequest with organizer when invite has valid organizer', async () => {
 		const mockState: Partial<RootState> = {
 			invites: {
 				invites: {
 					'test-invite-id': {
 						...mockedData.getInvite(),
-						organizer: {} as InviteOrganizer, // No organizer
+						// Valid organizer
+						organizer: {
+							a: 'organizer@test.com',
+							d: 'Test Organizer',
+							url: ''
+						},
 						participants: {
 							AC: [
 								{
@@ -46,13 +48,70 @@ describe('moveAppointmentToTrash', () => {
 			}
 		};
 
-		const mockResponse: CancelAppointmentReturnType = {
-			Fault: undefined,
-			error: false,
-			m: undefined
-		};
+		const mockDispatch = jest.fn();
+		const mockGetState = jest.fn(() => mockState as RootState);
+		const mockRejectWithValue = jest.fn();
 
-		mockCancelAppointmentRequest.mockResolvedValue(mockResponse);
+		const inviteId = 'test-invite-id';
+		const thunk = moveAppointmentToTrash({
+			inviteId,
+			t: mockTFunction,
+			isOrganizer: true,
+			deleteSingleInstance: true,
+			inst: { d: '20230102T100000Z', tz: 'America/New_York' },
+			s: 123,
+			newMessage: '',
+			ridZ: '',
+			recur: false,
+			isRecurrent: true,
+			id: inviteId
+		});
+
+		await thunk(mockDispatch, mockGetState, { rejectWithValue: mockRejectWithValue });
+
+		expect(mockCancelAppointmentRequest).toHaveBeenCalledWith({
+			deleteSingleInstance: true,
+			id: inviteId,
+			inst: { d: '20230102T100000Z', tz: 'America/New_York' },
+			isOrganizer: true,
+			m: expect.objectContaining({
+				e: expect.arrayContaining([
+					// Should include organizer
+					expect.objectContaining({
+						a: 'organizer@test.com',
+						p: 'Test Organizer',
+						t: 'f'
+					}),
+					// Should include regular participant
+					expect.objectContaining({
+						a: 'participant1@test.com',
+						p: 'Participant 1',
+						t: 't'
+					})
+				]),
+				su: expect.stringContaining('Cancelled:'),
+				mp: expect.objectContaining({
+					ct: 'multipart/alternative',
+					mp: expect.any(Array)
+				})
+			}),
+			s: 123
+		});
+	});
+
+	it('should call CancelAppointmentRequest with empty organizer when invite has no organizer', async () => {
+		const mockState: Partial<RootState> = {
+			invites: {
+				invites: {
+					'test-invite-id': {
+						...mockedData.getInvite(),
+						organizer: {} as InviteOrganizer, // No valid organizer
+						participants: {}
+					}
+				},
+				status: ''
+			}
+		};
 
 		const mockDispatch = jest.fn();
 		const mockGetState = jest.fn(() => mockState as RootState);
@@ -64,7 +123,7 @@ describe('moveAppointmentToTrash', () => {
 			isOrganizer: true,
 			deleteSingleInstance: true,
 			inst: { d: '20230102T100000Z', tz: 'America/New_York' },
-			s: 123456789,
+			s: 123,
 			newMessage: '',
 			ridZ: '',
 			recur: false,
@@ -91,7 +150,7 @@ describe('moveAppointmentToTrash', () => {
 					mp: expect.any(Array)
 				})
 			}),
-			s: 123456789
+			s: 123
 		});
 	});
 });


### PR DESCRIPTION
Don't pass the participant of type 'f' (from) is the organizer email is not defined in an appointment while making `CancelAppointmentRequest` in delete appointment action.