### PR TITLE
feat: [CO-1976] prevent changing calendar while editing draft/saved event

### DIFF
--- a/src/store/selectors/editor.ts
+++ b/src/store/selectors/editor.ts
@@ -174,6 +174,18 @@ export const selectEditorAttachmentAid =
 	(state: RootState): Array<string> =>
 		state?.editor?.editors?.[id]?.attach?.aid;
 
+export const selectEditorIsDraft =
+	(id: string) =>
+	(state: RootState): boolean => {
+		const editor = state?.editor?.editors?.[id];
+
+		if (editor?.draft === true || editor?.isNew === false) {
+			return true;
+		}
+
+		return editor?.draft === undefined && editor?.isNew === undefined;
+	};
+
 export const selectEditorAttach =
 	(id: string) =>
 	(state: RootState): Array<any> =>

--- a/src/view/editor/parts/calendar-selector.tsx
+++ b/src/view/editor/parts/calendar-selector.tsx
@@ -129,6 +129,7 @@ export const CalendarSelector = ({
 
 	return calendars && defaultCalendarSelection ? (
 		<Select
+			data-testid={'calendar-selector'}
 			label={label || t('label.calendar', 'Calendar')}
 			onChange={onSelectedCalendarChange}
 			items={calendarItems}

--- a/src/view/editor/parts/editor-calendar-selector.tsx
+++ b/src/view/editor/parts/editor-calendar-selector.tsx
@@ -10,13 +10,18 @@ import { Row, SingleSelectionOnChange } from '@zextras/carbonio-design-system';
 import { CalendarSelector } from './calendar-selector';
 import { normalizeCalendarEditor } from '../../../normalizations/normalize-editor';
 import { useAppDispatch, useAppSelector } from '../../../store/redux/hooks';
-import { selectEditorCalendarId, selectEditorDisabled } from '../../../store/selectors/editor';
+import {
+	selectEditorCalendarId,
+	selectEditorDisabled,
+	selectEditorIsDraft
+} from '../../../store/selectors/editor';
 import { editEditorCalendar } from '../../../store/slices/editor-slice';
 import { CalendarEditor } from '../../../types/editor';
 
 export const EditorCalendarSelector = ({ editorId }: { editorId: string }): ReactElement | null => {
 	const calendarId = useAppSelector(selectEditorCalendarId(editorId));
 	const disabled = useAppSelector(selectEditorDisabled(editorId));
+	const isDraft = useAppSelector(selectEditorIsDraft(editorId));
 	const dispatch = useAppDispatch();
 
 	const onChange = useCallback<SingleSelectionOnChange<CalendarEditor>>(
@@ -38,7 +43,7 @@ export const EditorCalendarSelector = ({ editorId }: { editorId: string }): Reac
 			<CalendarSelector
 				calendarId={calendarId}
 				onCalendarChange={onChange}
-				disabled={disabled?.calendar}
+				disabled={disabled?.calendar || isDraft}
 				excludeTrash
 			/>
 		</Row>

--- a/src/view/editor/parts/editor-calendar-selector.tsx
+++ b/src/view/editor/parts/editor-calendar-selector.tsx
@@ -6,6 +6,7 @@
 import React, { ReactElement, useCallback } from 'react';
 
 import { Row, SingleSelectionOnChange, Tooltip } from '@zextras/carbonio-design-system';
+import { useTranslation } from 'react-i18next';
 
 import { CalendarSelector } from './calendar-selector';
 import { normalizeCalendarEditor } from '../../../normalizations/normalize-editor';
@@ -19,6 +20,8 @@ import { editEditorCalendar } from '../../../store/slices/editor-slice';
 import { CalendarEditor } from '../../../types/editor';
 
 export const EditorCalendarSelector = ({ editorId }: { editorId: string }): ReactElement | null => {
+	const [t] = useTranslation();
+
 	const calendarId = useAppSelector(selectEditorCalendarId(editorId));
 	const disabled = useAppSelector(selectEditorDisabled(editorId));
 	const isDraft = useAppSelector(selectEditorIsDraft(editorId));
@@ -38,10 +41,15 @@ export const EditorCalendarSelector = ({ editorId }: { editorId: string }): Reac
 		[dispatch, editorId]
 	);
 
+	const disabledCalendarTooltipLabel = t(
+		'tooltip.calendarSelector.disabled',
+		"To move this event to another calendar use the 'Move' option"
+	);
+
 	return calendarId ? (
 		<>
 			{isDraft ? (
-				<Tooltip label={'Use move option to move event to a different calendar'}>
+				<Tooltip label={disabledCalendarTooltipLabel}>
 					<Row height="fit" width="fill" padding={{ top: 'large' }}>
 						<CalendarSelector
 							calendarId={calendarId}

--- a/src/view/editor/parts/editor-calendar-selector.tsx
+++ b/src/view/editor/parts/editor-calendar-selector.tsx
@@ -5,7 +5,7 @@
  */
 import React, { ReactElement, useCallback } from 'react';
 
-import { Row, SingleSelectionOnChange } from '@zextras/carbonio-design-system';
+import { Row, SingleSelectionOnChange, Tooltip } from '@zextras/carbonio-design-system';
 
 import { CalendarSelector } from './calendar-selector';
 import { normalizeCalendarEditor } from '../../../normalizations/normalize-editor';
@@ -39,13 +39,28 @@ export const EditorCalendarSelector = ({ editorId }: { editorId: string }): Reac
 	);
 
 	return calendarId ? (
-		<Row height="fit" width="fill" padding={{ top: 'large' }}>
-			<CalendarSelector
-				calendarId={calendarId}
-				onCalendarChange={onChange}
-				disabled={disabled?.calendar || isDraft}
-				excludeTrash
-			/>
-		</Row>
+		<>
+			{isDraft ? (
+				<Tooltip label={'Use move option to move event to a different calendar'}>
+					<Row height="fit" width="fill" padding={{ top: 'large' }}>
+						<CalendarSelector
+							calendarId={calendarId}
+							onCalendarChange={onChange}
+							disabled
+							excludeTrash
+						/>
+					</Row>
+				</Tooltip>
+			) : (
+				<Row height="fit" width="fill" padding={{ top: 'large' }}>
+					<CalendarSelector
+						calendarId={calendarId}
+						onCalendarChange={onChange}
+						disabled={disabled?.calendar}
+						excludeTrash
+					/>
+				</Row>
+			)}
+		</>
 	) : null;
 };

--- a/src/view/editor/parts/tests/editor-calendar-selector.test.tsx
+++ b/src/view/editor/parts/tests/editor-calendar-selector.test.tsx
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
+import { screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+
+import { setupTest } from '../../../../carbonio-ui-commons/test/test-setup';
+import {
+	disabledFields,
+	EditorContext,
+	generateEditor
+} from '../../../../commons/editor-generator';
+import { reducers } from '../../../../store/redux';
+import mockedData from '../../../../test/generators';
+import { Editor } from '../../../../types/editor';
+import { EditorCalendarSelector } from '../editor-calendar-selector';
+
+describe('EditorCalendarSelector', () => {
+	it('renders null if calendarId is missing', async () => {
+		const store = configureStore({ reducer: combineReducers(reducers) });
+		const context: EditorContext = {
+			folders: {},
+			dispatch: store.dispatch,
+			disabled: disabledFields
+		};
+
+		const editor = generateEditor({ context });
+
+		setupTest(
+			<Provider store={store}>
+				<EditorCalendarSelector editorId={editor.id} />
+			</Provider>
+		);
+
+		expect(screen.queryByTestId('calendar-selector')).not.toBeInTheDocument();
+	});
+
+	it('renders if calendarId is not missing', async () => {
+		const store = configureStore({ reducer: combineReducers(reducers) });
+		const context: EditorContext = {
+			folders: mockedData.calendars.getCalendarsMap({}),
+			dispatch: store.dispatch,
+			disabled: disabledFields
+		};
+
+		const editor = generateEditor({ context });
+
+		setupTest(
+			<Provider store={store}>
+				<EditorCalendarSelector editorId={editor.id} />
+			</Provider>
+		);
+
+		expect(screen.getByTestId('calendar-selector')).toBeInTheDocument();
+	});
+
+	it.each([
+		// Cases that should return TRUE (draft status)
+		[{ draft: true }, true], // explicit draft=true
+		[{ isNew: false }, true], // isNew=false means it's a draft
+		[{ draft: undefined, isNew: undefined }, true], // both undefined → treated as draft
+		[{ isNew: undefined }, true], // isNew undefined → treated as draft
+
+		// Cases that should return FALSE (not draft)
+		[{ draft: false }, false], // explicit draft=false
+		[{ draft: false, isNew: true }, false], // explicit not draft
+		[{ isNew: true }, false], // isNew=true means not draft
+		[{}, false] // empty object → should this be draft?
+	])(
+		'when editor %s, calendar selector must have prop disabled: %j',
+		async (editorProps: Partial<Editor>, expectedDisabled: boolean) => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+
+			const context: EditorContext = {
+				folders: mockedData.calendars.getCalendarsMap({}),
+				dispatch: store.dispatch,
+				...editorProps
+			};
+
+			const editor = generateEditor({ context });
+
+			setupTest(
+				<Provider store={store}>
+					<EditorCalendarSelector editorId={editor.id} />
+				</Provider>
+			);
+
+			const calendarSelector = screen.getByTestId('calendar-selector');
+			// eslint-disable-next-line testing-library/no-node-access
+			const allChildren = Array.from(calendarSelector.querySelectorAll('*'));
+
+			expect(allChildren.length).toBeGreaterThan(0);
+
+			allChildren.forEach((child) => {
+				const ele = child as HTMLElement;
+				if (ele.style.cursor) {
+					expect(ele).toHaveStyle(expectedDisabled ? 'cursor: no-drop;' : 'cursor: pointer;');
+				}
+			});
+		}
+	);
+});

--- a/src/view/move/move-modal.tsx
+++ b/src/view/move/move-modal.tsx
@@ -12,6 +12,7 @@ import ModalFooter from '../../carbonio-ui-commons/components/modals/modal-foote
 import ModalHeader from '../../carbonio-ui-commons/components/modals/modal-header';
 import { FolderSelector } from '../../carbonio-ui-commons/components/select/flatten-folders/folder-selector';
 import { FOLDERS } from '../../carbonio-ui-commons/constants/folders';
+import { isTrash } from '../../carbonio-ui-commons/helpers/folders';
 import { Folder } from '../../carbonio-ui-commons/types';
 import { EventType } from '../../types/event';
 
@@ -95,6 +96,7 @@ export const MoveModal = ({
 					}}
 					showSharedAccounts
 					allowRootSelection={false}
+					filterChildren={(folder: Folder): boolean => !isTrash(folder.id)}
 				/>
 
 				<Container padding={{ all: 'medium' }} mainAlignment="center" crossAlignment="flex-start">

--- a/src/view/move/move-modal.tsx
+++ b/src/view/move/move-modal.tsx
@@ -10,7 +10,7 @@ import { t } from '@zextras/carbonio-shell-ui';
 
 import ModalFooter from '../../carbonio-ui-commons/components/modals/modal-footer';
 import ModalHeader from '../../carbonio-ui-commons/components/modals/modal-header';
-import { FolderSelector } from '../../carbonio-ui-commons/components/select/flatten-folders/folder-selector';
+import { FolderSelector } from '../../carbonio-ui-commons/components/select/folders/folder-selector';
 import { isTrash } from '../../carbonio-ui-commons/helpers/folders';
 import { Folder } from '../../carbonio-ui-commons/types';
 import { EventType } from '../../types/event';

--- a/src/view/move/move-modal.tsx
+++ b/src/view/move/move-modal.tsx
@@ -11,7 +11,6 @@ import { t } from '@zextras/carbonio-shell-ui';
 import ModalFooter from '../../carbonio-ui-commons/components/modals/modal-footer';
 import ModalHeader from '../../carbonio-ui-commons/components/modals/modal-header';
 import { FolderSelector } from '../../carbonio-ui-commons/components/select/flatten-folders/folder-selector';
-import { FOLDERS } from '../../carbonio-ui-commons/constants/folders';
 import { isTrash } from '../../carbonio-ui-commons/helpers/folders';
 import { Folder } from '../../carbonio-ui-commons/types';
 import { EventType } from '../../types/event';
@@ -76,7 +75,7 @@ export const MoveModal = ({
 		>
 			<ModalHeader
 				title={`${
-					event.resource.calendar.id === FOLDERS.TRASH
+					isTrash(event.resource.calendar.id)
 						? t('label.restore', 'Restore')
 						: t('label.move', 'Move')
 				} ${event.title}`}
@@ -140,7 +139,7 @@ export const MoveModal = ({
 				secondaryColor="primary"
 				secondaryLabel={t('label.new_calendar', 'New Calendar')}
 				label={
-					event.resource.calendar.id === FOLDERS.TRASH
+					isTrash(event.resource.calendar.id)
 						? t('label.restore', 'Restore')
 						: t('label.move', 'Move')
 				}

--- a/src/view/move/move-modal.tsx
+++ b/src/view/move/move-modal.tsx
@@ -58,6 +58,10 @@ export const MoveModal = ({
 		onClose
 	]);
 
+	const isInvalidDestination = !folderDestination || !folderDestination.id;
+	const isInvalidCurrent = !currentFolder || !currentFolder.id;
+	const isSameFolder = folderDestination?.id === currentFolder?.id;
+
 	return (
 		<Container
 			padding={{ all: 'small' }}
@@ -143,9 +147,7 @@ export const MoveModal = ({
 						? t('label.restore', 'Restore')
 						: t('label.move', 'Move')
 				}
-				disabled={
-					folderDestination && (!folderDestination.id || folderDestination.id === currentFolder.id)
-				}
+				disabled={isInvalidDestination || isInvalidCurrent || isSameFolder}
 			/>
 		</Container>
 	);

--- a/src/view/move/move-modal.tsx
+++ b/src/view/move/move-modal.tsx
@@ -3,25 +3,16 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React, { ReactElement, useCallback, useMemo, useState } from 'react';
+import React, { ReactElement, useCallback, useState } from 'react';
 
-import {
-	AccordionDivider,
-	AccordionItemType,
-	Container,
-	Input,
-	Text
-} from '@zextras/carbonio-design-system';
+import { Container, Text } from '@zextras/carbonio-design-system';
 import { t } from '@zextras/carbonio-shell-ui';
-import { filter, isEmpty, map, reduce, startsWith } from 'lodash';
 
-import { FolderItem } from './folder-item';
 import ModalFooter from '../../carbonio-ui-commons/components/modals/modal-footer';
 import ModalHeader from '../../carbonio-ui-commons/components/modals/modal-header';
+import { FolderSelector } from '../../carbonio-ui-commons/components/select/flatten-folders/folder-selector';
 import { FOLDERS } from '../../carbonio-ui-commons/constants/folders';
-import { useFoldersMap } from '../../carbonio-ui-commons/store/zustand/folder';
-import { Folder, Folders } from '../../carbonio-ui-commons/types';
-import { getFolderTranslatedName } from '../../commons/utilities';
+import { Folder } from '../../carbonio-ui-commons/types';
 import { EventType } from '../../types/event';
 
 type ActionArgs = {
@@ -46,8 +37,6 @@ export const MoveModal = ({
 	currentFolder,
 	action
 }: MoveModalProps): ReactElement => {
-	const folders = useFoldersMap();
-	const [input, setInput] = useState('');
 	const [folderDestination, setFolderDestination] = useState<Folder | undefined>();
 	const [isSameFolder, setIsSameFolder] = useState(false);
 	const onConfirm = useCallback(() => {
@@ -70,71 +59,6 @@ export const MoveModal = ({
 		event.resource.id,
 		onClose
 	]);
-	const filterFromInput = useMemo<Array<Folder>>(
-		() =>
-			filter(folders, (v) => {
-				if (isEmpty(v)) {
-					return false;
-				}
-				if (v.id === currentFolder.id) {
-					return false;
-				}
-				return startsWith(v.name?.toLowerCase(), input?.toLowerCase());
-			}),
-		[currentFolder, folders, input]
-	);
-
-	const nestFilteredFolders = useCallback(
-		(
-			items: Folders,
-			calId: string | undefined,
-			results: Array<Folder>
-		): (AccordionItemType | AccordionDivider)[] =>
-			reduce(
-				filter(items, (item) => item.parent === calId),
-				(acc, item) => {
-					const match = filter(results, (result) => result.id === item.id);
-					if (match && match.length) {
-						const folderItems = map(folders, (folder) => ({ id: folder.id, label: folder.name }));
-						return [
-							...acc,
-							{
-								divider: true
-							} satisfies AccordionDivider,
-							{
-								...item,
-								label: item.name,
-								items: folderItems,
-								onClick: () => setFolderDestination(item),
-								open: !!input.length,
-								background: folderDestination?.id === item.id ? 'highlight' : undefined
-							} satisfies AccordionItemType
-						];
-					}
-					if (match && !match.length) {
-						return [...acc, ...nestFilteredFolders(items, item.id, results)];
-					}
-					return acc;
-				},
-				[] as (AccordionItemType | AccordionDivider)[]
-			),
-		[folderDestination?.id, folders, input.length]
-	);
-
-	const nestedData = useMemo(
-		() =>
-			[
-				{
-					id: FOLDERS.USER_ROOT,
-					label: getFolderTranslatedName({ folderId: FOLDERS.USER_ROOT, folderName: 'Root' }),
-					level: 0,
-					open: true,
-					items: nestFilteredFolders(folders, '1', filterFromInput),
-					background: folderDestination?.id === '1' ? 'highlight' : undefined
-				}
-			] as (AccordionItemType | AccordionDivider)[],
-		[filterFromInput, folderDestination, folders, nestFilteredFolders]
-	);
 
 	return (
 		<Container
@@ -164,18 +88,14 @@ export const MoveModal = ({
 						)}
 					</Text>
 				</Container>
-				<Input
-					label={t('folder.modal.move.input.filter', 'Filter calendars')}
-					backgroundColor="gray5"
-					value={input}
-					onChange={(e: React.ChangeEvent<HTMLInputElement>): void => {
-						if (e) {
-							setInput(e?.target?.value);
-						}
+				<FolderSelector
+					onFolderSelected={(folder: Folder): void => {
+						setFolderDestination(folder);
 					}}
+					showSharedAccounts
+					allowRootSelection
 				/>
 
-				<FolderItem folders={nestedData} />
 				<Container padding={{ all: 'medium' }} mainAlignment="center" crossAlignment="flex-start">
 					{isSameFolder && <Text color="error">Cannot move to same folder</Text>}
 				</Container>

--- a/src/view/move/move-modal.tsx
+++ b/src/view/move/move-modal.tsx
@@ -39,7 +39,7 @@ export const MoveModal = ({
 	action
 }: MoveModalProps): ReactElement => {
 	const [folderDestination, setFolderDestination] = useState<Folder | undefined>();
-	const [isSameFolder, setIsSameFolder] = useState(false);
+
 	const onConfirm = useCallback(() => {
 		if (folderDestination && folderDestination?.id !== currentFolder.id) {
 			action({
@@ -49,8 +49,6 @@ export const MoveModal = ({
 				destinationCalendarName: folderDestination.name
 			});
 			onClose();
-		} else {
-			setIsSameFolder(true);
 		}
 	}, [
 		folderDestination,
@@ -67,6 +65,14 @@ export const MoveModal = ({
 			mainAlignment="center"
 			crossAlignment="flex-start"
 			height="fit"
+			width="fill"
+			style={{
+				maxWidth: '100%',
+				boxSizing: 'border-box',
+				display: 'flex',
+				flexDirection: 'column',
+				minHeight: 0
+			}}
 		>
 			<ModalHeader
 				title={`${
@@ -76,11 +82,26 @@ export const MoveModal = ({
 				} ${event.title}`}
 				onClose={onClose}
 			/>
-			<Container mainAlignment="center" crossAlignment="flex-start" height="fit">
+
+			<Container
+				mainAlignment="flex-start"
+				crossAlignment="flex-start"
+				height="fit"
+				width="fill"
+				padding={{ bottom: 'small' }}
+				style={{
+					flex: 1,
+					minHeight: 0,
+					overflow: 'hidden',
+					display: 'flex',
+					flexDirection: 'column'
+				}}
+			>
 				<Container
 					padding={{ vertical: 'small' }}
 					mainAlignment="center"
 					crossAlignment="flex-start"
+					width="fill"
 				>
 					<Text overflow="break-word">
 						{t(
@@ -89,36 +110,44 @@ export const MoveModal = ({
 						)}
 					</Text>
 				</Container>
-				<FolderSelector
-					selectedFolderId={folderDestination?.id}
-					onFolderSelected={(folder: Folder): void => {
-						setFolderDestination(folder);
-					}}
-					showSharedAccounts
-					allowRootSelection={false}
-					filterChildren={(folder: Folder): boolean => !isTrash(folder.id)}
-				/>
 
-				<Container padding={{ all: 'medium' }} mainAlignment="center" crossAlignment="flex-start">
-					{isSameFolder && <Text color="error">Cannot move to same folder</Text>}
+				<Container
+					width="fill"
+					padding={{ bottom: 'small' }}
+					style={{
+						flex: 1,
+						minHeight: 0,
+						display: 'flex',
+						flexDirection: 'column'
+					}}
+				>
+					<FolderSelector
+						selectedFolderId={folderDestination?.id}
+						onFolderSelected={(folder: Folder): void => {
+							setFolderDestination(folder);
+						}}
+						showSharedAccounts
+						allowRootSelection={false}
+						filterChildren={(folder: Folder): boolean => !isTrash(folder.id)}
+					/>
 				</Container>
-				<ModalFooter
-					onConfirm={onConfirm}
-					secondaryAction={toggleModal}
-					secondaryBtnType="outlined"
-					secondaryColor="primary"
-					secondaryLabel={t('label.new_calendar', 'New Calendar')}
-					label={
-						event.resource.calendar.id === FOLDERS.TRASH
-							? t('label.restore', 'Restore')
-							: t('label.move', 'Move')
-					}
-					disabled={
-						folderDestination &&
-						(!folderDestination.id || folderDestination.id === currentFolder.id)
-					}
-				/>
 			</Container>
+
+			<ModalFooter
+				onConfirm={onConfirm}
+				secondaryAction={toggleModal}
+				secondaryBtnType="outlined"
+				secondaryColor="primary"
+				secondaryLabel={t('label.new_calendar', 'New Calendar')}
+				label={
+					event.resource.calendar.id === FOLDERS.TRASH
+						? t('label.restore', 'Restore')
+						: t('label.move', 'Move')
+				}
+				disabled={
+					folderDestination && (!folderDestination.id || folderDestination.id === currentFolder.id)
+				}
+			/>
 		</Container>
 	);
 };

--- a/src/view/move/move-modal.tsx
+++ b/src/view/move/move-modal.tsx
@@ -89,11 +89,12 @@ export const MoveModal = ({
 					</Text>
 				</Container>
 				<FolderSelector
+					selectedFolderId={folderDestination?.id}
 					onFolderSelected={(folder: Folder): void => {
 						setFolderDestination(folder);
 					}}
 					showSharedAccounts
-					allowRootSelection
+					allowRootSelection={false}
 				/>
 
 				<Container padding={{ all: 'medium' }} mainAlignment="center" crossAlignment="flex-start">

--- a/src/view/move/tests/move-modal.test.tsx
+++ b/src/view/move/tests/move-modal.test.tsx
@@ -1,0 +1,141 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { faker } from '@faker-js/faker';
+import { screen } from '@testing-library/react';
+
+import { FOLDER_VIEW } from '../../../carbonio-ui-commons/constants';
+import { FOLDERS } from '../../../carbonio-ui-commons/constants/folders';
+import { generateFolder } from '../../../carbonio-ui-commons/test/mocks/folders/folders-generator';
+import { populateFoldersStore } from '../../../carbonio-ui-commons/test/mocks/store/folders';
+import { setupTest } from '../../../carbonio-ui-commons/test/test-setup';
+import mockedData from '../../../test/generators';
+import { EventType } from '../../../types/event';
+import { MoveModal } from '../move-modal';
+
+const mockToggleModal = jest.fn();
+const mockOnClose = jest.fn();
+const mockAction = jest.fn();
+
+const mockEvent = mockedData.getEvent({ title: 'Test Event' });
+const defaultCalendarFolder = generateFolder({
+	id: faker.number.int({ min: 100 }).toString(),
+	name: 'DefaultCalendar',
+	color: faker.number.int({ min: 0, max: 9 })
+});
+
+describe('MoveModal', () => {
+	beforeEach(() => {
+		populateFoldersStore({
+			view: FOLDER_VIEW.appointment,
+			noSharedAccounts: true,
+			customFolders: [defaultCalendarFolder]
+		});
+	});
+
+	it('renders the modal with the correct title for moving an event', () => {
+		setupTest(
+			<MoveModal
+				toggleModal={mockToggleModal}
+				onClose={mockOnClose}
+				event={mockEvent}
+				currentFolder={defaultCalendarFolder}
+				action={mockAction}
+			/>
+		);
+
+		expect(screen.getByText('label.move Test Event')).toBeInTheDocument();
+	});
+
+	it('renders the modal with the correct title for restoring an event if in trash', () => {
+		const trashEvent: EventType = {
+			...mockEvent,
+			resource: {
+				...mockEvent.resource,
+				calendar: {
+					id: FOLDERS.TRASH,
+					name: 'trash',
+					color: {
+						color: '',
+						background: '',
+						label: undefined
+					}
+				}
+			}
+		};
+
+		setupTest(
+			<MoveModal
+				toggleModal={mockToggleModal}
+				onClose={mockOnClose}
+				event={trashEvent}
+				currentFolder={defaultCalendarFolder}
+				action={mockAction}
+			/>
+		);
+
+		expect(screen.getByText('label.restore Test Event')).toBeInTheDocument();
+	});
+
+	it('calls the action and onClose when confirming a valid folder destination', async () => {
+		const { user } = setupTest(
+			<MoveModal
+				toggleModal={mockToggleModal}
+				onClose={mockOnClose}
+				event={mockEvent}
+				currentFolder={defaultCalendarFolder}
+				action={mockAction}
+			/>
+		);
+
+		const moveButton = screen.getByRole('button', { name: 'label.move' });
+
+		expect(moveButton).toBeDisabled();
+
+		const destinationFolder = screen.getByText(/emailed contacts/i);
+		await user.click(destinationFolder);
+
+		expect(moveButton).toBeEnabled();
+
+		await user.click(moveButton);
+		expect(mockAction).toHaveBeenCalledTimes(1);
+		expect(mockOnClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('disables the confirm button if no folder is selected', () => {
+		setupTest(
+			<MoveModal
+				toggleModal={mockToggleModal}
+				onClose={mockOnClose}
+				event={mockEvent}
+				currentFolder={defaultCalendarFolder}
+				action={mockAction}
+			/>
+		);
+
+		const moveButton = screen.getByRole('button', { name: 'label.move' });
+		expect(moveButton).toBeDisabled();
+	});
+
+	it('disables the confirm button if the selected folder is the current folder', async () => {
+		const { user } = setupTest(
+			<MoveModal
+				toggleModal={mockToggleModal}
+				onClose={mockOnClose}
+				event={mockEvent}
+				currentFolder={defaultCalendarFolder}
+				action={mockAction}
+			/>
+		);
+
+		const destinationFolder = screen.getByText(defaultCalendarFolder.name);
+		await user.click(destinationFolder);
+
+		const moveButton = screen.getByRole('button', { name: 'label.move' });
+		expect(moveButton).toBeDisabled();
+	});
+});


### PR DESCRIPTION
**What has changed:**

- Do not allow user change the calendar from the editor by disabling the calendar selector while editing a saved appointment aligning behavior with the back-end requirements.

- New Improved Appointment move dialog.

    - Allows precise selection of destination calendars from primary and shared accounts.

    - Allows filtering Calendars for fast Move/Restore operations.

    - Fixed switching between restore and move mode, behavior is now aligned for shared folder appointments as well.

    - Improve Confirm button availability (based on essential checks like: isInvalidDestination || isInvalidCurrentFolder || isSameFolder)

- Improved Layout of Appointment Move Dialog, preventing overflow of buttons outside the dialog
 
**Required PRs:** 
- https://github.com/zextras/carbonio-ui-commons/pull/178
