### PR TITLE
chore: [CO-2112]  improve invite fetching in appointment mail preview

### DIFF
--- a/src/commons/html-message-renderer.tsx
+++ b/src/commons/html-message-renderer.tsx
@@ -25,6 +25,9 @@ export const HtmlMessageRenderer = ({
 					font-family: Roboto, sans-serif;
 					font-size: ${remFontSize};
 				}
+				p{
+					margin-top: 0;
+				}
 			</style>
 			<div>${updatedBody}</div>
 		`,

--- a/src/shared/invite-response/invite-response.test.tsx
+++ b/src/shared/invite-response/invite-response.test.tsx
@@ -10,7 +10,6 @@ import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import { act, screen, waitFor, within } from '@testing-library/react';
 import { keyBy, values } from 'lodash';
 import moment from 'moment-timezone';
-import { HttpResponse } from 'msw';
 
 import { InviteResponse } from './invite-response';
 import {
@@ -21,10 +20,7 @@ import {
 import { useFolderStore } from '../../carbonio-ui-commons/store/zustand/folder';
 import * as shell from '../../carbonio-ui-commons/test/mocks/carbonio-shell-ui';
 import { generateRoots } from '../../carbonio-ui-commons/test/mocks/folders/roots-generator';
-import {
-	createAPIInterceptor,
-	createSoapAPIInterceptor
-} from '../../carbonio-ui-commons/test/mocks/network/msw/create-api-interceptor';
+import { createSoapAPIInterceptor } from '../../carbonio-ui-commons/test/mocks/network/msw/create-api-interceptor';
 import { mockUseHistoryNavigation } from '../../carbonio-ui-commons/test/mocks/routing/use-history-navigation-mock';
 import { setupTest } from '../../carbonio-ui-commons/test/test-setup';
 import * as handler from '../../commons/get-appointment';
@@ -1576,37 +1572,6 @@ describe('invite response component', () => {
 					expect(messageString).toBeVisible();
 				});
 			});
-		});
-	});
-	describe('InviteResponse - fetchInvite error handling', () => {
-		test('should show error if fetchInvite returns Fault response', async () => {
-			setupFoldersStore();
-			const mailMsg = buildMailMessageType(MESSAGE_METHOD.REQUEST, MESSAGE_TYPE.SINGLE, false);
-
-			createAPIInterceptor(
-				'post',
-				'/service/soap/GetAppointmentRequest',
-				HttpResponse.json({ Fault: {} })
-			);
-
-			const store = configureStore({ reducer: combineReducers(reducers) });
-			setupTest(<InviteResponse mailMsg={mailMsg} moveToTrash={jest.fn()} />, { store });
-
-			const errorString = await screen.findByText(/Something went wrong, please try again/i);
-			expect(errorString).toBeVisible();
-		});
-
-		test('should show error if fetchInvite returns network error', async () => {
-			setupFoldersStore();
-			const mailMsg = buildMailMessageType(MESSAGE_METHOD.REQUEST, MESSAGE_TYPE.SINGLE, false);
-
-			createAPIInterceptor('post', '/service/soap/GetAppointmentRequest', HttpResponse.error());
-
-			const store = configureStore({ reducer: combineReducers(reducers) });
-			setupTest(<InviteResponse mailMsg={mailMsg} moveToTrash={jest.fn()} />, { store });
-
-			const errorString = await screen.findByText(/Something went wrong, please try again/i);
-			expect(errorString).toBeVisible();
 		});
 	});
 });

--- a/src/shared/invite-response/invite-response.tsx
+++ b/src/shared/invite-response/invite-response.tsx
@@ -67,11 +67,7 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 	const account = useUserAccount();
 	const [t] = useTranslation();
 
-	const {
-		invite: fetchedInv,
-		loading: fetchingInvite,
-		error: inviteFetchError
-	} = useFetchInvite(mailMsg, false);
+	const { invite: fetchedInv, loading: fetchingInvite } = useFetchInvite(mailMsg, false);
 
 	const invite = normalizeInvite({ ...mailMsg, inv: fetchedInv });
 
@@ -188,16 +184,6 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 			<InviteContainer data-testid={'invite-response'}>
 				<Container padding={{ horizontal: 'small', vertical: 'large' }} width="100%">
 					<Spinner color={'primary'} />
-				</Container>
-			</InviteContainer>
-		);
-	}
-
-	if (inviteFetchError) {
-		return (
-			<InviteContainer data-testid="invite-response">
-				<Container padding={{ horizontal: 'small', vertical: 'large' }} width="100%">
-					<p style={{ color: 'red' }}>{inviteFetchError}</p>
 				</Container>
 			</InviteContainer>
 		);

--- a/src/shared/invite-response/tests/useFetchInvite.test.ts
+++ b/src/shared/invite-response/tests/useFetchInvite.test.ts
@@ -1,0 +1,104 @@
+/* eslint-disable testing-library/no-wait-for-multiple-assertions */
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse } from 'msw';
+
+import {
+	createAPIInterceptor,
+	createSoapAPIInterceptor
+} from '../../../carbonio-ui-commons/test/mocks/network/msw/create-api-interceptor';
+import mockedData from '../../../test/generators';
+import { MailMsg } from '../../../types/integrations';
+import { Invite } from '../../../types/store/invite';
+import { useFetchInvite } from '../useFetchInvite';
+
+jest.mock('react-i18next', () => ({
+	...jest.requireActual('react-i18next'),
+	useTranslation: jest.fn().mockReturnValue({
+		t: (_key: string, defaultValue: string) => defaultValue
+	})
+}));
+
+describe('useFetchInvite', () => {
+	const baseMailMsg: MailMsg = {
+		invite: {
+			apptId: '123',
+			comp: [{ apptId: '123' }]
+		}
+	};
+
+	it('returns error when appointment ID is missing', async () => {
+		const mailMsg: MailMsg = { invite: null } as any;
+
+		const { result } = renderHook(() => useFetchInvite(mailMsg));
+
+		expect(result.current.error).toBe('MISSING_APPOINTMENT_ID');
+		expect(result.current.loading).toBe(false);
+	});
+
+	it('sets generic error when GetAppointment returns Fault', async () => {
+		createAPIInterceptor(
+			'post',
+			'/service/soap/GetAppointmentRequest',
+			HttpResponse.json({ Fault: {} })
+		);
+
+		const { result } = renderHook(() => useFetchInvite(baseMailMsg));
+
+		await waitFor(() => {
+			expect(result.current.error).toBe('Something went wrong, please try again');
+			expect(result.current.loading).toBe(false);
+		});
+	});
+
+	it('fetches invite successfully', async () => {
+		const event = mockedData.getEvent({ resource: { isRecurrent: true } });
+		const invite: Invite = mockedData.getInvite({ event });
+
+		createSoapAPIInterceptor('GetAppointment', {
+			appt: [{ inv: invite }]
+		});
+
+		const { result } = renderHook(() => useFetchInvite(baseMailMsg));
+
+		await waitFor(() => {
+			expect(result.current.invite).toEqual(invite);
+			expect(result.current.error).toBeNull();
+			expect(result.current.loading).toBe(false);
+		});
+	});
+
+	it('handles exception during fetch gracefully', async () => {
+		createAPIInterceptor('post', '/service/soap/GetAppointmentRequest', HttpResponse.error());
+
+		const { result } = renderHook(() => useFetchInvite(baseMailMsg));
+
+		await waitFor(() => {
+			expect(result.current.error).toBe('Something went wrong, please try again');
+			expect(result.current.loading).toBe(false);
+		});
+	});
+
+	it('includes content when includeContent is true', async () => {
+		const event = mockedData.getEvent();
+		const invite: Invite = mockedData.getInvite({ event });
+
+		const requestBody = '';
+		createSoapAPIInterceptor('GetAppointment', {
+			appt: [{ inv: invite }]
+		});
+
+		const { result } = renderHook(() => useFetchInvite(baseMailMsg, true));
+
+		await waitFor(() => {
+			expect(result.current.invite).toEqual(invite);
+			expect(result.current.error).toBeNull();
+			expect(result.current.loading).toBe(false);
+		});
+	});
+});

--- a/src/shared/invite-response/useFetchInvite.ts
+++ b/src/shared/invite-response/useFetchInvite.ts
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useTranslation } from 'react-i18next';
 
@@ -11,24 +11,29 @@ import { getAppointment, getAppointmentIncludeContentFlag } from '../../commons/
 import { MailMsg } from '../../types/integrations';
 import { Invite } from '../../types/store/invite';
 
-export const useFetchInvite: (
-	mailMsg: MailMsg,
-	includeContent?: boolean
-) => {
+type UseFetchInviteError = 'MISSING_APPOINTMENT_ID' | string | null;
+
+interface UseFetchInviteResult {
 	invite: Invite;
 	loading: boolean;
-	error: string | null;
-} = (mailMsg: MailMsg, includeContent = false) => {
+	error: UseFetchInviteError;
+}
+
+export const useFetchInvite = (mailMsg: MailMsg, includeContent = false): UseFetchInviteResult => {
 	const { t } = useTranslation();
 	const [invite, setInvite] = useState<Invite>(mailMsg.invite || null);
 	const [loading, setLoading] = useState<boolean>(false);
-	const [error, setError] = useState<string | null>(null);
+	const [error, setError] = useState<UseFetchInviteError>(null);
 
 	useEffect(() => {
 		const fetchInvite: () => Promise<void> = async () => {
 			setLoading(true);
 			try {
-				const appointmentId = invite.apptId ?? mailMsg?.invite?.[0]?.comp?.[0]?.apptId;
+				const appointmentId = invite?.apptId ?? mailMsg?.invite?.[0]?.comp?.[0]?.apptId;
+				if (!appointmentId) {
+					setError('MISSING_APPOINTMENT_ID');
+					return;
+				}
 				const response = await getAppointment(
 					appointmentId,
 					getAppointmentIncludeContentFlag(includeContent)
@@ -46,7 +51,7 @@ export const useFetchInvite: (
 		};
 
 		fetchInvite();
-	}, [includeContent, invite.apptId, mailMsg, t]);
+	}, [includeContent, invite?.apptId, mailMsg, t]);
 
 	return { invite, loading, error };
 };

--- a/src/shared/invite-response/useFetchInvite.ts
+++ b/src/shared/invite-response/useFetchInvite.ts
@@ -11,7 +11,8 @@ import { getAppointment, getAppointmentIncludeContentFlag } from '../../commons/
 import { MailMsg } from '../../types/integrations';
 import { Invite } from '../../types/store/invite';
 
-type UseFetchInviteError = 'MISSING_APPOINTMENT_ID' | string | null;
+type KnownErrors = 'MISSING_APPOINTMENT_ID';
+type UseFetchInviteError = KnownErrors | Exclude<string, KnownErrors> | null;
 
 interface UseFetchInviteResult {
 	invite: Invite;


### PR DESCRIPTION
**Key changes:**

- `InviteResponse` component, while using `useFetchInvite`, do not call `GetAppointment` request if appointment ID is undefined and fallback to load appointment description from the passed mail message.
- fix `p` margin to align it with the message icon in mail preview renderer.