### PR TITLE
feat: [CO-2199] Improve resource input validation in editor

### DIFF
--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 import { EditorChipAttendees, InviteClass, InviteFreeBusy } from './store/invite';
 
 export type CalendarEditor = {

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 import { EditorChipAttendees, InviteClass, InviteFreeBusy } from './store/invite';
 
 export type CalendarEditor = {

--- a/src/view/editor/parts/editor-equipments.tsx
+++ b/src/view/editor/parts/editor-equipments.tsx
@@ -19,6 +19,7 @@ export const EditorEquipments = ({ editorId }: { editorId: string }): ReactEleme
 	const dispatch = useAppDispatch();
 	const [t] = useTranslation();
 	const disabled = useAppSelector(selectEditorDisabled(editorId));
+
 	const equipmentValue = useAppSelector(selectEditorEquipment(editorId));
 
 	const equipmentChipValue = useMemo(
@@ -27,9 +28,7 @@ export const EditorEquipments = ({ editorId }: { editorId: string }): ReactEleme
 				id: resource.id,
 				label: resource.label,
 				email: resource.email,
-				avatarIcon: 'BriefcaseOutline' as const,
-				avatarBackground: 'transparent' as const,
-				avatarColor: 'gray0' as const
+				avatarIcon: 'BriefcaseOutline' as const
 			})),
 		[equipmentValue]
 	);
@@ -56,7 +55,7 @@ export const EditorEquipments = ({ editorId }: { editorId: string }): ReactEleme
 						value: normalizeResources(result)
 					}));
 				}
-				throw new Error('received error from API');
+				throw new Error('API failed');
 			}),
 		[]
 	);
@@ -76,6 +75,10 @@ export const EditorEquipments = ({ editorId }: { editorId: string }): ReactEleme
 			singleWarningLabel={t(
 				'attendee_equipment_unavailable',
 				'Equipment not available at the selected time of the event'
+			)}
+			invalidInputErrorLabel={t(
+				'attendees_equipments_invalid',
+				'One or more Equipments are invalid'
 			)}
 		/>
 	);

--- a/src/view/editor/parts/editor-equipments.tsx
+++ b/src/view/editor/parts/editor-equipments.tsx
@@ -9,7 +9,7 @@ import { filter, map } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { EditorResourceComponent, normalizeResources } from './editor-resource-component';
-import { generateResourceId } from './utils';
+import { generateResourceId, isValidResource } from './utils';
 import { searchResources } from '../../../soap/search-resources';
 import { useAppDispatch, useAppSelector } from '../../../store/redux/hooks';
 import { selectEditorDisabled, selectEditorEquipment } from '../../../store/selectors/editor';
@@ -25,14 +25,17 @@ export const EditorEquipments = ({ editorId }: { editorId: string }): ReactEleme
 
 	const equipmentChipValue = useMemo(
 		() =>
-			map(equipmentValue, (resource) => ({
-				id: resource.id ?? generateResourceId(resource),
-				label: resource.label,
-				email: resource.email,
-				avatarIcon: 'BriefcaseOutline' as const,
-				avatarBackground: 'transparent' as const,
-				avatarColor: 'gray0' as const
-			})),
+			map(equipmentValue, (resource) => {
+				const isValid = isValidResource(resource);
+				return {
+					id: resource.id ?? generateResourceId(resource),
+					label: resource.label,
+					email: resource.email,
+					avatarIcon: isValid ? 'BriefcaseOutline' : 'AlertCircleOutline',
+					avatarBackground: 'transparent' as const,
+					avatarColor: 'gray0' as const
+				};
+			}),
 		[equipmentValue]
 	);
 

--- a/src/view/editor/parts/editor-equipments.tsx
+++ b/src/view/editor/parts/editor-equipments.tsx
@@ -45,7 +45,7 @@ export const EditorEquipments = ({ editorId }: { editorId: string }): ReactEleme
 	const onSearchOptions = useCallback(
 		(searchedValued: string) =>
 			searchResources(searchedValued).then((response) => {
-				if (!response.error) {
+				if (response && !response.error) {
 					const equipmentResource = filter(
 						response.cn,
 						(cn) => cn._attrs.zimbraCalResType === 'Equipment'

--- a/src/view/editor/parts/editor-equipments.tsx
+++ b/src/view/editor/parts/editor-equipments.tsx
@@ -83,11 +83,11 @@ export const EditorEquipments = ({ editorId }: { editorId: string }): ReactEleme
 				'Equipment not available at the selected time of the event'
 			)}
 			invalidInputErrorLabel={t(
-				'attendees_equipments_invalid',
+				'equipment_invalid',
 				'One or more items of equipment are invalid. Try editing them or entering a new one.'
 			)}
 			duplicateChipsErrorLabel={t(
-				'duplicate_attendees_equipments_error',
+				'duplicate_equipment_error',
 				'One or more items of equipment were selected multiple times. Consider removing the duplicates.'
 			)}
 		/>

--- a/src/view/editor/parts/editor-equipments.tsx
+++ b/src/view/editor/parts/editor-equipments.tsx
@@ -86,6 +86,10 @@ export const EditorEquipments = ({ editorId }: { editorId: string }): ReactEleme
 				'attendees_equipments_invalid',
 				'One or more items of equipment are invalid. Try editing them or entering a new one.'
 			)}
+			duplicateChipsErrorLabel={t(
+				'duplicate_attendees_equipments_error',
+				'One or more items of equipment were selected multiple times. Consider removing the duplicates.'
+			)}
 		/>
 	);
 };

--- a/src/view/editor/parts/editor-equipments.tsx
+++ b/src/view/editor/parts/editor-equipments.tsx
@@ -9,6 +9,7 @@ import { filter, map } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { EditorResourceComponent, normalizeResources } from './editor-resource-component';
+import { generateResourceId } from './utils';
 import { searchResources } from '../../../soap/search-resources';
 import { useAppDispatch, useAppSelector } from '../../../store/redux/hooks';
 import { selectEditorDisabled, selectEditorEquipment } from '../../../store/selectors/editor';
@@ -25,7 +26,7 @@ export const EditorEquipments = ({ editorId }: { editorId: string }): ReactEleme
 	const equipmentChipValue = useMemo(
 		() =>
 			map(equipmentValue, (resource) => ({
-				id: resource.id,
+				id: resource.id ?? generateResourceId(resource),
 				label: resource.label,
 				email: resource.email,
 				avatarIcon: 'BriefcaseOutline' as const,

--- a/src/view/editor/parts/editor-equipments.tsx
+++ b/src/view/editor/parts/editor-equipments.tsx
@@ -80,7 +80,7 @@ export const EditorEquipments = ({ editorId }: { editorId: string }): ReactEleme
 			)}
 			invalidInputErrorLabel={t(
 				'attendees_equipments_invalid',
-				'One or more Equipments are invalid'
+				'One or more Equipments are invalid. Try editing them or entering a new one.'
 			)}
 		/>
 	);

--- a/src/view/editor/parts/editor-equipments.tsx
+++ b/src/view/editor/parts/editor-equipments.tsx
@@ -84,7 +84,7 @@ export const EditorEquipments = ({ editorId }: { editorId: string }): ReactEleme
 			)}
 			invalidInputErrorLabel={t(
 				'attendees_equipments_invalid',
-				'One or more Equipments are invalid. Try editing them or entering a new one.'
+				'One or more items of equipment are invalid. Try editing them or entering a new one.'
 			)}
 		/>
 	);

--- a/src/view/editor/parts/editor-equipments.tsx
+++ b/src/view/editor/parts/editor-equipments.tsx
@@ -28,7 +28,9 @@ export const EditorEquipments = ({ editorId }: { editorId: string }): ReactEleme
 				id: resource.id,
 				label: resource.label,
 				email: resource.email,
-				avatarIcon: 'BriefcaseOutline' as const
+				avatarIcon: 'BriefcaseOutline' as const,
+				avatarBackground: 'transparent' as const,
+				avatarColor: 'gray0' as const
 			})),
 		[equipmentValue]
 	);

--- a/src/view/editor/parts/editor-meeting-rooms.tsx
+++ b/src/view/editor/parts/editor-meeting-rooms.tsx
@@ -86,6 +86,10 @@ export const EditorMeetingRooms = ({ editorId }: { editorId: string }): ReactEle
 				'attendees_rooms_invalid',
 				'One or more Meeting rooms are invalid. Try editing them or entering a new one.'
 			)}
+			duplicateChipsErrorLabel={t(
+				'duplicate_attendees_rooms_error',
+				'One or more items of Meeting rooms were selected multiple times. Consider removing the duplicates.'
+			)}
 		/>
 	);
 };

--- a/src/view/editor/parts/editor-meeting-rooms.tsx
+++ b/src/view/editor/parts/editor-meeting-rooms.tsx
@@ -24,10 +24,10 @@ export const EditorMeetingRooms = ({ editorId }: { editorId: string }): ReactEle
 
 	const meetingRoomsChipValue = useMemo(
 		() =>
-			map(meetingRoomsValue, (result) => ({
-				id: result.id,
-				label: result.label,
-				email: result.email,
+			map(meetingRoomsValue, (resource) => ({
+				id: resource.id,
+				label: resource.label,
+				email: resource.email,
 				avatarIcon: 'BuildingOutline' as const,
 				avatarBackground: 'transparent' as const,
 				avatarColor: 'gray0' as const
@@ -78,6 +78,7 @@ export const EditorMeetingRooms = ({ editorId }: { editorId: string }): ReactEle
 				'attendee_room_unavailable',
 				'Room not available at the selected time of the event'
 			)}
+			invalidInputErrorLabel={t('attendees_rooms_invalid', 'One or more Meeting Rooms are invalid')}
 		/>
 	);
 };

--- a/src/view/editor/parts/editor-meeting-rooms.tsx
+++ b/src/view/editor/parts/editor-meeting-rooms.tsx
@@ -83,12 +83,12 @@ export const EditorMeetingRooms = ({ editorId }: { editorId: string }): ReactEle
 				'Room not available at the selected time of the event'
 			)}
 			invalidInputErrorLabel={t(
-				'attendees_rooms_invalid',
+				'rooms_invalid',
 				'One or more Meeting rooms are invalid. Try editing them or entering a new one.'
 			)}
 			duplicateChipsErrorLabel={t(
-				'duplicate_attendees_rooms_error',
-				'One or more items of Meeting rooms were selected multiple times. Consider removing the duplicates.'
+				'duplicate_rooms_error',
+				'One or more Meeting rooms were selected multiple times. Consider removing the duplicates.'
 			)}
 		/>
 	);

--- a/src/view/editor/parts/editor-meeting-rooms.tsx
+++ b/src/view/editor/parts/editor-meeting-rooms.tsx
@@ -9,7 +9,7 @@ import { filter, map } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { EditorResourceComponent, normalizeResources } from './editor-resource-component';
-import { generateResourceId } from './utils';
+import { generateResourceId, isValidResource } from './utils';
 import { searchResources } from '../../../soap/search-resources';
 import { useAppDispatch, useAppSelector } from '../../../store/redux/hooks';
 import { selectEditorDisabled, selectEditorMeetingRoom } from '../../../store/selectors/editor';
@@ -25,14 +25,17 @@ export const EditorMeetingRooms = ({ editorId }: { editorId: string }): ReactEle
 
 	const meetingRoomsChipValue = useMemo(
 		() =>
-			map(meetingRoomsValue, (resource) => ({
-				id: resource.id ?? generateResourceId(resource),
-				label: resource.label,
-				email: resource.email,
-				avatarIcon: 'BuildingOutline' as const,
-				avatarBackground: 'transparent' as const,
-				avatarColor: 'gray0' as const
-			})),
+			map(meetingRoomsValue, (resource) => {
+				const isValid = isValidResource(resource);
+				return {
+					id: resource.id ?? generateResourceId(resource),
+					label: resource.label,
+					email: resource.email,
+					avatarIcon: isValid ? 'BuildingOutline' : 'AlertCircleOutline',
+					avatarBackground: 'transparent' as const,
+					avatarColor: 'gray0' as const
+				};
+			}),
 		[meetingRoomsValue]
 	);
 

--- a/src/view/editor/parts/editor-meeting-rooms.tsx
+++ b/src/view/editor/parts/editor-meeting-rooms.tsx
@@ -45,7 +45,7 @@ export const EditorMeetingRooms = ({ editorId }: { editorId: string }): ReactEle
 	const onSearchOptions = useCallback(
 		(searchedValue: string) =>
 			searchResources(searchedValue).then((response) => {
-				if (!response.error) {
+				if (response && !response.error) {
 					const meetingResources = filter(
 						response.cn,
 						(cn) => cn._attrs.zimbraCalResType === 'Location'

--- a/src/view/editor/parts/editor-meeting-rooms.tsx
+++ b/src/view/editor/parts/editor-meeting-rooms.tsx
@@ -9,6 +9,7 @@ import { filter, map } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { EditorResourceComponent, normalizeResources } from './editor-resource-component';
+import { generateResourceId } from './utils';
 import { searchResources } from '../../../soap/search-resources';
 import { useAppDispatch, useAppSelector } from '../../../store/redux/hooks';
 import { selectEditorDisabled, selectEditorMeetingRoom } from '../../../store/selectors/editor';
@@ -25,7 +26,7 @@ export const EditorMeetingRooms = ({ editorId }: { editorId: string }): ReactEle
 	const meetingRoomsChipValue = useMemo(
 		() =>
 			map(meetingRoomsValue, (resource) => ({
-				id: resource.id,
+				id: resource.id ?? generateResourceId(resource),
 				label: resource.label,
 				email: resource.email,
 				avatarIcon: 'BuildingOutline' as const,

--- a/src/view/editor/parts/editor-meeting-rooms.tsx
+++ b/src/view/editor/parts/editor-meeting-rooms.tsx
@@ -78,7 +78,10 @@ export const EditorMeetingRooms = ({ editorId }: { editorId: string }): ReactEle
 				'attendee_room_unavailable',
 				'Room not available at the selected time of the event'
 			)}
-			invalidInputErrorLabel={t('attendees_rooms_invalid', 'One or more Meeting Rooms are invalid')}
+			invalidInputErrorLabel={t(
+				'attendees_rooms_invalid',
+				'One or more Meeting rooms are invalid. Try editing them or entering a new one.'
+			)}
 		/>
 	);
 };

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React, { ReactElement, useCallback, useMemo, useState } from 'react';
+import React, { ReactElement, useCallback, useMemo, useRef, useState } from 'react';
 
 import {
 	ChipInput,
@@ -12,7 +12,9 @@ import {
 	ChipItem,
 	Container,
 	DropdownItem,
-	Theme
+	KeyboardPresetObj,
+	Theme,
+	useKeyboard
 } from '@zextras/carbonio-design-system';
 import { find, uniqBy } from 'lodash';
 import styled from 'styled-components';
@@ -185,69 +187,99 @@ export const EditorResourceComponent = ({
 		[onChange]
 	);
 
+	const buildResourceChipItem = useCallback((room: Resource): ChipItem<Resource> => {
+		const isValid = isValidResource(room);
+
+		let avatarIcon: keyof Theme['icons'];
+		if (!isValid) {
+			avatarIcon = 'AlertCircleOutline';
+		} else if (room.type === 'Location') {
+			avatarIcon = 'BuildingOutline';
+		} else {
+			avatarIcon = 'BriefcaseOutline';
+		}
+
+		const avatarBackground: keyof Theme['palette'] = isValid ? 'transparent' : 'error';
+
+		return {
+			...room,
+			value: room,
+			background: isValid ? 'gray3' : 'error',
+			color: isValid ? 'text' : 'gray6',
+			avatarColor: isValid ? 'gray0' : 'gray6',
+			avatarIcon,
+			avatarBackground
+		};
+	}, []);
+
 	const resourceAvailability: ChipItem<Resource>[] = useMemo(() => {
 		if (!resourcesValue?.length) return [];
 
 		return resourcesValue.map((room) => {
+			const chip = buildResourceChipItem(room);
+
 			const roomInList = find(attendeesAvailabilityList, ['email', room.email]);
-			const resourceIsValid = isValidResource(room);
+			const isBusy =
+				roomInList &&
+				getIsBusyAtTimeOfTheEvent(roomInList, start, end, attendeesAvailabilityList, allDay);
 
-			let avatarIcon: keyof Theme['icons'];
-			let avatarBackground: keyof Theme['palette'];
-			if (!resourceIsValid) {
-				avatarIcon = 'AlertCircleOutline';
-				avatarBackground = 'error';
-			} else if (room.type === 'Location') {
-				avatarIcon = 'BuildingOutline';
-				avatarBackground = 'transparent';
-			} else {
-				avatarIcon = 'BriefcaseOutline';
-				avatarBackground = 'transparent';
+			if (isBusy) {
+				return {
+					...chip,
+					actions: [
+						{
+							id: 'unavailable',
+							label: singleWarningLabel,
+							color: 'error',
+							type: 'icon',
+							icon: 'AlertTriangle'
+						}
+					]
+				};
 			}
 
-			const baseChip: ChipItem<Resource> = {
-				...room,
-				value: room,
-				background: resourceIsValid ? 'gray3' : 'error',
-				avatarIcon,
-				avatarBackground,
-				avatarColor: resourceIsValid ? 'gray0' : 'gray6',
-				color: resourceIsValid ? 'text' : 'gray6'
-			};
-
-			if (roomInList) {
-				const isBusy = getIsBusyAtTimeOfTheEvent(
-					roomInList,
-					start,
-					end,
-					attendeesAvailabilityList,
-					allDay
-				);
-
-				if (isBusy) {
-					return {
-						...baseChip,
-						actions: [
-							{
-								id: 'unavailable',
-								label: singleWarningLabel,
-								color: 'error',
-								type: 'icon',
-								icon: 'AlertTriangle'
-							}
-						]
-					};
-				}
-			}
-
-			return baseChip;
+			return chip;
 		});
-	}, [allDay, attendeesAvailabilityList, end, resourcesValue, singleWarningLabel, start]);
+	}, [
+		allDay,
+		attendeesAvailabilityList,
+		buildResourceChipItem,
+		end,
+		resourcesValue,
+		singleWarningLabel,
+		start
+	]);
+
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	const onPressingEnterSelectFirstOption = useMemo<KeyboardPresetObj[]>(
+		() => [
+			{
+				type: 'keydown',
+				callback: (): void => {
+					if (options?.[0]?.value && handleChange && options?.[0]?.id !== 'loading') {
+						const { value } = options[0];
+						handleChange([...resourceAvailability, buildResourceChipItem(value)]);
+						if (inputRef.current) {
+							inputRef.current.value = '';
+							setOptions([]);
+						}
+					}
+				},
+				keys: [{ key: 'Enter', ctrlKey: false }],
+				haveToPreventDefault: true
+			}
+		],
+		[buildResourceChipItem, handleChange, options, resourceAvailability]
+	);
+
+	useKeyboard(inputRef, onPressingEnterSelectFirstOption);
 
 	return (
 		<>
 			<Container width="100%" height="100%">
 				<ChipInput
+					inputRef={inputRef}
 					disabled={disabled}
 					confirmChipOnBlur
 					createChipOnPaste={false}

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -16,7 +16,7 @@ import {
 	Theme,
 	useKeyboard
 } from '@zextras/carbonio-design-system';
-import { find, uniqBy } from 'lodash';
+import { find, uniqWith } from 'lodash';
 import styled from 'styled-components';
 
 import {
@@ -180,7 +180,10 @@ export const EditorResourceComponent = ({
 		(newChips: ChipItem<Resource>[]) => {
 			if (!onChange) return;
 
-			const uniqueItems = uniqBy(newChips, 'label');
+			const uniqueItems = uniqWith(
+				newChips,
+				(item1, item2) => item1?.value?.email === item2?.value?.email || item1.label === item2.label
+			);
 			setHasError(uniqueItems.some((item) => !isValidResource(item.value)));
 			onChange(uniqueItems.map((chip) => chip.value as Resource));
 		},

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -17,7 +17,7 @@ import {
 	Theme,
 	useKeyboard
 } from '@zextras/carbonio-design-system';
-import { find, uniqWith } from 'lodash';
+import { find } from 'lodash';
 import styled from 'styled-components';
 
 import {
@@ -209,13 +209,8 @@ export const EditorResourceComponent = ({
 		(newChips: ChipItem<Resource>[]): void => {
 			if (!onChange) return;
 
-			const uniqueItems = uniqWith(newChips, (item1, item2) =>
-				item1?.value?.email && item2?.value?.email
-					? item1.value.email === item2.value.email
-					: item1.label === item2.label
-			);
-			setHasError(uniqueItems.some((item) => !isValidResource(item.value)));
-			onChange(uniqueItems.map((chip) => chip.value as Resource));
+			setHasError(newChips.some((item) => !isValidResource(item.value)));
+			onChange(newChips.map((chip) => chip.value as Resource));
 		},
 		[onChange, isValidResource]
 	);

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -224,16 +224,13 @@ export const EditorResourceComponent = ({
 				}
 			}
 
-			let label: string;
-			let resource: Resource;
+			let label = 'Invalid input';
+			let resource: Resource = { email: '', label };
 			if (isResourceOption(valueToAdd)) {
 				resource = valueToAdd;
 				label = resource.label;
 			} else if (isStringInput(valueToAdd)) {
 				label = valueToAdd.trim();
-				resource = { email: '', label };
-			} else {
-				label = 'Invalid input';
 				resource = { email: '', label };
 			}
 			const resourceId = resource.id ?? generateResourceId(resource);

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -97,6 +97,7 @@ interface EditorResourceComponentProps {
 	disabled?: boolean;
 	singleWarningLabel: string;
 	invalidInputErrorLabel: string;
+	duplicateChipsErrorLabel: string;
 }
 
 type ResourceChipItem = ChipItem<Resource> & {
@@ -115,7 +116,8 @@ export const EditorResourceComponent = ({
 	warningLabel,
 	disabled,
 	singleWarningLabel,
-	invalidInputErrorLabel
+	invalidInputErrorLabel,
+	duplicateChipsErrorLabel
 }: EditorResourceComponentProps): JSX.Element | null => {
 	const start = useAppSelector(selectEditorStart(editorId));
 	const end = useAppSelector(selectEditorEnd(editorId));
@@ -131,7 +133,15 @@ export const EditorResourceComponent = ({
 		[resourcesValue]
 	);
 
+	const duplicateResourceIds = useMemo(
+		() => getDuplicateResourceIds(resourcesValue),
+		[resourcesValue]
+	);
+
 	const [hasError, setHasError] = useState(!resourcesAreValid);
+	const [hasDuplicateValidChips, setHasDuplicateValidChips] = useState(
+		duplicateResourceIds.size > 0
+	);
 
 	const handleAdd = useCallback((valueToAdd: unknown): ResourceChipItem => {
 		setEditingResource(null);
@@ -224,16 +234,12 @@ export const EditorResourceComponent = ({
 		}
 	}, []);
 
-	const duplicateResourceIds = useMemo(
-		() => getDuplicateResourceIds(resourcesValue),
-		[resourcesValue]
-	);
-
 	const buildResourceChipItem = useCallback(
 		(resource: Resource): ResourceChipItem => {
 			const isValid = isValidResource(resource);
 			const key = resource.id || resource.email;
 			const isDuplicate = isValid && duplicateResourceIds.has(key);
+			setHasDuplicateValidChips(isDuplicate);
 
 			const actions: ChipAction[] = [
 				{
@@ -337,6 +343,16 @@ export const EditorResourceComponent = ({
 
 	useKeyboard(inputRef, onPressingEnterSelectFirstOption);
 
+	const chipInputDescription = useMemo(() => {
+		if (hasError) {
+			return invalidInputErrorLabel;
+		}
+		if (hasDuplicateValidChips) {
+			return duplicateChipsErrorLabel;
+		}
+		return undefined;
+	}, [hasError, hasDuplicateValidChips, invalidInputErrorLabel, duplicateChipsErrorLabel]);
+
 	return (
 		<>
 			<Container width="100%" height="100%">
@@ -357,7 +373,7 @@ export const EditorResourceComponent = ({
 					]}
 					onInputType={handleInputType}
 					hasError={hasError}
-					description={hasError ? invalidInputErrorLabel : undefined}
+					description={chipInputDescription}
 				/>
 			</Container>
 			<EditorAvailabilityWarningRow

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -198,8 +198,11 @@ export const EditorResourceComponent = ({
 						setOptions(receivedOptions);
 					})
 					.catch((reason) => {
+						setOptions([]);
 						console.warn(reason.error ?? reason);
 					});
+			} else {
+				setOptions([]);
 			}
 		},
 		[onSearchOptions]

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -168,8 +168,8 @@ export const EditorResourceComponent = ({
 					.then((receivedOptions) => {
 						setOptions(receivedOptions);
 					})
-					.catch(() => {
-						// ignore
+					.catch((reason) => {
+						console.warn(reason.error || reason);
 					});
 			}
 		},

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -373,7 +373,7 @@ export const EditorResourceComponent = ({
 					{ code: 'NumpadEnter', ctrlKey: false }
 				]}
 				onInputType={handleInputType}
-				hasError={hasError}
+				hasError={hasError || hasDuplicateValidChips}
 				description={chipInputDescription}
 			/>
 			<EditorAvailabilityWarningRow

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -182,17 +182,22 @@ export const EditorResourceComponent = ({
 		[isValidResource]
 	);
 
+	const loadingOption = useMemo(
+		() => [
+			{
+				id: 'loading',
+				label: 'loading',
+				customComponent: <Loader />,
+				disabled: true
+			}
+		],
+		[]
+	);
+
 	const handleInputType = useCallback<NonNullable<ChipInputProps<Resource>['onInputType']>>(
 		(e) => {
 			if (e.textContent && e.textContent !== '') {
-				setOptions([
-					{
-						id: 'loading',
-						label: 'loading',
-						customComponent: <Loader />,
-						disabled: true
-					}
-				]);
+				setOptions(loadingOption);
 				onSearchOptions(e.textContent)
 					.then((receivedOptions) => {
 						setOptions(receivedOptions);
@@ -205,7 +210,7 @@ export const EditorResourceComponent = ({
 				setOptions([]);
 			}
 		},
-		[onSearchOptions]
+		[loadingOption, onSearchOptions]
 	);
 
 	const handleChange = useCallback(

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -266,7 +266,7 @@ export const EditorResourceComponent = ({
 						}
 					}
 				},
-				keys: [{ key: 'Enter', ctrlKey: true }],
+				keys: [{ key: 'Enter', ctrlKey: false }],
 				haveToPreventDefault: true
 			}
 		],
@@ -284,7 +284,6 @@ export const EditorResourceComponent = ({
 					confirmChipOnBlur
 					createChipOnPaste={false}
 					disableOptions={false}
-					separators={[{ key: 'Enter', ctrlKey: false }]}
 					placeholder={placeholder}
 					value={resourceAvailability}
 					options={options}

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -115,15 +115,21 @@ export const EditorResourceComponent = ({
 	const [hasError, setHasError] = useState(false);
 
 	const inputRef = useRef<HTMLInputElement>(null);
-	const [chipIdToRemove, setChipIdToRemove] = useState<string | null>(null);
+	const [editingResource, setEditingResource] = useState<Resource | null>(null);
 
 	const attendeesAvailabilityList = useAttendeesAvailability(start, resourcesValue, uid);
 
 	const isValidResource = (resource: Resource | undefined): boolean =>
 		!!resource?.label?.trim() && !!resource?.email?.trim();
 
+	const generateResourceId = (resource: Resource): string => {
+		if (resource.email?.trim()) return resource.email.trim();
+		if (resource.id?.trim()) return resource.id.trim();
+		return `manual-${resource.label?.trim() ?? 'unknown'}`;
+	};
+
 	const handleAdd = useCallback((valueToAdd: unknown): ChipItem<Resource> => {
-		setChipIdToRemove(null);
+		setEditingResource(null);
 
 		const isResourceOption = (obj: unknown): obj is Resource =>
 			typeof obj === 'object' &&
@@ -154,6 +160,7 @@ export const EditorResourceComponent = ({
 
 		return {
 			label,
+			id: resource.id ?? generateResourceId(resource),
 			value: resource,
 			...(isValid ? {} : { background: 'error', hasError: true })
 		};
@@ -197,11 +204,11 @@ export const EditorResourceComponent = ({
 		[onChange]
 	);
 
-	const handleEditResource = useCallback((text: string, id: string) => {
-		setChipIdToRemove(id);
+	const handleEditResource = useCallback((resource: Resource) => {
+		setEditingResource(resource);
 
 		if (inputRef.current) {
-			inputRef.current.value = text;
+			inputRef.current.value = resource.label;
 			inputRef.current.focus();
 		}
 	}, []);
@@ -229,12 +236,13 @@ export const EditorResourceComponent = ({
 				color: 'error',
 				onClick: (event) => {
 					event.stopPropagation();
-					handleEditResource(resource.label, resource.id || resource.email);
+					handleEditResource(resource);
 				}
 			};
 
 			return {
 				...resource,
+				id: resource.id ?? generateResourceId(resource),
 				value: resource,
 				background: isValid ? 'gray3' : 'error',
 				color: isValid ? 'text' : 'gray6',
@@ -251,7 +259,7 @@ export const EditorResourceComponent = ({
 		if (!resourcesValue?.length) return [];
 
 		return resourcesValue
-			.filter((r) => r.id !== chipIdToRemove)
+			.filter((r) => !editingResource || r.id !== editingResource.id)
 			.map((resource) => {
 				const chip = buildResourceChipItem(resource);
 
@@ -281,7 +289,7 @@ export const EditorResourceComponent = ({
 		allDay,
 		attendeesAvailabilityList,
 		buildResourceChipItem,
-		chipIdToRemove,
+		editingResource,
 		end,
 		resourcesValue,
 		singleWarningLabel,

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React, { ReactElement, useCallback, useMemo, useRef, useState } from 'react';
+import React, { ReactElement, useCallback, useMemo, useState } from 'react';
 
 import {
 	ChipInput,
@@ -12,10 +12,9 @@ import {
 	ChipItem,
 	Container,
 	DropdownItem,
-	KeyboardPresetObj,
-	useKeyboard
+	Theme
 } from '@zextras/carbonio-design-system';
-import { find, map, reduce, uniqWith } from 'lodash';
+import { find, uniqBy } from 'lodash';
 import styled from 'styled-components';
 
 import {
@@ -30,7 +29,7 @@ import {
 	selectEditorStart,
 	selectEditorUid
 } from '../../../store/selectors/editor';
-import { ChipResource, Resource } from '../../../types/editor';
+import { Resource } from '../../../types/editor';
 import { Contact } from '../../../types/soap/soap-actions';
 
 interface SkeletonTileProps {
@@ -50,12 +49,6 @@ const SkeletonTile = styled.div<SkeletonTileProps>`
 	border-radius: ${({ $radius }): string => $radius ?? '0.125rem'};
 	background: ${({ theme }): string => theme.palette.gray2.regular};
 `;
-
-const createChipFromResource = (optionValue: Resource): ChipItem<Resource> => ({
-	id: optionValue.id,
-	label: optionValue.label,
-	value: optionValue
-});
 
 const Loader = (): ReactElement => (
 	<Container
@@ -98,34 +91,67 @@ export const EditorResourceComponent = ({
 	onSearchOptions,
 	warningLabel,
 	disabled,
-	singleWarningLabel
+	singleWarningLabel,
+	invalidInputErrorLabel
 }: {
 	editorId: string;
-	onChange: (items: ChipResource[]) => void;
+	onChange: (items: Array<Resource>) => void;
 	onSearchOptions: (stringToSearch: string) => Promise<Array<ResourceInputOption>>;
 	placeholder: string;
-	resourcesValue: Array<ChipResource>;
+	resourcesValue: Array<Resource>;
 	warningLabel: string;
 	disabled?: boolean;
 	singleWarningLabel: string;
+	invalidInputErrorLabel: string;
 }): JSX.Element | null => {
-	const inputRef = useRef<HTMLInputElement>(null);
-
 	const start = useAppSelector(selectEditorStart(editorId));
 	const end = useAppSelector(selectEditorEnd(editorId));
 	const allDay = useAppSelector(selectEditorAllDay(editorId));
 	const uid = useAppSelector(selectEditorUid(editorId));
-
 	const [options, setOptions] = useState<Array<ResourceInputOption>>([]);
+	const [hasError, setHasError] = useState(false);
 
 	const attendeesAvailabilityList = useAttendeesAvailability(start, resourcesValue, uid);
 
-	const onAdd = useCallback((valueToAdd: unknown): ChipItem<Resource> => {
-		const resourceFromOptions = valueToAdd as Resource;
-		return createChipFromResource(resourceFromOptions);
+	const isValidResource = (resource: Resource | undefined): boolean =>
+		!!resource?.label?.trim() && !!resource?.email?.trim();
+
+	const handleAdd = useCallback((valueToAdd: unknown): ChipItem<Resource> => {
+		const isResourceOption = (obj: unknown): obj is Resource =>
+			typeof obj === 'object' &&
+			obj !== null &&
+			'id' in obj &&
+			'label' in obj &&
+			'email' in obj &&
+			'type' in obj;
+
+		const isStringInput = (input: unknown): input is string =>
+			typeof input === 'string' && input.trim() !== '';
+
+		let label: string;
+		let resource: Resource;
+
+		if (isResourceOption(valueToAdd)) {
+			resource = valueToAdd;
+			label = resource.label;
+		} else if (isStringInput(valueToAdd)) {
+			label = valueToAdd.trim();
+			resource = { email: '', label };
+		} else {
+			label = 'Invalid input';
+			resource = { email: '', label };
+		}
+
+		const isValid = isValidResource(resource);
+
+		return {
+			label,
+			value: resource,
+			...(isValid ? {} : { background: 'error', hasError: true })
+		};
 	}, []);
 
-	const onInputType = useCallback<NonNullable<ChipInputProps<Resource>['onInputType']>>(
+	const handleInputType = useCallback<NonNullable<ChipInputProps<Resource>['onInputType']>>(
 		(e) => {
 			if (e.textContent && e.textContent !== '') {
 				setOptions([
@@ -148,39 +174,49 @@ export const EditorResourceComponent = ({
 		[onSearchOptions]
 	);
 
-	const onInternalChange = useCallback(
-		(items: ChipItem<Resource>[]) => {
-			const itemsWithValue = reduce(
-				items,
-				(acc, item) => {
-					const { value, label } = item;
-					if (label && value) {
-						acc.push({ label, email: value.email });
-					}
-					return acc;
-				},
-				[] as ChipResource[]
-			);
+	const handleChange: (newChips: ChipItem<Resource>[]) => void = useCallback(
+		(newChips: ChipItem<Resource>[]) => {
+			if (!onChange) return;
 
-			const filterdItems = uniqWith(
-				itemsWithValue,
-				(item1, item2) => item1.email === item2.email || item1.label === item2.label
-			);
-
-			onChange(filterdItems);
+			const uniqueItems = uniqBy(newChips, 'label');
+			setHasError(uniqueItems.some((item) => !isValidResource(item.value)));
+			onChange(uniqueItems.map((chip) => chip.value as Resource));
 		},
 		[onChange]
 	);
 
 	const resourceAvailability: ChipItem<Resource>[] = useMemo(() => {
-		if (!resourcesValue?.length) {
-			return [];
-		}
-		return map(resourcesValue, (room) => {
+		if (!resourcesValue?.length) return [];
+
+		return resourcesValue.map((room) => {
 			const roomInList = find(attendeesAvailabilityList, ['email', room.email]);
-			const chipRoom = { ...room, value: room };
+			const resourceIsValid = isValidResource(room);
+
+			let avatarIcon: keyof Theme['icons'];
+			let avatarBackground: keyof Theme['palette'];
+			if (!resourceIsValid) {
+				avatarIcon = 'AlertCircleOutline';
+				avatarBackground = 'error';
+			} else if (room.type === 'Location') {
+				avatarIcon = 'BuildingOutline';
+				avatarBackground = 'transparent';
+			} else {
+				avatarIcon = 'BriefcaseOutline';
+				avatarBackground = 'transparent';
+			}
+
+			const baseChip: ChipItem<Resource> = {
+				...room,
+				value: room,
+				background: resourceIsValid ? 'gray3' : 'error',
+				avatarIcon,
+				avatarBackground,
+				avatarColor: resourceIsValid ? 'gray0' : 'gray6',
+				color: resourceIsValid ? 'text' : 'gray6'
+			};
+
 			if (roomInList) {
-				const isBusyAtTimeOfEvent = getIsBusyAtTimeOfTheEvent(
+				const isBusy = getIsBusyAtTimeOfTheEvent(
 					roomInList,
 					start,
 					end,
@@ -188,63 +224,43 @@ export const EditorResourceComponent = ({
 					allDay
 				);
 
-				if (isBusyAtTimeOfEvent) {
-					const actions = [
-						{
-							id: 'unavailable',
-							label: singleWarningLabel,
-							color: 'error',
-							type: 'icon',
-							icon: 'AlertTriangle'
-						} as const
-					];
+				if (isBusy) {
 					return {
-						...chipRoom,
-						actions
+						...baseChip,
+						actions: [
+							{
+								id: 'unavailable',
+								label: singleWarningLabel,
+								color: 'error',
+								type: 'icon',
+								icon: 'AlertTriangle'
+							}
+						]
 					};
 				}
 			}
-			return chipRoom;
+
+			return baseChip;
 		});
 	}, [allDay, attendeesAvailabilityList, end, resourcesValue, singleWarningLabel, start]);
-
-	const onPressingEnterSelectFirstOption = useMemo<KeyboardPresetObj[]>(
-		() => [
-			{
-				type: 'keydown',
-				callback: (): void => {
-					if (options?.[0]?.value && onInternalChange && options?.[0]?.id !== 'loading') {
-						const { value } = options[0];
-						onInternalChange([...resourceAvailability, createChipFromResource(value)]);
-						if (inputRef.current) {
-							inputRef.current.value = '';
-							setOptions([]);
-						}
-					}
-				},
-				keys: [{ key: 'Enter', ctrlKey: false }],
-				haveToPreventDefault: true
-			}
-		],
-		[onInternalChange, options, resourceAvailability]
-	);
-
-	useKeyboard(inputRef, onPressingEnterSelectFirstOption);
 
 	return (
 		<>
 			<Container width="100%" height="100%">
 				<ChipInput
-					inputRef={inputRef}
+					disabled={disabled}
 					confirmChipOnBlur
+					createChipOnPaste={false}
+					disableOptions={false}
+					separators={[{ key: 'Enter', ctrlKey: false }]}
 					placeholder={placeholder}
-					separators={[]}
 					value={resourceAvailability}
 					options={options}
-					onInputType={onInputType}
-					onAdd={onAdd}
-					onChange={onInternalChange}
-					disabled={disabled}
+					onChange={handleChange}
+					onAdd={handleAdd}
+					onInputType={handleInputType}
+					hasError={hasError}
+					description={hasError ? invalidInputErrorLabel : undefined}
 				/>
 			</Container>
 			<EditorAvailabilityWarningRow

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -293,17 +293,19 @@ export const EditorResourceComponent = ({
 					getIsBusyAtTimeOfTheEvent(roomInList, start, end, attendeesAvailabilityList, allDay);
 
 				if (isBusy) {
+					const actions: ChipAction[] = [...(chip.actions ?? [])];
+
+					actions.unshift({
+						id: 'unavailable',
+						label: singleWarningLabel,
+						color: 'error',
+						type: 'icon',
+						icon: 'AlertTriangle'
+					});
+
 					return {
 						...chip,
-						actions: [
-							{
-								id: 'unavailable',
-								label: singleWarningLabel,
-								color: 'error',
-								type: 'icon',
-								icon: 'AlertTriangle'
-							}
-						]
+						actions
 					};
 				}
 

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -180,9 +180,10 @@ export const EditorResourceComponent = ({
 		(newChips: ChipItem<Resource>[]) => {
 			if (!onChange) return;
 
-			const uniqueItems = uniqWith(
-				newChips,
-				(item1, item2) => item1?.value?.email === item2?.value?.email || item1.label === item2.label
+			const uniqueItems = uniqWith(newChips, (item1, item2) =>
+				item1?.value?.email && item2?.value?.email
+					? item1.value.email === item2.value.email
+					: item1.label === item2.label
 			);
 			setHasError(uniqueItems.some((item) => !isValidResource(item.value)));
 			onChange(uniqueItems.map((chip) => chip.value as Resource));

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -24,7 +24,7 @@ import {
 	EditorAvailabilityWarningRow,
 	getIsBusyAtTimeOfTheEvent
 } from './editor-availability-warning-row';
-import { generateResourceId, isValidResource } from './utils';
+import { generateResourceId, getDuplicateResourceIds, isValidResource } from './utils';
 import { useAttendeesAvailability } from '../../../hooks/use-attendees-availability';
 import { useAppSelector } from '../../../store/redux/hooks';
 import {
@@ -224,20 +224,39 @@ export const EditorResourceComponent = ({
 		}
 	}, []);
 
+	const duplicateResourceIds = useMemo(
+		() => getDuplicateResourceIds(resourcesValue),
+		[resourcesValue]
+	);
+
 	const buildResourceChipItem = useCallback(
 		(resource: Resource): ResourceChipItem => {
 			const isValid = isValidResource(resource);
+			const key = resource.id || resource.email;
+			const isDuplicate = isValid && duplicateResourceIds.has(key);
 
-			const editChipAction: ChipAction = {
-				id: 'edit',
-				icon: 'EditOutline',
-				type: 'button',
-				label: 'Edit',
-				onClick: (event) => {
-					event.stopPropagation();
-					handleEditResource(resource);
+			const actions: ChipAction[] = [
+				{
+					id: 'edit',
+					icon: 'EditOutline',
+					type: 'button',
+					label: 'Edit',
+					onClick: (event): void => {
+						event.stopPropagation();
+						handleEditResource(resource);
+					}
 				}
-			};
+			];
+
+			if (isDuplicate) {
+				actions.unshift({
+					id: 'duplicate',
+					label: 'Duplicate resource',
+					color: 'warning',
+					type: 'icon',
+					icon: 'AlertTriangle'
+				});
+			}
 
 			return {
 				...resource,
@@ -247,11 +266,11 @@ export const EditorResourceComponent = ({
 				color: isValid ? 'text' : 'gray6',
 				avatarColor: isValid ? 'gray0' : 'gray6',
 				avatarBackground: isValid ? 'transparent' : 'error',
-				actions: [editChipAction],
+				actions,
 				error: !isValid
 			};
 		},
-		[handleEditResource]
+		[duplicateResourceIds, handleEditResource]
 	);
 
 	const resourceAvailability: ResourceChipItem[] = useMemo(() => {

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -24,6 +24,7 @@ import {
 	EditorAvailabilityWarningRow,
 	getIsBusyAtTimeOfTheEvent
 } from './editor-availability-warning-row';
+import { generateResourceId } from './utils';
 import { useAttendeesAvailability } from '../../../hooks/use-attendees-availability';
 import { useAppSelector } from '../../../store/redux/hooks';
 import {
@@ -112,21 +113,19 @@ export const EditorResourceComponent = ({
 	const allDay = useAppSelector(selectEditorAllDay(editorId));
 	const uid = useAppSelector(selectEditorUid(editorId));
 	const [options, setOptions] = useState<Array<ResourceInputOption>>([]);
-	const [hasError, setHasError] = useState(false);
-
 	const inputRef = useRef<HTMLInputElement>(null);
 	const [editingResource, setEditingResource] = useState<Resource | null>(null);
-
 	const attendeesAvailabilityList = useAttendeesAvailability(start, resourcesValue, uid);
 
 	const isValidResource = (resource: Resource | undefined): boolean =>
 		!!resource?.label?.trim() && !!resource?.email?.trim();
 
-	const generateResourceId = (resource: Resource): string => {
-		if (resource.email?.trim()) return resource.email.trim();
-		if (resource.id?.trim()) return resource.id.trim();
-		return `manual-${resource.label?.trim() ?? 'unknown'}`;
-	};
+	const resourcesAreValid = useMemo(
+		() => resourcesValue.every((resource) => isValidResource(resource)),
+		[resourcesValue]
+	);
+
+	const [hasError, setHasError] = useState(!resourcesAreValid);
 
 	const handleAdd = useCallback((valueToAdd: unknown): ChipItem<Resource> => {
 		setEditingResource(null);
@@ -144,7 +143,6 @@ export const EditorResourceComponent = ({
 
 		let label: string;
 		let resource: Resource;
-
 		if (isResourceOption(valueToAdd)) {
 			resource = valueToAdd;
 			label = resource.label;
@@ -156,11 +154,15 @@ export const EditorResourceComponent = ({
 			resource = { email: '', label };
 		}
 
+		const resourceId = resource.id ?? generateResourceId(resource);
+
+		resource = { ...resource, id: resourceId };
+
 		const isValid = isValidResource(resource);
 
 		return {
 			label,
-			id: resource.id ?? generateResourceId(resource),
+			id: resourceId,
 			value: resource,
 			...(isValid ? {} : { background: 'error', hasError: true })
 		};
@@ -209,6 +211,9 @@ export const EditorResourceComponent = ({
 
 		if (inputRef.current) {
 			inputRef.current.value = resource.label;
+			inputRef.current.style.width = inputRef.current.value
+				? `${inputRef.current.scrollWidth}px`
+				: '';
 			inputRef.current.focus();
 		}
 	}, []);
@@ -233,7 +238,7 @@ export const EditorResourceComponent = ({
 				icon: 'EditOutline',
 				type: 'button',
 				label: 'Edit',
-				color: 'error',
+				color: isValid ? 'text' : 'error',
 				onClick: (event) => {
 					event.stopPropagation();
 					handleEditResource(resource);

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -169,7 +169,7 @@ export const EditorResourceComponent = ({
 						setOptions(receivedOptions);
 					})
 					.catch((reason) => {
-						console.warn(reason.error || reason);
+						console.warn(reason.error ?? reason);
 					});
 			}
 		},

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -7,6 +7,7 @@
 import React, { ReactElement, useCallback, useMemo, useRef, useState } from 'react';
 
 import {
+	ChipAction,
 	ChipInput,
 	ChipInputProps,
 	ChipItem,
@@ -205,6 +206,17 @@ export const EditorResourceComponent = ({
 
 		const avatarBackground: keyof Theme['palette'] = isValid ? 'transparent' : 'error';
 
+		const editChipAction: ChipAction = {
+			id: 'edit',
+			icon: 'EditOutline',
+			type: 'button',
+			label: 'Edit',
+			color: 'primary',
+			onClick: (event) => {
+				console.log('edit', event);
+			}
+		};
+
 		return {
 			...room,
 			value: room,
@@ -212,7 +224,8 @@ export const EditorResourceComponent = ({
 			color: isValid ? 'text' : 'gray6',
 			avatarColor: isValid ? 'gray0' : 'gray6',
 			avatarIcon,
-			avatarBackground
+			avatarBackground,
+			actions: [editChipAction]
 		};
 	}, []);
 

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -114,6 +114,9 @@ export const EditorResourceComponent = ({
 	const [options, setOptions] = useState<Array<ResourceInputOption>>([]);
 	const [hasError, setHasError] = useState(false);
 
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [chipIdToRemove, setChipIdToRemove] = useState<string | null>(null);
+
 	const attendeesAvailabilityList = useAttendeesAvailability(start, resourcesValue, uid);
 
 	const isValidResource = (resource: Resource | undefined): boolean =>
@@ -192,82 +195,96 @@ export const EditorResourceComponent = ({
 		[onChange]
 	);
 
-	const buildResourceChipItem = useCallback((room: Resource): ChipItem<Resource> => {
-		const isValid = isValidResource(room);
+	const handleEditResource = useCallback((text: string, id: string) => {
+		setChipIdToRemove(id);
 
-		let avatarIcon: keyof Theme['icons'];
-		if (!isValid) {
-			avatarIcon = 'AlertCircleOutline';
-		} else if (room.type === 'Location') {
-			avatarIcon = 'BuildingOutline';
-		} else {
-			avatarIcon = 'BriefcaseOutline';
+		if (inputRef.current) {
+			inputRef.current.value = text;
+			inputRef.current.focus();
 		}
-
-		const avatarBackground: keyof Theme['palette'] = isValid ? 'transparent' : 'error';
-
-		const editChipAction: ChipAction = {
-			id: 'edit',
-			icon: 'EditOutline',
-			type: 'button',
-			label: 'Edit',
-			color: 'primary',
-			onClick: (event) => {
-				console.log('edit', event);
-			}
-		};
-
-		return {
-			...room,
-			value: room,
-			background: isValid ? 'gray3' : 'error',
-			color: isValid ? 'text' : 'gray6',
-			avatarColor: isValid ? 'gray0' : 'gray6',
-			avatarIcon,
-			avatarBackground,
-			actions: [editChipAction]
-		};
 	}, []);
+
+	const buildResourceChipItem = useCallback(
+		(resource: Resource): ChipItem<Resource> => {
+			const isValid = isValidResource(resource);
+
+			let avatarIcon: keyof Theme['icons'];
+			if (!isValid) {
+				avatarIcon = 'AlertCircleOutline';
+			} else if (resource.type === 'Location') {
+				avatarIcon = 'BuildingOutline';
+			} else {
+				avatarIcon = 'BriefcaseOutline';
+			}
+
+			const avatarBackground: keyof Theme['palette'] = isValid ? 'transparent' : 'error';
+
+			const editChipAction: ChipAction = {
+				id: 'edit',
+				icon: 'EditOutline',
+				type: 'button',
+				label: 'Edit',
+				color: 'error',
+				onClick: (event) => {
+					event.stopPropagation();
+					handleEditResource(resource.label, resource.id || resource.email);
+				}
+			};
+
+			return {
+				...resource,
+				value: resource,
+				background: isValid ? 'gray3' : 'error',
+				color: isValid ? 'text' : 'gray6',
+				avatarColor: isValid ? 'gray0' : 'gray6',
+				avatarIcon,
+				avatarBackground,
+				actions: [editChipAction]
+			};
+		},
+		[handleEditResource]
+	);
 
 	const resourceAvailability: ChipItem<Resource>[] = useMemo(() => {
 		if (!resourcesValue?.length) return [];
 
-		return resourcesValue.map((room) => {
-			const chip = buildResourceChipItem(room);
+		return resourcesValue
+			.filter((r) => r.id !== chipIdToRemove)
+			.map((resource) => {
+				const chip = buildResourceChipItem(resource);
 
-			const roomInList = find(attendeesAvailabilityList, ['email', room.email]);
-			const isBusy =
-				roomInList &&
-				getIsBusyAtTimeOfTheEvent(roomInList, start, end, attendeesAvailabilityList, allDay);
+				const roomInList = find(attendeesAvailabilityList, ['email', resource.email]);
+				const isBusy =
+					roomInList &&
+					getIsBusyAtTimeOfTheEvent(roomInList, start, end, attendeesAvailabilityList, allDay);
 
-			if (isBusy) {
-				return {
-					...chip,
-					actions: [
-						{
-							id: 'unavailable',
-							label: singleWarningLabel,
-							color: 'error',
-							type: 'icon',
-							icon: 'AlertTriangle'
-						}
-					]
-				};
-			}
+				if (isBusy) {
+					return {
+						...chip,
+						actions: [
+							{
+								id: 'unavailable',
+								label: singleWarningLabel,
+								color: 'error',
+								type: 'icon',
+								icon: 'AlertTriangle'
+							}
+						]
+					};
+				}
 
-			return chip;
-		});
+				return chip;
+			});
 	}, [
 		allDay,
 		attendeesAvailabilityList,
 		buildResourceChipItem,
+		chipIdToRemove,
 		end,
 		resourcesValue,
 		singleWarningLabel,
 		start
 	]);
-
-	const inputRef = useRef<HTMLInputElement>(null);
 
 	const onPressingEnterSelectFirstOption = useMemo<KeyboardPresetObj[]>(
 		() => [

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -87,6 +87,18 @@ export const normalizeResources = (r: Contact): Resource => ({
 	type: r._attrs.zimbraCalResType
 });
 
+interface EditorResourceComponentProps {
+	editorId: string;
+	onChange: (items: Array<Resource>) => void;
+	onSearchOptions: (stringToSearch: string) => Promise<Array<ResourceInputOption>>;
+	placeholder: string;
+	resourcesValue: Array<Resource>;
+	warningLabel: string;
+	disabled?: boolean;
+	singleWarningLabel: string;
+	invalidInputErrorLabel: string;
+}
+
 export const EditorResourceComponent = ({
 	editorId,
 	onChange,
@@ -97,17 +109,7 @@ export const EditorResourceComponent = ({
 	disabled,
 	singleWarningLabel,
 	invalidInputErrorLabel
-}: {
-	editorId: string;
-	onChange: (items: Array<Resource>) => void;
-	onSearchOptions: (stringToSearch: string) => Promise<Array<ResourceInputOption>>;
-	placeholder: string;
-	resourcesValue: Array<Resource>;
-	warningLabel: string;
-	disabled?: boolean;
-	singleWarningLabel: string;
-	invalidInputErrorLabel: string;
-}): JSX.Element | null => {
+}: EditorResourceComponentProps): JSX.Element | null => {
 	const start = useAppSelector(selectEditorStart(editorId));
 	const end = useAppSelector(selectEditorEnd(editorId));
 	const allDay = useAppSelector(selectEditorAllDay(editorId));

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -99,6 +99,12 @@ interface EditorResourceComponentProps {
 	invalidInputErrorLabel: string;
 }
 
+type ResourceChipItem = ChipItem<Resource> & {
+	avatarIcon?: keyof Theme['icons'];
+	avatarBackground?: keyof Theme['palette'];
+	avatarColor?: string;
+};
+
 export const EditorResourceComponent = ({
 	editorId,
 	onChange,
@@ -119,56 +125,62 @@ export const EditorResourceComponent = ({
 	const [editingResource, setEditingResource] = useState<Resource | null>(null);
 	const attendeesAvailabilityList = useAttendeesAvailability(start, resourcesValue, uid);
 
-	const isValidResource = (resource: Resource | undefined): boolean =>
-		!!resource?.label?.trim() && !!resource?.email?.trim();
+	const isValidResource = useCallback(
+		(resource: Resource | undefined): boolean =>
+			!!resource?.label?.trim() && !!resource?.email?.trim(),
+		[]
+	);
 
 	const resourcesAreValid = useMemo(
 		() => resourcesValue.every((resource) => isValidResource(resource)),
-		[resourcesValue]
+		[isValidResource, resourcesValue]
 	);
 
 	const [hasError, setHasError] = useState(!resourcesAreValid);
 
-	const handleAdd = useCallback((valueToAdd: unknown): ChipItem<Resource> => {
-		setEditingResource(null);
+	const handleAdd = useCallback(
+		(valueToAdd: unknown): ResourceChipItem => {
+			setEditingResource(null);
 
-		const isResourceOption = (obj: unknown): obj is Resource =>
-			typeof obj === 'object' &&
-			obj !== null &&
-			'id' in obj &&
-			'label' in obj &&
-			'email' in obj &&
-			'type' in obj;
+			const isResourceOption = (obj: unknown): obj is Resource =>
+				typeof obj === 'object' &&
+				obj !== null &&
+				'id' in obj &&
+				'label' in obj &&
+				'email' in obj &&
+				'type' in obj;
 
-		const isStringInput = (input: unknown): input is string =>
-			typeof input === 'string' && input.trim() !== '';
+			const isStringInput = (input: unknown): input is string =>
+				typeof input === 'string' && input.trim() !== '';
 
-		let label: string;
-		let resource: Resource;
-		if (isResourceOption(valueToAdd)) {
-			resource = valueToAdd;
-			label = resource.label;
-		} else if (isStringInput(valueToAdd)) {
-			label = valueToAdd.trim();
-			resource = { email: '', label };
-		} else {
-			label = 'Invalid input';
-			resource = { email: '', label };
-		}
+			let label: string;
+			let resource: Resource;
+			if (isResourceOption(valueToAdd)) {
+				resource = valueToAdd;
+				label = resource.label;
+			} else if (isStringInput(valueToAdd)) {
+				label = valueToAdd.trim();
+				resource = { email: '', label };
+			} else {
+				label = 'Invalid input';
+				resource = { email: '', label };
+			}
 
-		const resourceId = resource.id ?? generateResourceId(resource);
+			const resourceId = resource.id ?? generateResourceId(resource);
 
-		resource = { ...resource, id: resourceId };
+			resource = { ...resource, id: resourceId };
 
-		const isValid = isValidResource(resource);
+			const isValid = isValidResource(resource);
 
-		return {
-			label,
-			id: resourceId,
-			value: resource,
-			...(isValid ? {} : { background: 'error', hasError: true })
-		};
-	}, []);
+			return {
+				label,
+				id: resourceId,
+				value: resource,
+				...(isValid ? {} : { background: 'error', hasError: true })
+			};
+		},
+		[isValidResource]
+	);
 
 	const handleInputType = useCallback<NonNullable<ChipInputProps<Resource>['onInputType']>>(
 		(e) => {
@@ -193,8 +205,8 @@ export const EditorResourceComponent = ({
 		[onSearchOptions]
 	);
 
-	const handleChange: (newChips: ChipItem<Resource>[]) => void = useCallback(
-		(newChips: ChipItem<Resource>[]) => {
+	const handleChange = useCallback(
+		(newChips: ChipItem<Resource>[]): void => {
 			if (!onChange) return;
 
 			const uniqueItems = uniqWith(newChips, (item1, item2) =>
@@ -205,7 +217,7 @@ export const EditorResourceComponent = ({
 			setHasError(uniqueItems.some((item) => !isValidResource(item.value)));
 			onChange(uniqueItems.map((chip) => chip.value as Resource));
 		},
-		[onChange]
+		[onChange, isValidResource]
 	);
 
 	const handleEditResource = useCallback((resource: Resource) => {
@@ -221,7 +233,7 @@ export const EditorResourceComponent = ({
 	}, []);
 
 	const buildResourceChipItem = useCallback(
-		(resource: Resource): ChipItem<Resource> => {
+		(resource: Resource): ResourceChipItem => {
 			const isValid = isValidResource(resource);
 
 			let avatarIcon: keyof Theme['icons'];
@@ -259,10 +271,10 @@ export const EditorResourceComponent = ({
 				actions: [editChipAction]
 			};
 		},
-		[handleEditResource]
+		[handleEditResource, isValidResource]
 	);
 
-	const resourceAvailability: ChipItem<Resource>[] = useMemo(() => {
+	const resourceAvailability: ResourceChipItem[] = useMemo(() => {
 		if (!resourcesValue?.length) return [];
 
 		return resourcesValue

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -266,7 +266,7 @@ export const EditorResourceComponent = ({
 						}
 					}
 				},
-				keys: [{ key: 'Enter', ctrlKey: false }],
+				keys: [{ key: 'Enter', ctrlKey: true }],
 				haveToPreventDefault: true
 			}
 		],

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -18,6 +18,7 @@ import {
 	useKeyboard
 } from '@zextras/carbonio-design-system';
 import { find } from 'lodash';
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import {
@@ -119,6 +120,8 @@ export const EditorResourceComponent = ({
 	invalidInputErrorLabel,
 	duplicateChipsErrorLabel
 }: EditorResourceComponentProps): JSX.Element | null => {
+	const [t] = useTranslation();
+
 	const start = useAppSelector(selectEditorStart(editorId));
 	const end = useAppSelector(selectEditorEnd(editorId));
 	const allDay = useAppSelector(selectEditorAllDay(editorId));
@@ -167,7 +170,7 @@ export const EditorResourceComponent = ({
 					id: 'edit',
 					icon: 'EditOutline',
 					type: 'button',
-					label: 'Edit',
+					label: t('label.edit', 'Edit'),
 					onClick: (event): void => {
 						event.stopPropagation();
 						handleEditResource(resource);
@@ -178,7 +181,7 @@ export const EditorResourceComponent = ({
 			if (isDuplicate) {
 				actions.unshift({
 					id: 'duplicate',
-					label: 'Duplicate resource',
+					label: t('label.duplicate_resource', 'This resource was selected multiple times'),
 					color: 'warning',
 					type: 'icon',
 					icon: 'AlertTriangle'
@@ -197,7 +200,7 @@ export const EditorResourceComponent = ({
 				error: !isValid
 			};
 		},
-		[duplicateResourceIds, handleEditResource]
+		[duplicateResourceIds, handleEditResource, t]
 	);
 
 	const handleAdd = useCallback(

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -237,7 +237,7 @@ export const EditorResourceComponent = ({
 	const buildResourceChipItem = useCallback(
 		(resource: Resource): ResourceChipItem => {
 			const isValid = isValidResource(resource);
-			const key = resource.id || resource.email;
+			const key = resource.id ?? resource.email;
 			const isDuplicate = isValid && duplicateResourceIds.has(key);
 			setHasDuplicateValidChips(isDuplicate);
 

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -123,6 +123,8 @@ export const EditorResourceComponent = ({
 		!!resource?.label?.trim() && !!resource?.email?.trim();
 
 	const handleAdd = useCallback((valueToAdd: unknown): ChipItem<Resource> => {
+		setChipIdToRemove(null);
+
 		const isResourceOption = (obj: unknown): obj is Resource =>
 			typeof obj === 'object' &&
 			obj !== null &&

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -349,7 +349,7 @@ export const EditorResourceComponent = ({
 					disabled={disabled}
 					confirmChipOnBlur
 					createChipOnPaste={false}
-					disableOptions={false}
+					disableOptions
 					placeholder={placeholder}
 					value={resourceAvailability}
 					options={options}

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -332,7 +332,10 @@ export const EditorResourceComponent = ({
 					options={options}
 					onChange={handleChange}
 					onAdd={handleAdd}
-					separators={[{ code: 'Enter', ctrlKey: false }]}
+					separators={[
+						{ code: 'Enter', ctrlKey: false },
+						{ code: 'NumpadEnter', ctrlKey: false }
+					]}
 					onInputType={handleInputType}
 					hasError={hasError}
 					description={hasError ? invalidInputErrorLabel : undefined}

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -143,85 +143,6 @@ export const EditorResourceComponent = ({
 		duplicateResourceIds.size > 0
 	);
 
-	const handleAdd = useCallback((valueToAdd: unknown): ResourceChipItem => {
-		setEditingResource(null);
-
-		const isResourceOption = (obj: unknown): obj is Resource =>
-			typeof obj === 'object' &&
-			obj !== null &&
-			'id' in obj &&
-			'label' in obj &&
-			'email' in obj &&
-			'type' in obj;
-
-		const isStringInput = (input: unknown): input is string =>
-			typeof input === 'string' && input.trim() !== '';
-
-		let label: string;
-		let resource: Resource;
-		if (isResourceOption(valueToAdd)) {
-			resource = valueToAdd;
-			label = resource.label;
-		} else if (isStringInput(valueToAdd)) {
-			label = valueToAdd.trim();
-			resource = { email: '', label };
-		} else {
-			label = 'Invalid input';
-			resource = { email: '', label };
-		}
-		const resourceId = resource.id ?? generateResourceId(resource);
-		resource = { ...resource, id: resourceId };
-		const isValid = isValidResource(resource);
-
-		return {
-			label,
-			id: resourceId,
-			value: resource,
-			...(isValid ? {} : { background: 'error', error: true })
-		};
-	}, []);
-
-	const loadingOption = useMemo(
-		() => [
-			{
-				id: 'loading',
-				label: 'loading',
-				customComponent: <Loader />,
-				disabled: true
-			}
-		],
-		[]
-	);
-
-	const handleInputType = useCallback<NonNullable<ChipInputProps<Resource>['onInputType']>>(
-		(e) => {
-			if (e.textContent && e.textContent !== '') {
-				setOptions(loadingOption);
-				onSearchOptions(e.textContent)
-					.then((receivedOptions) => {
-						setOptions(receivedOptions);
-					})
-					.catch((reason) => {
-						setOptions([]);
-						console.warn(reason.error ?? reason);
-					});
-			} else {
-				setOptions([]);
-			}
-		},
-		[loadingOption, onSearchOptions]
-	);
-
-	const handleChange = useCallback(
-		(newChips: ChipItem<Resource>[]): void => {
-			if (!onChange) return;
-
-			setHasError(newChips.some((item) => !isValidResource(item.value)));
-			onChange(newChips.map((chip) => chip.value as Resource));
-		},
-		[onChange]
-	);
-
 	const handleEditResource = useCallback((resource: Resource) => {
 		setEditingResource(resource);
 
@@ -277,6 +198,97 @@ export const EditorResourceComponent = ({
 			};
 		},
 		[duplicateResourceIds, handleEditResource]
+	);
+
+	const handleAdd = useCallback(
+		(valueToAdd: unknown): ResourceChipItem => {
+			setEditingResource(null);
+
+			const isResourceOption = (obj: unknown): obj is Resource =>
+				typeof obj === 'object' &&
+				obj !== null &&
+				'id' in obj &&
+				'label' in obj &&
+				'email' in obj &&
+				'type' in obj;
+
+			const isStringInput = (input: unknown): input is string =>
+				typeof input === 'string' && input.trim() !== '';
+
+			if (isStringInput(valueToAdd)) {
+				const exactMatch = options.find(
+					(opt) => opt.label?.toLowerCase() === valueToAdd.trim().toLowerCase()
+				);
+				if (exactMatch && exactMatch.value) {
+					return buildResourceChipItem(exactMatch.value);
+				}
+			}
+
+			let label: string;
+			let resource: Resource;
+			if (isResourceOption(valueToAdd)) {
+				resource = valueToAdd;
+				label = resource.label;
+			} else if (isStringInput(valueToAdd)) {
+				label = valueToAdd.trim();
+				resource = { email: '', label };
+			} else {
+				label = 'Invalid input';
+				resource = { email: '', label };
+			}
+			const resourceId = resource.id ?? generateResourceId(resource);
+			resource = { ...resource, id: resourceId };
+			const isValid = isValidResource(resource);
+
+			return {
+				label,
+				id: resourceId,
+				value: resource,
+				...(isValid ? {} : { background: 'error', error: true })
+			};
+		},
+		[buildResourceChipItem, options]
+	);
+
+	const loadingOption = useMemo(
+		() => [
+			{
+				id: 'loading',
+				label: 'loading',
+				customComponent: <Loader />,
+				disabled: true
+			}
+		],
+		[]
+	);
+
+	const handleInputType = useCallback<NonNullable<ChipInputProps<Resource>['onInputType']>>(
+		(e) => {
+			if (e.textContent && e.textContent !== '') {
+				setOptions(loadingOption);
+				onSearchOptions(e.textContent)
+					.then((receivedOptions) => {
+						setOptions(receivedOptions);
+					})
+					.catch((reason) => {
+						setOptions([]);
+						console.warn(reason.error ?? reason);
+					});
+			} else {
+				setOptions([]);
+			}
+		},
+		[loadingOption, onSearchOptions]
+	);
+
+	const handleChange = useCallback(
+		(newChips: ChipItem<Resource>[]): void => {
+			if (!onChange) return;
+
+			setHasError(newChips.some((item) => !isValidResource(item.value)));
+			onChange(newChips.map((chip) => chip.value as Resource));
+		},
+		[onChange]
 	);
 
 	const resourceAvailability: ResourceChipItem[] = useMemo(() => {

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -24,7 +24,7 @@ import {
 	EditorAvailabilityWarningRow,
 	getIsBusyAtTimeOfTheEvent
 } from './editor-availability-warning-row';
-import { generateResourceId } from './utils';
+import { generateResourceId, isValidResource } from './utils';
 import { useAttendeesAvailability } from '../../../hooks/use-attendees-availability';
 import { useAppSelector } from '../../../store/redux/hooks';
 import {
@@ -103,6 +103,7 @@ type ResourceChipItem = ChipItem<Resource> & {
 	avatarIcon?: keyof Theme['icons'];
 	avatarBackground?: keyof Theme['palette'];
 	avatarColor?: string;
+	error?: boolean;
 };
 
 export const EditorResourceComponent = ({
@@ -125,62 +126,50 @@ export const EditorResourceComponent = ({
 	const [editingResource, setEditingResource] = useState<Resource | null>(null);
 	const attendeesAvailabilityList = useAttendeesAvailability(start, resourcesValue, uid);
 
-	const isValidResource = useCallback(
-		(resource: Resource | undefined): boolean =>
-			!!resource?.label?.trim() && !!resource?.email?.trim(),
-		[]
-	);
-
 	const resourcesAreValid = useMemo(
 		() => resourcesValue.every((resource) => isValidResource(resource)),
-		[isValidResource, resourcesValue]
+		[resourcesValue]
 	);
 
 	const [hasError, setHasError] = useState(!resourcesAreValid);
 
-	const handleAdd = useCallback(
-		(valueToAdd: unknown): ResourceChipItem => {
-			setEditingResource(null);
+	const handleAdd = useCallback((valueToAdd: unknown): ResourceChipItem => {
+		setEditingResource(null);
 
-			const isResourceOption = (obj: unknown): obj is Resource =>
-				typeof obj === 'object' &&
-				obj !== null &&
-				'id' in obj &&
-				'label' in obj &&
-				'email' in obj &&
-				'type' in obj;
+		const isResourceOption = (obj: unknown): obj is Resource =>
+			typeof obj === 'object' &&
+			obj !== null &&
+			'id' in obj &&
+			'label' in obj &&
+			'email' in obj &&
+			'type' in obj;
 
-			const isStringInput = (input: unknown): input is string =>
-				typeof input === 'string' && input.trim() !== '';
+		const isStringInput = (input: unknown): input is string =>
+			typeof input === 'string' && input.trim() !== '';
 
-			let label: string;
-			let resource: Resource;
-			if (isResourceOption(valueToAdd)) {
-				resource = valueToAdd;
-				label = resource.label;
-			} else if (isStringInput(valueToAdd)) {
-				label = valueToAdd.trim();
-				resource = { email: '', label };
-			} else {
-				label = 'Invalid input';
-				resource = { email: '', label };
-			}
+		let label: string;
+		let resource: Resource;
+		if (isResourceOption(valueToAdd)) {
+			resource = valueToAdd;
+			label = resource.label;
+		} else if (isStringInput(valueToAdd)) {
+			label = valueToAdd.trim();
+			resource = { email: '', label };
+		} else {
+			label = 'Invalid input';
+			resource = { email: '', label };
+		}
+		const resourceId = resource.id ?? generateResourceId(resource);
+		resource = { ...resource, id: resourceId };
+		const isValid = isValidResource(resource);
 
-			const resourceId = resource.id ?? generateResourceId(resource);
-
-			resource = { ...resource, id: resourceId };
-
-			const isValid = isValidResource(resource);
-
-			return {
-				label,
-				id: resourceId,
-				value: resource,
-				...(isValid ? {} : { background: 'error', hasError: true })
-			};
-		},
-		[isValidResource]
-	);
+		return {
+			label,
+			id: resourceId,
+			value: resource,
+			...(isValid ? {} : { background: 'error', error: true })
+		};
+	}, []);
 
 	const loadingOption = useMemo(
 		() => [
@@ -220,7 +209,7 @@ export const EditorResourceComponent = ({
 			setHasError(newChips.some((item) => !isValidResource(item.value)));
 			onChange(newChips.map((chip) => chip.value as Resource));
 		},
-		[onChange, isValidResource]
+		[onChange]
 	);
 
 	const handleEditResource = useCallback((resource: Resource) => {
@@ -239,23 +228,11 @@ export const EditorResourceComponent = ({
 		(resource: Resource): ResourceChipItem => {
 			const isValid = isValidResource(resource);
 
-			let avatarIcon: keyof Theme['icons'];
-			if (!isValid) {
-				avatarIcon = 'AlertCircleOutline';
-			} else if (resource.type === 'Location') {
-				avatarIcon = 'BuildingOutline';
-			} else {
-				avatarIcon = 'BriefcaseOutline';
-			}
-
-			const avatarBackground: keyof Theme['palette'] = isValid ? 'transparent' : 'error';
-
 			const editChipAction: ChipAction = {
 				id: 'edit',
 				icon: 'EditOutline',
 				type: 'button',
 				label: 'Edit',
-				color: isValid ? 'text' : 'error',
 				onClick: (event) => {
 					event.stopPropagation();
 					handleEditResource(resource);
@@ -269,12 +246,12 @@ export const EditorResourceComponent = ({
 				background: isValid ? 'gray3' : 'error',
 				color: isValid ? 'text' : 'gray6',
 				avatarColor: isValid ? 'gray0' : 'gray6',
-				avatarIcon,
-				avatarBackground,
-				actions: [editChipAction]
+				avatarBackground: isValid ? 'transparent' : 'error',
+				actions: [editChipAction],
+				error: !isValid
 			};
 		},
-		[handleEditResource, isValidResource]
+		[handleEditResource]
 	);
 
 	const resourceAvailability: ResourceChipItem[] = useMemo(() => {

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -309,7 +309,7 @@ export const EditorResourceComponent = ({
 						}
 					}
 				},
-				keys: [{ key: 'Enter', ctrlKey: false }],
+				keys: [{ key: 'Enter', ctrlKey: true }],
 				haveToPreventDefault: true
 			}
 		],
@@ -332,6 +332,7 @@ export const EditorResourceComponent = ({
 					options={options}
 					onChange={handleChange}
 					onAdd={handleAdd}
+					separators={[{ code: 'Enter', ctrlKey: false }]}
 					onInputType={handleInputType}
 					hasError={hasError}
 					description={hasError ? invalidInputErrorLabel : undefined}

--- a/src/view/editor/parts/editor-send-button.tsx
+++ b/src/view/editor/parts/editor-send-button.tsx
@@ -7,9 +7,9 @@ import React, { ReactElement, useCallback, useMemo } from 'react';
 
 import { Button, useModal, useSnackbar } from '@zextras/carbonio-design-system';
 import { closeBoard, useBoard } from '@zextras/carbonio-shell-ui';
+import { useHistoryNavigation } from '@zextras/carbonio-ui-commons';
 import { useTranslation } from 'react-i18next';
 
-import { useHistoryNavigation } from '@zextras/carbonio-ui-commons';
 import { onSend } from '../../../commons/editor-save-send-fns';
 import { CALENDAR_ROUTE } from '../../../constants';
 import { StoreProvider } from '../../../store/redux';
@@ -45,23 +45,29 @@ export const EditorSendButton = ({ editorId }: EditorProps): ReactElement => {
 	const dispatch = useAppDispatch();
 	const { replaceHistory } = useHistoryNavigation();
 
-	const isDisabled = useMemo(
-		() =>
+	const isDisabled = useMemo(() => {
+		const hasInvalidMeetingRoom = meetingRooms?.some((room) => !room?.email?.trim());
+		const hasInvalidEquipment = equipments?.some((eq) => !eq?.email?.trim());
+
+		return (
 			disabled?.sendButton ||
 			(!attendees?.length &&
 				!optionalAttendees?.length &&
 				!meetingRooms?.length &&
 				!equipments?.length) ||
-			!title?.length,
-		[
-			attendees?.length,
-			disabled?.sendButton,
-			equipments?.length,
-			meetingRooms?.length,
-			optionalAttendees?.length,
-			title?.length
-		]
-	);
+			!title?.trim() ||
+			hasInvalidMeetingRoom ||
+			hasInvalidEquipment
+		);
+	}, [
+		attendees?.length,
+		optionalAttendees?.length,
+		meetingRooms,
+		equipments,
+		disabled?.sendButton,
+		title
+	]);
+
 	const onClick = useCallback(() => {
 		if (editor.isSeries && !isNew && !editor.isInstance) {
 			const modalId = 'series-edit-warning';

--- a/src/view/editor/parts/editor-send-button.tsx
+++ b/src/view/editor/parts/editor-send-button.tsx
@@ -45,29 +45,23 @@ export const EditorSendButton = ({ editorId }: EditorProps): ReactElement => {
 	const dispatch = useAppDispatch();
 	const { replaceHistory } = useHistoryNavigation();
 
-	const isDisabled = useMemo(() => {
-		const hasInvalidMeetingRoom = meetingRooms?.some((room) => !room?.email?.trim());
-		const hasInvalidEquipment = equipments?.some((eq) => !eq?.email?.trim());
-
-		return (
+	const isDisabled = useMemo(
+		() =>
 			disabled?.sendButton ||
 			(!attendees?.length &&
 				!optionalAttendees?.length &&
 				!meetingRooms?.length &&
 				!equipments?.length) ||
-			!title?.trim() ||
-			hasInvalidMeetingRoom ||
-			hasInvalidEquipment
-		);
-	}, [
-		attendees?.length,
-		optionalAttendees?.length,
-		meetingRooms,
-		equipments,
-		disabled?.sendButton,
-		title
-	]);
-
+			!title?.length,
+		[
+			attendees?.length,
+			disabled?.sendButton,
+			equipments?.length,
+			meetingRooms?.length,
+			optionalAttendees?.length,
+			title?.length
+		]
+	);
 	const onClick = useCallback(() => {
 		if (editor.isSeries && !isNew && !editor.isInstance) {
 			const modalId = 'series-edit-warning';

--- a/src/view/editor/parts/tests/editor-equipment.test.tsx
+++ b/src/view/editor/parts/tests/editor-equipment.test.tsx
@@ -211,7 +211,7 @@ describe('Editor equipment', () => {
 		expect(screen.getByText(selectedEquipmentLabel)).toBeVisible();
 	});
 
-	it('should not add a new chip that have the same label', async () => {
+	it('should allow adding a new chip that have the same label', async () => {
 		const label = `resource 1`;
 		const itemFromAutoComplete = {
 			id: faker.string.uuid(),
@@ -241,9 +241,10 @@ describe('Editor equipment', () => {
 		const dropdown = await screen.findByTestId(TEST_SELECTORS.DROPDOWN);
 		await user.click(await within(dropdown).findByText(itemFromAutoComplete.label));
 
-		expect((await screen.findAllByText(label)).length).toBe(1);
+		expect((await screen.findAllByText(label)).length).toBe(2);
 	});
-	it('should not display multiple chips with the same email', async () => {
+
+	it('should allow adding multiple chips with the same email', async () => {
 		const email = `same@email.it`;
 		const itemFromAutoComplete = {
 			id: faker.string.uuid(),
@@ -275,9 +276,10 @@ describe('Editor equipment', () => {
 		expect(dropdown).not.toBeInTheDocument();
 
 		expect((await screen.findAllByText(storedItem.label)).length).toBe(1);
-		expect(screen.queryAllByText(itemFromAutoComplete.label).length).toBe(0);
+		expect(screen.queryAllByText(itemFromAutoComplete.label).length).toBe(1);
 	});
-	it('should not add a new chip that already exists', async () => {
+
+	it('should allow add a new chip that already exists', async () => {
 		const items = map({ length: 3 }, (_, index) => {
 			const label = `resource ${index}`;
 			return {
@@ -305,8 +307,9 @@ describe('Editor equipment', () => {
 		const dropdown = await screen.findByTestId(TEST_SELECTORS.DROPDOWN);
 		await user.click(await within(dropdown).findByText(selectedEquipment.label));
 
-		expect((await screen.findAllByText(selectedEquipment.label)).length).toBe(1);
+		expect((await screen.findAllByText(selectedEquipment.label)).length).toBe(2);
 	});
+
 	it('should leave options dropdown open with loader when call to AutoCompleteGal api fails with generic 500', async () => {
 		const store = configureStore({ reducer: combineReducers(reducers) });
 		const editor = generateEditor({

--- a/src/view/editor/parts/tests/editor-equipment.test.tsx
+++ b/src/view/editor/parts/tests/editor-equipment.test.tsx
@@ -173,7 +173,7 @@ describe('Editor equipment', () => {
 		await user.type(screen.getByText('Equipment'), 'resource');
 		const dropDownItems = await screen.findAllByTestId('dropdown-item');
 
-		await user.keyboard('{Enter}');
+		await user.keyboard('{Control>}{Enter}{/Control}');
 
 		expect(dropDownItems[0]).not.toBeInTheDocument();
 		expect(screen.getByText(/resource 0/i)).toBeVisible();

--- a/src/view/editor/parts/tests/editor-equipment.test.tsx
+++ b/src/view/editor/parts/tests/editor-equipment.test.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 import { faker } from '@faker-js/faker';
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
-import { act, screen, within } from '@testing-library/react';
+import { act, screen, waitFor, within } from '@testing-library/react';
 import { ErrorSoapBodyResponse, SuccessSoapResponse } from '@zextras/carbonio-shell-ui';
 import { map } from 'lodash';
 import { http, HttpResponse } from 'msw';
@@ -313,7 +313,7 @@ describe('Editor equipment', () => {
 		getSetupServer().use(
 			http.post('/service/soap/AutoCompleteGalRequest', async () => {
 				await new Promise((resolve) => {
-					setTimeout(resolve, 1000);
+					setTimeout(resolve, 500);
 				});
 				return new HttpResponse(null, { status: 500 });
 			})
@@ -334,7 +334,7 @@ describe('Editor equipment', () => {
 		getSetupServer().use(
 			http.post('/service/soap/AutoCompleteGalRequest', async () => {
 				await new Promise((resolve) => {
-					setTimeout(resolve, 1000);
+					setTimeout(resolve, 500);
 				});
 				return HttpResponse.json<ErrorSoapBodyResponse>(buildSoapErrorResponseBody());
 			})
@@ -344,5 +344,32 @@ describe('Editor equipment', () => {
 		const dropdown = await screen.findByTestId(TEST_SELECTORS.DROPDOWN);
 
 		expect(await within(dropdown).findByTestId('dropdown-options-loader')).toBeVisible();
+	});
+
+	it('should handle API failure when searching for equipment', async () => {
+		const store = configureStore({ reducer: combineReducers(reducers) });
+		const editor = generateEditor({
+			context: { dispatch: store.dispatch, folders: {} }
+		});
+
+		getSetupServer().use(
+			http.post('/service/soap/AutoCompleteGalRequest', async () =>
+				HttpResponse.json(buildSoapErrorResponseBody())
+			)
+		);
+
+		const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+		const { user } = setupTest(<EditorEquipments editorId={editor.id} />, { store });
+
+		await user.type(screen.getByText('Equipment'), 'test');
+
+		await waitFor(() => {
+			expect(consoleSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					message: 'API failed'
+				})
+			);
+		});
+		consoleSpy.mockRestore();
 	});
 });

--- a/src/view/editor/parts/tests/editor-equipment.test.tsx
+++ b/src/view/editor/parts/tests/editor-equipment.test.tsx
@@ -33,6 +33,7 @@ describe('Editor equipment', () => {
 
 		expect(screen.getByText('Equipment')).toBeInTheDocument();
 	});
+
 	it('should render the chip when present in the store', async () => {
 		const store = configureStore({ reducer: combineReducers(reducers) });
 
@@ -49,6 +50,7 @@ describe('Editor equipment', () => {
 
 		expect(screen.getByText(/automobile 1/i)).toBeVisible();
 	});
+
 	it('should display equipment busy when is already booked', async () => {
 		const store = configureStore({ reducer: combineReducers(reducers) });
 		const equipment1 = {
@@ -79,6 +81,7 @@ describe('Editor equipment', () => {
 		expect(screen.getByText(equipment1.label)).toBeVisible();
 		expect(await screen.findByTestId('icon: AlertTriangle')).toBeVisible();
 	});
+
 	it('should display options on screen when typing', async () => {
 		const store = configureStore({ reducer: combineReducers(reducers) });
 		const editor = generateEditor({ context: { dispatch: store.dispatch, folders: {} } });
@@ -109,6 +112,7 @@ describe('Editor equipment', () => {
 		expect(within(dropdown).getByText(items[1].label)).toBeVisible();
 		expect(within(dropdown).getByText(items[2].label)).toBeVisible();
 	});
+
 	it('should add a chip when selecting an option', async () => {
 		const store = configureStore({ reducer: combineReducers(reducers) });
 		const editor = generateEditor({ context: { dispatch: store.dispatch, folders: {} } });
@@ -141,6 +145,7 @@ describe('Editor equipment', () => {
 		});
 		expect(screen.getByText(/resource 0/i)).toBeVisible();
 	});
+
 	it('should select the first option when pressing enter', async () => {
 		const store = configureStore({ reducer: combineReducers(reducers) });
 		const editor = generateEditor({ context: { dispatch: store.dispatch, folders: {} } });
@@ -330,6 +335,7 @@ describe('Editor equipment', () => {
 		const dropdown = await screen.findByTestId(TEST_SELECTORS.DROPDOWN);
 		expect(await within(dropdown).findByTestId('dropdown-options-loader')).toBeVisible();
 	});
+
 	it('should leave options dropdown open with loader when call to AutoCompleteGal api fails with Soap Fault', async () => {
 		const store = configureStore({ reducer: combineReducers(reducers) });
 		const editor = generateEditor({

--- a/src/view/editor/parts/tests/editor-equipment.test.tsx
+++ b/src/view/editor/parts/tests/editor-equipment.test.tsx
@@ -173,6 +173,7 @@ describe('Editor equipment', () => {
 		expect(dropDownItems[0]).not.toBeInTheDocument();
 		expect(screen.getByText(/resource 0/i)).toBeVisible();
 	});
+
 	it('should not remove the already existing chips when adding a new one', async () => {
 		const equipment1 = {
 			label: 'automobile 1',
@@ -209,13 +210,14 @@ describe('Editor equipment', () => {
 		expect(screen.getByText(equipment1.label)).toBeVisible();
 		expect(screen.getByText(selectedEquipmentLabel)).toBeVisible();
 	});
+
 	it('should not add a new chip that have the same label', async () => {
 		const label = `resource 1`;
 		const itemFromAutoComplete = {
 			id: faker.string.uuid(),
 			label,
 			value: label,
-			email: 'resource1@test.it',
+			email: '',
 			type: 'Equipment'
 		};
 		const storedItem = {

--- a/src/view/editor/parts/tests/editor-equipment.test.tsx
+++ b/src/view/editor/parts/tests/editor-equipment.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { faker } from '@faker-js/faker';
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import { act, screen, within } from '@testing-library/react';
-import { SuccessSoapResponse } from '@zextras/carbonio-shell-ui';
+import { ErrorSoapBodyResponse, SuccessSoapResponse } from '@zextras/carbonio-shell-ui';
 import { map } from 'lodash';
 import { http, HttpResponse } from 'msw';
 
@@ -21,7 +21,6 @@ import { getCustomResources } from '../../../../test/mocks/network/msw/handle-au
 import { EditorEquipments } from '../editor-equipments';
 import { getSetupServer } from '@jest-setup';
 import { setupTest } from '@test-setup';
-import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { CarbonioMailboxRestHandlerRequest } from '@test-utils/network/msw/handlers';
 import { buildSoapErrorResponseBody } from '@test-utils/utils/soap';
 
@@ -167,15 +166,11 @@ describe('Editor equipment', () => {
 		const { user } = setupTest(<EditorEquipments editorId={editor.id} />, { store });
 
 		await user.type(screen.getByText('Equipment'), 'resource');
+		const dropDownItems = await screen.findAllByTestId('dropdown-item');
 
-		await act(async () => {
-			await jest.advanceTimersToNextTimerAsync();
-		});
+		await user.keyboard('{Enter}');
 
-		const dropdown = await screen.findByTestId(TEST_SELECTORS.DROPDOWN);
-
-		await user.keyboard('[Enter]');
-		expect(dropdown).not.toBeInTheDocument();
+		expect(dropDownItems[0]).not.toBeInTheDocument();
 		expect(screen.getByText(/resource 0/i)).toBeVisible();
 	});
 	it('should not remove the already existing chips when adding a new one', async () => {
@@ -206,9 +201,10 @@ describe('Editor equipment', () => {
 		const { user } = setupTest(<EditorEquipments editorId={editor.id} />, { store });
 
 		await user.type(screen.getByText('Equipment'), 'resource');
-		const dropdown = await screen.findByTestId(TEST_SELECTORS.DROPDOWN);
+		const dropDownItems = await screen.findAllByTestId('dropdown-item');
+
 		const selectedEquipmentLabel = items[0].label;
-		await user.click(within(dropdown).getByText(selectedEquipmentLabel));
+		await user.click(within(dropDownItems[0]).getByText(selectedEquipmentLabel));
 
 		expect(screen.getByText(equipment1.label)).toBeVisible();
 		expect(screen.getByText(selectedEquipmentLabel)).toBeVisible();
@@ -239,8 +235,9 @@ describe('Editor equipment', () => {
 		const { user } = setupTest(<EditorEquipments editorId={editor.id} />, { store });
 
 		await user.type(screen.getByText('Equipment'), 'resource');
+
 		const dropdown = await screen.findByTestId(TEST_SELECTORS.DROPDOWN);
-		await user.click(within(dropdown).getByText(itemFromAutoComplete.label));
+		await user.click(await within(dropdown).findByText(itemFromAutoComplete.label));
 
 		expect((await screen.findAllByText(label)).length).toBe(1);
 	});
@@ -271,7 +268,7 @@ describe('Editor equipment', () => {
 
 		await user.type(screen.getByText('Equipment'), 'resource');
 		const dropdown = await screen.findByTestId(TEST_SELECTORS.DROPDOWN);
-		await user.click(within(dropdown).getByText(itemFromAutoComplete.label));
+		await user.click(await within(dropdown).findByText(itemFromAutoComplete.label));
 
 		expect(dropdown).not.toBeInTheDocument();
 
@@ -304,7 +301,7 @@ describe('Editor equipment', () => {
 
 		await user.type(screen.getByText('Equipment'), 'resource');
 		const dropdown = await screen.findByTestId(TEST_SELECTORS.DROPDOWN);
-		await user.click(within(dropdown).getByText(selectedEquipment.label));
+		await user.click(await within(dropdown).findByText(selectedEquipment.label));
 
 		expect((await screen.findAllByText(selectedEquipment.label)).length).toBe(1);
 	});
@@ -314,15 +311,19 @@ describe('Editor equipment', () => {
 			context: { dispatch: store.dispatch, folders: {}, meetingRoom: [] }
 		});
 		getSetupServer().use(
-			http.post('/service/soap/AutoCompleteGalRequest', async () => HttpResponse.error())
+			http.post('/service/soap/AutoCompleteGalRequest', async () => {
+				await new Promise((resolve) => {
+					setTimeout(resolve, 1000);
+				});
+				return new HttpResponse(null, { status: 500 });
+			})
 		);
 
 		const { user } = setupTest(<EditorEquipments editorId={editor.id} />, { store });
 		await user.type(screen.getByText('Equipment'), 'resource');
 
 		const dropdown = await screen.findByTestId(TEST_SELECTORS.DROPDOWN);
-
-		expect(within(dropdown).getByTestId('dropdown-options-loader')).toBeVisible();
+		expect(await within(dropdown).findByTestId('dropdown-options-loader')).toBeVisible();
 	});
 	it('should leave options dropdown open with loader when call to AutoCompleteGal api fails with Soap Fault', async () => {
 		const store = configureStore({ reducer: combineReducers(reducers) });
@@ -330,13 +331,18 @@ describe('Editor equipment', () => {
 			context: { dispatch: store.dispatch, folders: {}, meetingRoom: [] }
 		});
 
-		const interceptor = createSoapAPIInterceptor('AutoCompleteGal', buildSoapErrorResponseBody());
-
+		getSetupServer().use(
+			http.post('/service/soap/AutoCompleteGalRequest', async () => {
+				await new Promise((resolve) => {
+					setTimeout(resolve, 1000);
+				});
+				return HttpResponse.json<ErrorSoapBodyResponse>(buildSoapErrorResponseBody());
+			})
+		);
 		const { user } = setupTest(<EditorEquipments editorId={editor.id} />, { store });
 		await user.type(screen.getByText('Equipment'), 'resource');
 		const dropdown = await screen.findByTestId(TEST_SELECTORS.DROPDOWN);
-		await interceptor;
 
-		expect(within(dropdown).getByTestId('dropdown-options-loader')).toBeVisible();
+		expect(await within(dropdown).findByTestId('dropdown-options-loader')).toBeVisible();
 	});
 });

--- a/src/view/editor/parts/tests/editor-meeting-rooms.test.tsx
+++ b/src/view/editor/parts/tests/editor-meeting-rooms.test.tsx
@@ -215,7 +215,7 @@ describe('Editor meeting rooms', () => {
 			id: faker.string.uuid(),
 			label,
 			value: label,
-			email: 'location1@test.it',
+			email: '',
 			type: 'Location'
 		};
 		const storedItem = {
@@ -238,6 +238,7 @@ describe('Editor meeting rooms', () => {
 
 		const dropdown = await screen.findByTestId('dropdown-item');
 		await user.click(within(dropdown).getByText(itemFromAutoComplete.label));
+		expect(dropdown).not.toBeInTheDocument();
 
 		expect((await screen.findAllByText(label)).length).toBe(1);
 	});

--- a/src/view/editor/parts/tests/editor-meeting-rooms.test.tsx
+++ b/src/view/editor/parts/tests/editor-meeting-rooms.test.tsx
@@ -173,7 +173,7 @@ describe('Editor meeting rooms', () => {
 		await user.type(screen.getByText('Meeting room'), 'resource');
 		const dropDownItems = await screen.findAllByTestId('dropdown-item');
 
-		await user.keyboard('{Enter}');
+		await user.keyboard('{Control>}{Enter}{/Control}');
 
 		expect(dropDownItems[0]).not.toBeInTheDocument();
 		expect(screen.getByText(/resource 0/i)).toBeVisible();

--- a/src/view/editor/parts/tests/editor-meeting-rooms.test.tsx
+++ b/src/view/editor/parts/tests/editor-meeting-rooms.test.tsx
@@ -209,7 +209,7 @@ describe('Editor meeting rooms', () => {
 		expect(screen.getByText(meetinRoom1.label)).toBeVisible();
 		expect(screen.getByText(selectedMeetingRoomLabel)).toBeVisible();
 	});
-	it('should not add a new chip that have the same label', async () => {
+	it('should allow adding a new chip that have the same label', async () => {
 		const label = `location 1`;
 		const itemFromAutoComplete = {
 			id: faker.string.uuid(),
@@ -240,9 +240,10 @@ describe('Editor meeting rooms', () => {
 		await user.click(within(dropdown).getByText(itemFromAutoComplete.label));
 		expect(dropdown).not.toBeInTheDocument();
 
-		expect((await screen.findAllByText(label)).length).toBe(1);
+		expect((await screen.findAllByText(label)).length).toBe(2);
 	});
-	it('should not display multiple chips with the same email', async () => {
+
+	it('should allow adding multiple chips with the same email', async () => {
 		const email = `same@email.it`;
 		const itemFromAutoComplete = {
 			id: faker.string.uuid(),
@@ -275,8 +276,9 @@ describe('Editor meeting rooms', () => {
 		expect(dropDownItem).not.toBeInTheDocument();
 
 		expect((await screen.findAllByText(storedItem.label)).length).toBe(1);
-		expect(screen.queryAllByText(itemFromAutoComplete.label).length).toBe(0);
+		expect(screen.queryAllByText(itemFromAutoComplete.label).length).toBe(1);
 	});
+
 	it('should leave options dropdown open with loader when AutoCompleteGal api fails with 500', async () => {
 		const store = configureStore({ reducer: combineReducers(reducers) });
 		const editor = generateEditor({

--- a/src/view/editor/parts/tests/editor-meeting-rooms.test.tsx
+++ b/src/view/editor/parts/tests/editor-meeting-rooms.test.tsx
@@ -32,6 +32,7 @@ describe('Editor meeting rooms', () => {
 
 		expect(screen.getByText('Meeting room')).toBeInTheDocument();
 	});
+
 	it('should render the chip when present in the store', async () => {
 		const store = configureStore({ reducer: combineReducers(reducers) });
 
@@ -48,6 +49,7 @@ describe('Editor meeting rooms', () => {
 
 		expect(screen.getByText(meetingRoom1.label)).toBeVisible();
 	});
+
 	it('should display meeting room busy when is already booked', async () => {
 		const store = configureStore({ reducer: combineReducers(reducers) });
 		const meetingRoom1 = {
@@ -78,6 +80,7 @@ describe('Editor meeting rooms', () => {
 		expect(screen.getByText(meetingRoom1.label)).toBeVisible();
 		expect(await screen.findByTestId('icon: AlertTriangle')).toBeVisible();
 	});
+
 	it('should display options on screen when typing', async () => {
 		const store = configureStore({ reducer: combineReducers(reducers) });
 		const editor = generateEditor({ context: { dispatch: store.dispatch, folders: {} } });
@@ -108,6 +111,7 @@ describe('Editor meeting rooms', () => {
 		expect(within(dropdown).getByText(items[1].label)).toBeVisible();
 		expect(within(dropdown).getByText(items[2].label)).toBeVisible();
 	});
+
 	it('should add a chip when selecting an option', async () => {
 		const store = configureStore({ reducer: combineReducers(reducers) });
 		const editor = generateEditor({ context: { dispatch: store.dispatch, folders: {} } });
@@ -143,6 +147,7 @@ describe('Editor meeting rooms', () => {
 		});
 		expect(screen.getByText(/resource 0/i)).toBeVisible();
 	});
+
 	it('should select the first option when pressing enter', async () => {
 		const store = configureStore({ reducer: combineReducers(reducers) });
 		const editor = generateEditor({ context: { dispatch: store.dispatch, folders: {} } });
@@ -173,6 +178,7 @@ describe('Editor meeting rooms', () => {
 		expect(dropDownItems[0]).not.toBeInTheDocument();
 		expect(screen.getByText(/resource 0/i)).toBeVisible();
 	});
+
 	it('should not remove the already existing chips when adding a new one', async () => {
 		const meetinRoom1 = {
 			label: 'meeting room 1',
@@ -209,6 +215,7 @@ describe('Editor meeting rooms', () => {
 		expect(screen.getByText(meetinRoom1.label)).toBeVisible();
 		expect(screen.getByText(selectedMeetingRoomLabel)).toBeVisible();
 	});
+
 	it('should allow adding a new chip that have the same label', async () => {
 		const label = `location 1`;
 		const itemFromAutoComplete = {

--- a/src/view/editor/parts/tests/editor-meeting-rooms.test.tsx
+++ b/src/view/editor/parts/tests/editor-meeting-rooms.test.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { faker } from '@faker-js/faker';
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import { act, screen, within } from '@testing-library/react';
+import { ErrorSoapBodyResponse } from '@zextras/carbonio-shell-ui';
 import { map } from 'lodash';
 import { http, HttpResponse } from 'msw';
 
@@ -20,7 +21,6 @@ import { getCustomResources } from '../../../../test/mocks/network/msw/handle-au
 import { EditorMeetingRooms } from '../editor-meeting-rooms';
 import { getSetupServer } from '@jest-setup';
 import { setupTest } from '@test-setup';
-import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
 import { buildSoapErrorResponseBody } from '@test-utils/utils/soap';
 
 describe('Editor meeting rooms', () => {
@@ -162,23 +162,15 @@ describe('Editor meeting rooms', () => {
 		getSetupServer().use(
 			http.post('/service/soap/AutoCompleteGalRequest', async () => HttpResponse.json(soapResponse))
 		);
+
 		const { user } = setupTest(<EditorMeetingRooms editorId={editor.id} />, { store });
 
 		await user.type(screen.getByText('Meeting room'), 'resource');
+		const dropDownItems = await screen.findAllByTestId('dropdown-item');
 
-		await act(async () => {
-			await jest.advanceTimersToNextTimerAsync();
-		});
+		await user.keyboard('{Enter}');
 
-		const dropdown = screen.getByTestId(TEST_SELECTORS.DROPDOWN);
-
-		await user.keyboard('[Enter]');
-
-		await act(async () => {
-			await jest.advanceTimersToNextTimerAsync();
-		});
-
-		expect(dropdown).not.toBeInTheDocument();
+		expect(dropDownItems[0]).not.toBeInTheDocument();
 		expect(screen.getByText(/resource 0/i)).toBeVisible();
 	});
 	it('should not remove the already existing chips when adding a new one', async () => {
@@ -200,18 +192,19 @@ describe('Editor meeting rooms', () => {
 				type: 'Location'
 			};
 		});
-		const handler = getCustomResources(items);
+		const soapResponse = getCustomResources(items);
 		mockFreeBusyResponse([]);
 		getSetupServer().use(
-			http.post('/service/soap/AutoCompleteGalRequest', async () => HttpResponse.json(handler))
+			http.post('/service/soap/AutoCompleteGalRequest', async () => HttpResponse.json(soapResponse))
 		);
 
 		const { user } = setupTest(<EditorMeetingRooms editorId={editor.id} />, { store });
 
 		await user.type(screen.getByText('Meeting room'), 'location');
-		const dropdown = await screen.findByTestId(TEST_SELECTORS.DROPDOWN);
+		const dropDownItems = await screen.findAllByTestId('dropdown-item');
+
 		const selectedMeetingRoomLabel = items[0].label;
-		await user.click(within(dropdown).getByText(selectedMeetingRoomLabel));
+		await user.click(within(dropDownItems[0]).getByText(selectedMeetingRoomLabel));
 
 		expect(screen.getByText(meetinRoom1.label)).toBeVisible();
 		expect(screen.getByText(selectedMeetingRoomLabel)).toBeVisible();
@@ -233,18 +226,18 @@ describe('Editor meeting rooms', () => {
 		const editor = generateEditor({
 			context: { dispatch: store.dispatch, folders: {}, meetingRoom: [storedItem] }
 		});
-		const handler = getCustomResources([itemFromAutoComplete]);
+		const soapResponse = getCustomResources([itemFromAutoComplete]);
 		mockFreeBusyResponse([]);
 		getSetupServer().use(
-			http.post('/service/soap/AutoCompleteGalRequest', async () => HttpResponse.json(handler))
+			http.post('/service/soap/AutoCompleteGalRequest', async () => HttpResponse.json(soapResponse))
 		);
 
 		const { user } = setupTest(<EditorMeetingRooms editorId={editor.id} />, { store });
 
 		await user.type(screen.getByText('Meeting room'), 'location');
-		const dropdown = await screen.findByTestId(TEST_SELECTORS.DROPDOWN);
-		await user.click(within(dropdown).getByText(itemFromAutoComplete.label));
 
+		const dropdown = await screen.findByTestId('dropdown-item');
+		await user.click(within(dropdown).getByText(itemFromAutoComplete.label));
 		expect((await screen.findAllByText(label)).length).toBe(1);
 	});
 	it('should not display multiple chips with the same email', async () => {
@@ -264,52 +257,67 @@ describe('Editor meeting rooms', () => {
 		const editor = generateEditor({
 			context: { dispatch: store.dispatch, folders: {}, meetingRoom: [storedItem] }
 		});
-		const handler = getCustomResources([itemFromAutoComplete]);
+
 		mockFreeBusyResponse([]);
+		const soapResponse = getCustomResources([itemFromAutoComplete]);
 		getSetupServer().use(
-			http.post('/service/soap/AutoCompleteGalRequest', async () => HttpResponse.json(handler))
+			http.post('/service/soap/AutoCompleteGalRequest', async () => HttpResponse.json(soapResponse))
 		);
 
 		const { user } = setupTest(<EditorMeetingRooms editorId={editor.id} />, { store });
 
 		await user.type(screen.getByText('Meeting room'), 'meeting');
-		const dropdown = await screen.findByTestId(TEST_SELECTORS.DROPDOWN);
-		await user.click(within(dropdown).getByText(itemFromAutoComplete.label));
+		const dropDownItem = await screen.findByTestId('dropdown-item');
+		await user.click(within(dropDownItem).getByText(itemFromAutoComplete.label));
 
-		expect(dropdown).not.toBeInTheDocument();
+		expect(dropDownItem).not.toBeInTheDocument();
 
 		expect((await screen.findAllByText(storedItem.label)).length).toBe(1);
 		expect(screen.queryAllByText(itemFromAutoComplete.label).length).toBe(0);
 	});
-	it('should leave options dropdown open with loader when call to AutoCompleteGal api fails with generic 500', async () => {
+	it('should leave options dropdown open with loader when AutoCompleteGal api fails with 500', async () => {
 		const store = configureStore({ reducer: combineReducers(reducers) });
 		const editor = generateEditor({
 			context: { dispatch: store.dispatch, folders: {}, meetingRoom: [] }
 		});
 
 		getSetupServer().use(
-			http.post('/service/soap/AutoCompleteGalRequest', async () => HttpResponse.error())
+			http.post('/service/soap/AutoCompleteGalRequest', async () => {
+				await new Promise((resolve) => {
+					setTimeout(resolve, 1000);
+				});
+				return new HttpResponse(null, { status: 500 });
+			})
 		);
 
 		const { user } = setupTest(<EditorMeetingRooms editorId={editor.id} />, { store });
+
 		await user.type(screen.getByText('Meeting room'), 'location');
+
 		const dropdown = await screen.findByTestId(TEST_SELECTORS.DROPDOWN);
 
-		expect(within(dropdown).getByTestId('dropdown-options-loader')).toBeVisible();
+		expect(await within(dropdown).findByTestId('dropdown-options-loader')).toBeVisible();
 	});
+
 	it('should leave options dropdown open with loader when call to AutoCompleteGal api fails with Soap Fault', async () => {
 		const store = configureStore({ reducer: combineReducers(reducers) });
 		const editor = generateEditor({
 			context: { dispatch: store.dispatch, folders: {}, meetingRoom: [] }
 		});
 
-		const interceptor = createSoapAPIInterceptor('AutoCompleteGal', buildSoapErrorResponseBody());
+		getSetupServer().use(
+			http.post('/service/soap/AutoCompleteGalRequest', async () => {
+				await new Promise((resolve) => {
+					setTimeout(resolve, 1000);
+				});
+				return HttpResponse.json<ErrorSoapBodyResponse>(buildSoapErrorResponseBody());
+			})
+		);
 
 		const { user } = setupTest(<EditorMeetingRooms editorId={editor.id} />, { store });
 		await user.type(screen.getByText('Meeting room'), 'location');
 		const dropdown = await screen.findByTestId(TEST_SELECTORS.DROPDOWN);
-		await interceptor;
 
-		expect(within(dropdown).getByTestId('dropdown-options-loader')).toBeVisible();
+		expect(await within(dropdown).findByTestId('dropdown-options-loader')).toBeVisible();
 	});
 });

--- a/src/view/editor/parts/tests/editor-meeting-rooms.test.tsx
+++ b/src/view/editor/parts/tests/editor-meeting-rooms.test.tsx
@@ -238,6 +238,7 @@ describe('Editor meeting rooms', () => {
 
 		const dropdown = await screen.findByTestId('dropdown-item');
 		await user.click(within(dropdown).getByText(itemFromAutoComplete.label));
+
 		expect((await screen.findAllByText(label)).length).toBe(1);
 	});
 	it('should not display multiple chips with the same email', async () => {

--- a/src/view/editor/parts/tests/editor-meeting-rooms.test.tsx
+++ b/src/view/editor/parts/tests/editor-meeting-rooms.test.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 import { faker } from '@faker-js/faker';
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
-import { act, screen, within } from '@testing-library/react';
+import { act, screen, waitFor, within } from '@testing-library/react';
 import { ErrorSoapBodyResponse } from '@zextras/carbonio-shell-ui';
 import { map } from 'lodash';
 import { http, HttpResponse } from 'msw';
@@ -320,5 +320,32 @@ describe('Editor meeting rooms', () => {
 		const dropdown = await screen.findByTestId(TEST_SELECTORS.DROPDOWN);
 
 		expect(await within(dropdown).findByTestId('dropdown-options-loader')).toBeVisible();
+	});
+
+	it('should handle API failure when searching for meeting rooms', async () => {
+		const store = configureStore({ reducer: combineReducers(reducers) });
+		const editor = generateEditor({
+			context: { dispatch: store.dispatch, folders: {} }
+		});
+
+		getSetupServer().use(
+			http.post('/service/soap/AutoCompleteGalRequest', async () =>
+				HttpResponse.json(buildSoapErrorResponseBody())
+			)
+		);
+
+		const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+		const { user } = setupTest(<EditorMeetingRooms editorId={editor.id} />, { store });
+
+		await user.type(screen.getByText('Meeting room'), 'test');
+
+		await waitFor(() => {
+			expect(consoleSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					message: 'API failed'
+				})
+			);
+		});
+		consoleSpy.mockRestore();
 	});
 });

--- a/src/view/editor/parts/tests/editor-resource-component.test.tsx
+++ b/src/view/editor/parts/tests/editor-resource-component.test.tsx
@@ -1,92 +1,222 @@
+/* eslint-disable */
 /*
- * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
 import React from 'react';
 
-import { combineReducers, configureStore } from '@reduxjs/toolkit';
-import { screen } from '@testing-library/react';
-import { DropdownItem } from '@zextras/carbonio-design-system';
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
+import { screen, waitFor } from '@testing-library/react';
 
 import { generateEditor } from '../../../../commons/editor-generator';
-import { TEST_SELECTORS } from '../../../../constants/test-utils';
 import { reducers } from '../../../../store/redux';
 import { Resource } from '../../../../types/editor';
 import { EditorResourceComponent } from '../editor-resource-component';
 import { setupTest } from '@test-setup';
 
-function mockSearchOptions(): Promise<Array<DropdownItem & { value?: Resource }>> {
-	return Promise.resolve([
+describe('EditorResourceComponent', () => {
+	let store: ReturnType<typeof configureStore>;
+	let editor: ReturnType<typeof generateEditor>;
+	const onChangeMock = jest.fn();
+
+	const mockSearchOptions = jest.fn(async (text: string) => [
 		{
 			id: '1',
-			label: 'First Option',
+			label: `Resource: ${text}`,
 			value: {
-				label: 'My resource',
-				email: 'mynewresource@test.com'
+				id: 'res1',
+				label: `Resource: ${text}`,
+				email: 'resource@example.com',
+				type: 'Location'
 			}
 		}
 	]);
-}
-describe('EditorResourceComponent', () => {
-	it('should clear typed text after selecting the first option with enter', async () => {
-		const store = configureStore({ reducer: combineReducers(reducers) });
-		const editor = generateEditor({ context: { dispatch: store.dispatch, folders: {} } });
-		const onChangeMock = jest.fn();
-		const { user } = setupTest(
+
+	beforeEach(() => {
+		store = configureStore({ reducer: combineReducers(reducers) });
+		editor = generateEditor({ context: { dispatch: store.dispatch, folders: {} } });
+		onChangeMock.mockClear();
+		mockSearchOptions.mockClear();
+	});
+
+	it('renders the component', () => {
+		setupTest(
 			<EditorResourceComponent
-				placeholder={'Test'}
+				placeholder="Test"
 				editorId={editor.id}
 				onChange={onChangeMock}
 				onSearchOptions={mockSearchOptions}
 				resourcesValue={[]}
-				warningLabel={''}
-				singleWarningLabel={''}
-				invalidInputErrorLabel={'Invalid input'}
+				warningLabel=""
+				singleWarningLabel=""
+				invalidInputErrorLabel="Invalid input"
 			/>,
 			{ store }
 		);
 
-		const resourceInput = screen.getByRole('textbox', { name: 'Test' });
-		await user.type(resourceInput, 'aaaaaa');
-		const dropdown = await screen.findByTestId(TEST_SELECTORS.DROPDOWN);
-		await user.keyboard('[Enter]');
-
-		expect(dropdown).not.toBeInTheDocument();
-		expect(resourceInput).toHaveValue('');
+		expect(screen.getByPlaceholderText('Test')).toBeInTheDocument();
 	});
 
-	it('should not remove current chips after selecting the first option with Enter', async () => {
-		const store = configureStore({ reducer: combineReducers(reducers) });
-		const editor = generateEditor({ context: { dispatch: store.dispatch, folders: {} } });
-		const onChangeMock = jest.fn();
-		const resource1 = {
-			label: 'My resource 1',
-			email: 'myresource@test.com'
-		};
+	it('allows adding a valid resource via search', async () => {
 		const { user } = setupTest(
 			<EditorResourceComponent
-				placeholder={'Test'}
+				placeholder="Test"
 				editorId={editor.id}
 				onChange={onChangeMock}
 				onSearchOptions={mockSearchOptions}
-				resourcesValue={[resource1]}
-				warningLabel={''}
-				singleWarningLabel={''}
-				invalidInputErrorLabel={'Invalid input'}
+				resourcesValue={[]}
+				warningLabel=""
+				singleWarningLabel=""
+				invalidInputErrorLabel="Invalid input"
 			/>,
 			{ store }
 		);
 
-		const resourceInput = screen.getByRole('textbox', { name: 'Test' });
-		await user.type(resourceInput, 'aaaaaa');
-		const dropdown = await screen.findByTestId(TEST_SELECTORS.DROPDOWN);
+		const input = screen.getByPlaceholderText('Test');
+
+		await user.type(input, 'meeting-room');
+		await waitFor(() => expect(mockSearchOptions).toHaveBeenCalledWith('meeting-room'));
+
+		await user.keyboard('{Enter}');
+
+		await waitFor(() => {
+			expect(onChangeMock).toHaveBeenCalledTimes(1);
+			const [resources] = onChangeMock.mock.calls[0];
+			expect(resources[0]).toMatchObject({
+				label: 'Resource: meeting-room',
+				email: 'resource@example.com'
+			});
+		});
+	});
+
+	it('adds invalid chip manually and shows error', async () => {
+		const { user } = setupTest(
+			<EditorResourceComponent
+				placeholder="Test"
+				editorId={editor.id}
+				onChange={onChangeMock}
+				onSearchOptions={mockSearchOptions}
+				resourcesValue={[]}
+				warningLabel=""
+				singleWarningLabel=""
+				invalidInputErrorLabel="Invalid input"
+			/>,
+			{ store }
+		);
+
+		const input = screen.getByPlaceholderText('Test');
+		await user.type(input, 'unknown-resource');
+		await user.keyboard('{Enter}');
+
+		await waitFor(() => {
+			expect(screen.getByText('Invalid input')).toBeInTheDocument();
+		});
+	});
+
+	it('prevents duplicate entries onChange', async () => {
+		const resource: Resource = {
+			id: 'r1',
+			label: 'Room-A',
+			email: 'rooma@example.com',
+			type: 'Location'
+		};
+
+		const { user } = setupTest(
+			<EditorResourceComponent
+				placeholder="Test"
+				editorId={editor.id}
+				onChange={onChangeMock}
+				onSearchOptions={mockSearchOptions}
+				resourcesValue={[resource]}
+				warningLabel=""
+				singleWarningLabel=""
+				invalidInputErrorLabel="Invalid input"
+			/>,
+			{ store }
+		);
+
+		const input = screen.getByPlaceholderText('Test');
+		await user.type(input, 'Room-A');
+		await user.keyboard('{Enter}');
+
+		await waitFor(() => {
+			expect(onChangeMock).toHaveBeenCalled();
+			const [chips] = onChangeMock.mock.calls.at(-1)!;
+			expect(chips).toHaveLength(1);
+		});
+	});
+
+	it('should not add resource on Enter key if input is empty', async () => {
+		const { user } = setupTest(
+			<EditorResourceComponent
+				placeholder="Test"
+				editorId={editor.id}
+				onChange={onChangeMock}
+				onSearchOptions={mockSearchOptions}
+				resourcesValue={[]}
+				warningLabel=""
+				singleWarningLabel=""
+				invalidInputErrorLabel="Invalid input"
+			/>,
+			{ store }
+		);
+
+		const input = screen.getByPlaceholderText('Test');
 		await user.keyboard('[Enter]');
-		expect(dropdown).not.toBeInTheDocument();
-		expect(onChangeMock).toHaveBeenCalledWith([
-			resource1,
-			expect.objectContaining({ email: 'mynewresource@test.com' })
-		]);
+
+		expect(onChangeMock).not.toHaveBeenCalled();
+		expect(screen.queryByText('Invalid input')).not.toBeInTheDocument();
+	});
+
+	it('should clear input and options after selecting a resource', async () => {
+		const { user } = setupTest(
+			<EditorResourceComponent
+				placeholder="Test"
+				editorId={editor.id}
+				onChange={onChangeMock}
+				onSearchOptions={mockSearchOptions}
+				resourcesValue={[]}
+				warningLabel=""
+				singleWarningLabel=""
+				invalidInputErrorLabel="Invalid input"
+			/>,
+			{ store }
+		);
+
+		const input = screen.getByPlaceholderText('Test');
+		await user.type(input, 'meeting-room');
+		await waitFor(() => expect(mockSearchOptions).toHaveBeenCalledWith('meeting-room'));
+
+		await user.keyboard('{Enter}');
+
+		expect(input).toHaveValue('');
+		expect(screen.queryByText('Resource: meeting-room')).not.toBeInTheDocument();
+	});
+
+	it('should select the first option when user press Enter', async () => {
+		const { user } = setupTest(
+			<EditorResourceComponent
+				placeholder="Test"
+				editorId={editor.id}
+				onChange={onChangeMock}
+				onSearchOptions={mockSearchOptions}
+				resourcesValue={[]}
+				warningLabel=""
+				singleWarningLabel=""
+				invalidInputErrorLabel="Invalid input"
+			/>,
+			{ store }
+		);
+
+		const input = screen.getByPlaceholderText('Test');
+		await user.type(input, 'meeting-room');
+		await waitFor(() => expect(mockSearchOptions).toHaveBeenCalledWith('meeting-room'));
+
+		await user.keyboard('{Enter}');
+
+		expect(onChangeMock).toHaveBeenCalled();
+		expect(input).toHaveValue('');
 	});
 });

--- a/src/view/editor/parts/tests/editor-resource-component.test.tsx
+++ b/src/view/editor/parts/tests/editor-resource-component.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 
 import { configureStore, combineReducers } from '@reduxjs/toolkit';
-import { screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 
 import { generateEditor } from '../../../../commons/editor-generator';
 import { reducers } from '../../../../store/redux';
@@ -53,6 +53,7 @@ describe('EditorResourceComponent', () => {
 				warningLabel=""
 				singleWarningLabel=""
 				invalidInputErrorLabel="Invalid input"
+				duplicateChipsErrorLabel={'Duplicate input'}
 			/>,
 			{ store }
 		);
@@ -73,6 +74,7 @@ describe('EditorResourceComponent', () => {
 				warningLabel=""
 				singleWarningLabel=""
 				invalidInputErrorLabel="Invalid input"
+				duplicateChipsErrorLabel={'Duplicate input'}
 			/>,
 			{ store }
 		);
@@ -107,6 +109,7 @@ describe('EditorResourceComponent', () => {
 				warningLabel=""
 				singleWarningLabel=""
 				invalidInputErrorLabel="Invalid input"
+				duplicateChipsErrorLabel={'Duplicate input'}
 			/>,
 			{ store }
 		);
@@ -132,6 +135,7 @@ describe('EditorResourceComponent', () => {
 				warningLabel=""
 				singleWarningLabel=""
 				invalidInputErrorLabel="Invalid input"
+				duplicateChipsErrorLabel={'Duplicate input'}
 			/>,
 			{ store }
 		);
@@ -168,6 +172,7 @@ describe('EditorResourceComponent', () => {
 				warningLabel=""
 				singleWarningLabel=""
 				invalidInputErrorLabel="Invalid input"
+				duplicateChipsErrorLabel={'Duplicate input'}
 			/>,
 			{ store }
 		);
@@ -189,6 +194,7 @@ describe('EditorResourceComponent', () => {
 				warningLabel=""
 				singleWarningLabel=""
 				invalidInputErrorLabel="Invalid input"
+				duplicateChipsErrorLabel={'Duplicate input'}
 			/>,
 			{ store }
 		);
@@ -236,6 +242,7 @@ describe('EditorResourceComponent', () => {
 				warningLabel=""
 				singleWarningLabel=""
 				invalidInputErrorLabel="Invalid input"
+				duplicateChipsErrorLabel={'Duplicate input'}
 			/>,
 			{ store }
 		);
@@ -269,6 +276,7 @@ describe('EditorResourceComponent', () => {
 				warningLabel=""
 				singleWarningLabel=""
 				invalidInputErrorLabel="Invalid input"
+				duplicateChipsErrorLabel={'Duplicate input'}
 			/>,
 			{ store }
 		);
@@ -292,6 +300,7 @@ describe('EditorResourceComponent', () => {
 				warningLabel=""
 				singleWarningLabel=""
 				invalidInputErrorLabel="Invalid input"
+				duplicateChipsErrorLabel={'Duplicate input'}
 			/>,
 			{ store }
 		);
@@ -317,6 +326,7 @@ describe('EditorResourceComponent', () => {
 				warningLabel=""
 				singleWarningLabel=""
 				invalidInputErrorLabel="Invalid input"
+				duplicateChipsErrorLabel={'Duplicate input'}
 			/>,
 			{ store }
 		);
@@ -340,6 +350,41 @@ describe('EditorResourceComponent', () => {
 			const [resources] = onChangeMock.mock.calls[0];
 			expect(resources[0]).toMatchObject({
 				label: 'UpdatedResource',
+				email: ''
+			});
+		});
+	});
+
+	it('should add resource chip when user presses NumberPadEnter after typing', async () => {
+		const { user } = setupTest(
+			<EditorResourceComponent
+				placeholder="Test"
+				editorId={editor.id}
+				onChange={onChangeMock}
+				onSearchOptions={mockSearchOptions}
+				resourcesValue={[]}
+				warningLabel=""
+				singleWarningLabel=""
+				invalidInputErrorLabel="Invalid input"
+				duplicateChipsErrorLabel={'Duplicate input'}
+			/>,
+			{ store }
+		);
+
+		const input = screen.getByPlaceholderText('Test');
+		await user.type(input, 'DefaultResource');
+		await waitFor(() => expect(mockSearchOptions).toHaveBeenCalledWith('DefaultResource'));
+
+		const dropDownItem = await screen.findByTestId('dropdown-item');
+		expect(dropDownItem).toHaveTextContent('DefaultResource');
+
+		fireEvent.keyDown(input, { code: 'NumpadEnter' });
+
+		await waitFor(async () => {
+			expect(onChangeMock).toHaveBeenCalledTimes(1);
+			const [resources] = onChangeMock.mock.calls[0];
+			expect(resources[0]).toMatchObject({
+				label: 'DefaultResource',
 				email: ''
 			});
 		});

--- a/src/view/editor/parts/tests/editor-resource-component.test.tsx
+++ b/src/view/editor/parts/tests/editor-resource-component.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 
 import { configureStore, combineReducers } from '@reduxjs/toolkit';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 
 import { generateEditor } from '../../../../commons/editor-generator';
 import { reducers } from '../../../../store/redux';
@@ -60,6 +60,33 @@ describe('EditorResourceComponent', () => {
 		expect(screen.getByPlaceholderText('Test')).toBeInTheDocument();
 		const chip = screen.getByTestId('chip');
 		expect(chip).toHaveTextContent('DefaultResource');
+	});
+
+	it('renders an invalid resource chip with error styles', async () => {
+		setupTest(
+			<EditorResourceComponent
+				placeholder="Test"
+				editorId={editor.id}
+				onChange={jest.fn()}
+				onSearchOptions={jest.fn()}
+				resourcesValue={[
+					{
+						id: '123',
+						label: 'error-resource',
+						email: '',
+						type: 'Location'
+					}
+				]}
+				warningLabel=""
+				singleWarningLabel=""
+				invalidInputErrorLabel=""
+			/>,
+			{ store }
+		);
+
+		const chip = await screen.findByTestId('chip');
+		expect(chip).toHaveTextContent('error-resource');
+		expect(await within(chip).findByTestId('icon: AlertCircleOutline')).toBeInTheDocument();
 	});
 
 	it('allows adding a valid resource via search', async () => {

--- a/src/view/editor/parts/tests/editor-resource-component.test.tsx
+++ b/src/view/editor/parts/tests/editor-resource-component.test.tsx
@@ -306,4 +306,68 @@ describe('EditorResourceComponent', () => {
 			expect(screen.getByTestId('dropdown-options-loader')).toBeInTheDocument();
 		});
 	});
+
+	it('shows edit action in added chip', async () => {
+		const { user } = setupTest(
+			<EditorResourceComponent
+				placeholder="Test"
+				editorId={editor.id}
+				onChange={onChangeMock}
+				onSearchOptions={mockSearchOptions}
+				resourcesValue={[defaultResource]}
+				warningLabel=""
+				singleWarningLabel=""
+				invalidInputErrorLabel="Invalid input"
+			/>,
+			{ store }
+		);
+
+		const chip = screen.getByTestId('chip');
+		expect(chip).toHaveTextContent('DefaultResource');
+
+		const editButton = within(chip).getByTestId('icon: EditOutline');
+		expect(editButton).toBeInTheDocument();
+
+		await user.click(editButton);
+		expect(onChangeMock).toHaveBeenCalledTimes(0); // No change on edit click
+	});
+
+	it('triggers onChange when user commit edit using edit chip action', async () => {
+		const { user } = setupTest(
+			<EditorResourceComponent
+				placeholder="Test"
+				editorId={editor.id}
+				onChange={onChangeMock}
+				onSearchOptions={mockSearchOptions}
+				resourcesValue={[defaultResource]}
+				warningLabel=""
+				singleWarningLabel=""
+				invalidInputErrorLabel="Invalid input"
+			/>,
+			{ store }
+		);
+
+		const chip = screen.getByTestId('chip');
+		expect(chip).toHaveTextContent('DefaultResource');
+
+		const editButton = within(chip).getByTestId('icon: EditOutline');
+		expect(editButton).toBeInTheDocument();
+
+		await user.click(editButton);
+		expect(onChangeMock).toHaveBeenCalledTimes(0);
+
+		const input = screen.getByPlaceholderText('Test');
+
+		await user.clear(input);
+		await user.type(input, 'UpdatedResource');
+		await user.keyboard('{Enter}');
+		await waitFor(() => {
+			expect(onChangeMock).toHaveBeenCalledTimes(1);
+			const [resources] = onChangeMock.mock.calls[0];
+			expect(resources[0]).toMatchObject({
+				label: 'UpdatedResource',
+				email: ''
+			});
+		});
+	});
 });

--- a/src/view/editor/parts/tests/editor-resource-component.test.tsx
+++ b/src/view/editor/parts/tests/editor-resource-component.test.tsx
@@ -62,33 +62,6 @@ describe('EditorResourceComponent', () => {
 		expect(chip).toHaveTextContent('DefaultResource');
 	});
 
-	it('renders an invalid resource chip with error styles', async () => {
-		setupTest(
-			<EditorResourceComponent
-				placeholder="Test"
-				editorId={editor.id}
-				onChange={jest.fn()}
-				onSearchOptions={jest.fn()}
-				resourcesValue={[
-					{
-						id: '123',
-						label: 'error-resource',
-						email: '',
-						type: 'Location'
-					}
-				]}
-				warningLabel=""
-				singleWarningLabel=""
-				invalidInputErrorLabel=""
-			/>,
-			{ store }
-		);
-
-		const chip = await screen.findByTestId('chip');
-		expect(chip).toHaveTextContent('error-resource');
-		expect(await within(chip).findByTestId('icon: AlertCircleOutline')).toBeInTheDocument();
-	});
-
 	it('allows adding a valid resource via search', async () => {
 		const { user } = setupTest(
 			<EditorResourceComponent

--- a/src/view/editor/parts/tests/editor-resource-component.test.tsx
+++ b/src/view/editor/parts/tests/editor-resource-component.test.tsx
@@ -147,7 +147,7 @@ describe('EditorResourceComponent', () => {
 		});
 	});
 
-	it('prevents duplicate entries onChange', async () => {
+	it('allows duplicate entries onChange', async () => {
 		const { user } = setupTest(
 			<EditorResourceComponent
 				placeholder="Test"
@@ -178,7 +178,7 @@ describe('EditorResourceComponent', () => {
 		await waitFor(() => {
 			expect(onChangeMock).toHaveBeenCalled();
 			const [chips] = onChangeMock.mock.calls.at(-1)!;
-			expect(chips).toHaveLength(1);
+			expect(chips).toHaveLength(2);
 			expect(dropDownItem).not.toBeInTheDocument();
 		});
 	});

--- a/src/view/editor/parts/tests/editor-resource-component.test.tsx
+++ b/src/view/editor/parts/tests/editor-resource-component.test.tsx
@@ -21,16 +21,17 @@ describe('EditorResourceComponent', () => {
 	let editor: ReturnType<typeof generateEditor>;
 	const onChangeMock = jest.fn();
 
-	const mockSearchOptions = jest.fn(async (text: string) => [
+	const defaultResource: Resource = {
+		id: 'r1',
+		label: 'DefaultResource',
+		email: 'default@example.com',
+		type: 'Location'
+	};
+	const mockSearchOptions = jest.fn(async (_text: string) => [
 		{
 			id: '1',
-			label: `Resource: ${text}`,
-			value: {
-				id: 'res1',
-				label: `Resource: ${text}`,
-				email: 'resource@example.com',
-				type: 'Location'
-			}
+			label: 'DefaultResource',
+			value: defaultResource
 		}
 	]);
 
@@ -41,14 +42,14 @@ describe('EditorResourceComponent', () => {
 		mockSearchOptions.mockClear();
 	});
 
-	it('renders the component', () => {
+	it('renders the component with provided resources', () => {
 		setupTest(
 			<EditorResourceComponent
 				placeholder="Test"
 				editorId={editor.id}
 				onChange={onChangeMock}
-				onSearchOptions={mockSearchOptions}
-				resourcesValue={[]}
+				onSearchOptions={() => Promise.resolve([])}
+				resourcesValue={[defaultResource]}
 				warningLabel=""
 				singleWarningLabel=""
 				invalidInputErrorLabel="Invalid input"
@@ -57,6 +58,8 @@ describe('EditorResourceComponent', () => {
 		);
 
 		expect(screen.getByPlaceholderText('Test')).toBeInTheDocument();
+		const chip = screen.getByTestId('chip');
+		expect(chip).toHaveTextContent('DefaultResource');
 	});
 
 	it('allows adding a valid resource via search', async () => {
@@ -75,19 +78,21 @@ describe('EditorResourceComponent', () => {
 		);
 
 		const input = screen.getByPlaceholderText('Test');
+		await user.type(input, 'DefaultResource');
+		await waitFor(() => expect(mockSearchOptions).toHaveBeenCalledWith('DefaultResource'));
 
-		await user.type(input, 'meeting-room');
-		await waitFor(() => expect(mockSearchOptions).toHaveBeenCalledWith('meeting-room'));
-
+		const dropDownItem = await screen.findByTestId('dropdown-item');
+		expect(dropDownItem).toHaveTextContent('DefaultResource');
 		await user.keyboard('{Enter}');
 
-		await waitFor(() => {
+		await waitFor(async () => {
 			expect(onChangeMock).toHaveBeenCalledTimes(1);
 			const [resources] = onChangeMock.mock.calls[0];
 			expect(resources[0]).toMatchObject({
-				label: 'Resource: meeting-room',
-				email: 'resource@example.com'
+				label: 'DefaultResource',
+				email: 'default@example.com'
 			});
+			expect(dropDownItem).not.toBeInTheDocument();
 		});
 	});
 
@@ -116,20 +121,13 @@ describe('EditorResourceComponent', () => {
 	});
 
 	it('prevents duplicate entries onChange', async () => {
-		const resource: Resource = {
-			id: 'r1',
-			label: 'Room-A',
-			email: 'rooma@example.com',
-			type: 'Location'
-		};
-
 		const { user } = setupTest(
 			<EditorResourceComponent
 				placeholder="Test"
 				editorId={editor.id}
 				onChange={onChangeMock}
 				onSearchOptions={mockSearchOptions}
-				resourcesValue={[resource]}
+				resourcesValue={[defaultResource]}
 				warningLabel=""
 				singleWarningLabel=""
 				invalidInputErrorLabel="Invalid input"
@@ -137,14 +135,24 @@ describe('EditorResourceComponent', () => {
 			{ store }
 		);
 
+		// existing default resource chip
+		const chip = screen.getByTestId('chip');
+		expect(chip).toHaveTextContent('DefaultResource');
+
+		// try to add the same resource again
 		const input = screen.getByPlaceholderText('Test');
-		await user.type(input, 'Room-A');
+		await user.type(input, 'DefaultResource');
+
+		const dropDownItem = await screen.findByTestId('dropdown-item');
+		expect(dropDownItem).toHaveTextContent('DefaultResource');
+
 		await user.keyboard('{Enter}');
 
 		await waitFor(() => {
 			expect(onChangeMock).toHaveBeenCalled();
 			const [chips] = onChangeMock.mock.calls.at(-1)!;
 			expect(chips).toHaveLength(1);
+			expect(dropDownItem).not.toBeInTheDocument();
 		});
 	});
 
@@ -163,14 +171,13 @@ describe('EditorResourceComponent', () => {
 			{ store }
 		);
 
-		const input = screen.getByPlaceholderText('Test');
 		await user.keyboard('[Enter]');
 
 		expect(onChangeMock).not.toHaveBeenCalled();
 		expect(screen.queryByText('Invalid input')).not.toBeInTheDocument();
 	});
 
-	it('should clear input and options after selecting a resource', async () => {
+	it('should clear options after selecting a resource', async () => {
 		const { user } = setupTest(
 			<EditorResourceComponent
 				placeholder="Test"
@@ -186,22 +193,44 @@ describe('EditorResourceComponent', () => {
 		);
 
 		const input = screen.getByPlaceholderText('Test');
-		await user.type(input, 'meeting-room');
-		await waitFor(() => expect(mockSearchOptions).toHaveBeenCalledWith('meeting-room'));
+		await user.type(input, 'DefaultResource');
+		await waitFor(() => expect(mockSearchOptions).toHaveBeenCalledWith('DefaultResource'));
+
+		const dropDownItem = await screen.findByTestId('dropdown-item');
+		expect(dropDownItem).toHaveTextContent('DefaultResource');
 
 		await user.keyboard('{Enter}');
 
-		expect(input).toHaveValue('');
-		expect(screen.queryByText('Resource: meeting-room')).not.toBeInTheDocument();
+		expect(dropDownItem).not.toBeInTheDocument();
 	});
 
 	it('should select the first option when user press Enter', async () => {
+		const resource2: Resource = {
+			id: 'r2',
+			label: 'Room-B',
+			email: 'roomb@example.com',
+			type: 'Location'
+		};
+
+		const mockSearchOptions2 = jest.fn(async (_text: string) => [
+			{
+				id: '1',
+				label: 'DefaultResource',
+				value: defaultResource
+			},
+			{
+				id: '2',
+				label: 'Resource2',
+				value: resource2
+			}
+		]);
+
 		const { user } = setupTest(
 			<EditorResourceComponent
 				placeholder="Test"
 				editorId={editor.id}
 				onChange={onChangeMock}
-				onSearchOptions={mockSearchOptions}
+				onSearchOptions={mockSearchOptions2}
 				resourcesValue={[]}
 				warningLabel=""
 				singleWarningLabel=""
@@ -211,12 +240,20 @@ describe('EditorResourceComponent', () => {
 		);
 
 		const input = screen.getByPlaceholderText('Test');
-		await user.type(input, 'meeting-room');
-		await waitFor(() => expect(mockSearchOptions).toHaveBeenCalledWith('meeting-room'));
+		await user.type(input, 'Resource');
+
+		const dropDownItems = await screen.findAllByTestId('dropdown-item');
+		expect(dropDownItems).toHaveLength(2);
 
 		await user.keyboard('{Enter}');
 
-		expect(onChangeMock).toHaveBeenCalled();
-		expect(input).toHaveValue('');
+		await waitFor(async () => {
+			expect(onChangeMock).toHaveBeenCalledTimes(1);
+			const [resources] = onChangeMock.mock.calls[0];
+			expect(resources[0]).toMatchObject({
+				label: defaultResource.label,
+				email: defaultResource.email
+			});
+		});
 	});
 });

--- a/src/view/editor/parts/tests/editor-resource-component.test.tsx
+++ b/src/view/editor/parts/tests/editor-resource-component.test.tsx
@@ -318,6 +318,36 @@ describe('EditorResourceComponent', () => {
 					placeholder="Test"
 					editorId={editor.id}
 					onChange={onChangeMock}
+					onSearchOptions={() => Promise.resolve([])}
+					resourcesValue={[]}
+					warningLabel=""
+					singleWarningLabel=""
+					invalidInputErrorLabel="Invalid input"
+					duplicateChipsErrorLabel={'Duplicate input'}
+				/>,
+				{ store }
+			);
+
+			const input = screen.getByPlaceholderText('Test');
+			await user.type(input, 'resource1');
+
+			fireEvent.keyDown(input, { code: 'NumpadEnter' });
+
+			await waitFor(async () => {
+				expect(onChangeMock).toHaveBeenCalledTimes(1);
+				const [resources] = onChangeMock.mock.calls[0];
+				expect(resources[0]).toMatchObject({
+					label: 'resource1',
+					email: ''
+				});
+			});
+		});
+		it('should add resource chip when user presses Enter after typing exact match', async () => {
+			const { user } = setupTest(
+				<EditorResourceComponent
+					placeholder="Test"
+					editorId={editor.id}
+					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[]}
 					warningLabel=""
@@ -330,19 +360,18 @@ describe('EditorResourceComponent', () => {
 
 			const input = screen.getByPlaceholderText('Test');
 			await user.type(input, 'DefaultResource');
-			await waitFor(() => expect(mockSearchOptions).toHaveBeenCalledWith('DefaultResource'));
 
 			const dropDownItem = await screen.findByTestId('dropdown-item');
 			expect(dropDownItem).toHaveTextContent('DefaultResource');
 
-			fireEvent.keyDown(input, { code: 'NumpadEnter' });
+			await user.keyboard('{Enter}');
 
 			await waitFor(async () => {
 				expect(onChangeMock).toHaveBeenCalledTimes(1);
 				const [resources] = onChangeMock.mock.calls[0];
 				expect(resources[0]).toMatchObject({
 					label: 'DefaultResource',
-					email: ''
+					email: defaultResource.email // Ensure email is included
 				});
 			});
 		});

--- a/src/view/editor/parts/tests/editor-resource-component.test.tsx
+++ b/src/view/editor/parts/tests/editor-resource-component.test.tsx
@@ -43,6 +43,7 @@ describe('EditorResourceComponent', () => {
 				resourcesValue={[]}
 				warningLabel={''}
 				singleWarningLabel={''}
+				invalidInputErrorLabel={'Invalid input'}
 			/>,
 			{ store }
 		);
@@ -73,6 +74,7 @@ describe('EditorResourceComponent', () => {
 				resourcesValue={[resource1]}
 				warningLabel={''}
 				singleWarningLabel={''}
+				invalidInputErrorLabel={'Invalid input'}
 			/>,
 			{ store }
 		);

--- a/src/view/editor/parts/tests/editor-resource-component.test.tsx
+++ b/src/view/editor/parts/tests/editor-resource-component.test.tsx
@@ -83,7 +83,7 @@ describe('EditorResourceComponent', () => {
 
 		const dropDownItem = await screen.findByTestId('dropdown-item');
 		expect(dropDownItem).toHaveTextContent('DefaultResource');
-		await user.keyboard('{Enter}');
+		await user.keyboard('{Control>}{Enter}{/Control}');
 
 		await waitFor(async () => {
 			expect(onChangeMock).toHaveBeenCalledTimes(1);
@@ -199,7 +199,7 @@ describe('EditorResourceComponent', () => {
 		const dropDownItem = await screen.findByTestId('dropdown-item');
 		expect(dropDownItem).toHaveTextContent('DefaultResource');
 
-		await user.keyboard('{Enter}');
+		await user.keyboard('{Control>}{Enter}{/Control}');
 
 		expect(dropDownItem).not.toBeInTheDocument();
 	});
@@ -245,7 +245,7 @@ describe('EditorResourceComponent', () => {
 		const dropDownItems = await screen.findAllByTestId('dropdown-item');
 		expect(dropDownItems).toHaveLength(2);
 
-		await user.keyboard('{Enter}');
+		await user.keyboard('{Control>}{Enter}{/Control}');
 
 		await waitFor(async () => {
 			expect(onChangeMock).toHaveBeenCalledTimes(1);

--- a/src/view/editor/parts/tests/editor-resource-component.test.tsx
+++ b/src/view/editor/parts/tests/editor-resource-component.test.tsx
@@ -256,4 +256,27 @@ describe('EditorResourceComponent', () => {
 			});
 		});
 	});
+
+	it('shows loader while searching for options', async () => {
+		const { user } = setupTest(
+			<EditorResourceComponent
+				placeholder="Test"
+				editorId={editor.id}
+				onChange={onChangeMock}
+				onSearchOptions={() => new Promise((resolve) => setTimeout(() => resolve([]), 1000))}
+				resourcesValue={[]}
+				warningLabel=""
+				singleWarningLabel=""
+				invalidInputErrorLabel="Invalid input"
+			/>,
+			{ store }
+		);
+
+		const input = screen.getByPlaceholderText('Test');
+		await user.type(input, 'Meeting Room');
+
+		await waitFor(() => {
+			expect(screen.getByTestId('dropdown-options-loader')).toBeInTheDocument();
+		});
+	});
 });

--- a/src/view/editor/parts/tests/editor-resource-component.test.tsx
+++ b/src/view/editor/parts/tests/editor-resource-component.test.tsx
@@ -42,351 +42,407 @@ describe('EditorResourceComponent', () => {
 		mockSearchOptions.mockClear();
 	});
 
-	it('renders the component with provided resources', () => {
-		setupTest(
-			<EditorResourceComponent
-				placeholder="Test"
-				editorId={editor.id}
-				onChange={onChangeMock}
-				onSearchOptions={() => Promise.resolve([])}
-				resourcesValue={[defaultResource]}
-				warningLabel=""
-				singleWarningLabel=""
-				invalidInputErrorLabel="Invalid input"
-				duplicateChipsErrorLabel={'Duplicate input'}
-			/>,
-			{ store }
-		);
+	describe('Initial Rendering', () => {
+		it('renders the component with provided resources', () => {
+			setupTest(
+				<EditorResourceComponent
+					placeholder="Test"
+					editorId={editor.id}
+					onChange={onChangeMock}
+					onSearchOptions={() => Promise.resolve([])}
+					resourcesValue={[defaultResource]}
+					warningLabel=""
+					singleWarningLabel=""
+					invalidInputErrorLabel="Invalid input"
+					duplicateChipsErrorLabel={'Duplicate input'}
+				/>,
+				{ store }
+			);
 
-		expect(screen.getByPlaceholderText('Test')).toBeInTheDocument();
-		const chip = screen.getByTestId('chip');
-		expect(chip).toHaveTextContent('DefaultResource');
+			expect(screen.getByPlaceholderText('Test')).toBeInTheDocument();
+			const chip = screen.getByTestId('chip');
+			expect(chip).toHaveTextContent('DefaultResource');
+		});
 	});
 
-	it('allows adding a valid resource via search', async () => {
-		const { user } = setupTest(
-			<EditorResourceComponent
-				placeholder="Test"
-				editorId={editor.id}
-				onChange={onChangeMock}
-				onSearchOptions={mockSearchOptions}
-				resourcesValue={[]}
-				warningLabel=""
-				singleWarningLabel=""
-				invalidInputErrorLabel="Invalid input"
-				duplicateChipsErrorLabel={'Duplicate input'}
-			/>,
-			{ store }
-		);
+	describe('Resource Selection', () => {
+		it('allows adding a valid resource via search', async () => {
+			const { user } = setupTest(
+				<EditorResourceComponent
+					placeholder="Test"
+					editorId={editor.id}
+					onChange={onChangeMock}
+					onSearchOptions={mockSearchOptions}
+					resourcesValue={[]}
+					warningLabel=""
+					singleWarningLabel=""
+					invalidInputErrorLabel="Invalid input"
+					duplicateChipsErrorLabel={'Duplicate input'}
+				/>,
+				{ store }
+			);
 
-		const input = screen.getByPlaceholderText('Test');
-		await user.type(input, 'DefaultResource');
-		await waitFor(() => expect(mockSearchOptions).toHaveBeenCalledWith('DefaultResource'));
+			const input = screen.getByPlaceholderText('Test');
+			await user.type(input, 'DefaultResource');
+			await waitFor(() => expect(mockSearchOptions).toHaveBeenCalledWith('DefaultResource'));
 
-		const dropDownItem = await screen.findByTestId('dropdown-item');
-		expect(dropDownItem).toHaveTextContent('DefaultResource');
-		await user.keyboard('{Control>}{Enter}{/Control}');
+			const dropDownItem = await screen.findByTestId('dropdown-item');
+			expect(dropDownItem).toHaveTextContent('DefaultResource');
+			await user.keyboard('{Control>}{Enter}{/Control}');
 
-		await waitFor(async () => {
-			expect(onChangeMock).toHaveBeenCalledTimes(1);
-			const [resources] = onChangeMock.mock.calls[0];
-			expect(resources[0]).toMatchObject({
-				label: 'DefaultResource',
-				email: 'default@example.com'
+			await waitFor(async () => {
+				expect(onChangeMock).toHaveBeenCalledTimes(1);
+				const [resources] = onChangeMock.mock.calls[0];
+				expect(resources[0]).toMatchObject({
+					label: 'DefaultResource',
+					email: 'default@example.com'
+				});
+				expect(dropDownItem).not.toBeInTheDocument();
 			});
+		});
+
+		it('should select the first option when user press Control+Enter', async () => {
+			const resource2: Resource = {
+				id: 'r2',
+				label: 'Room-B',
+				email: 'roomb@example.com',
+				type: 'Location'
+			};
+
+			const mockSearchOptions2 = jest.fn(async (_text: string) => [
+				{
+					id: '1',
+					label: 'DefaultResource',
+					value: defaultResource
+				},
+				{
+					id: '2',
+					label: 'Resource2',
+					value: resource2
+				}
+			]);
+
+			const { user } = setupTest(
+				<EditorResourceComponent
+					placeholder="Test"
+					editorId={editor.id}
+					onChange={onChangeMock}
+					onSearchOptions={mockSearchOptions2}
+					resourcesValue={[]}
+					warningLabel=""
+					singleWarningLabel=""
+					invalidInputErrorLabel="Invalid input"
+					duplicateChipsErrorLabel={'Duplicate input'}
+				/>,
+				{ store }
+			);
+
+			const input = screen.getByPlaceholderText('Test');
+			await user.type(input, 'Resource');
+
+			const dropDownItems = await screen.findAllByTestId('dropdown-item');
+			expect(dropDownItems).toHaveLength(2);
+
+			await user.keyboard('{Control>}{Enter}{/Control}');
+
+			await waitFor(async () => {
+				expect(onChangeMock).toHaveBeenCalledTimes(1);
+				const [resources] = onChangeMock.mock.calls[0];
+				expect(resources[0]).toMatchObject({
+					label: defaultResource.label,
+					email: defaultResource.email
+				});
+			});
+		});
+
+		it('shows loader while searching for options', async () => {
+			const { user } = setupTest(
+				<EditorResourceComponent
+					placeholder="Test"
+					editorId={editor.id}
+					onChange={onChangeMock}
+					onSearchOptions={() => new Promise((resolve) => setTimeout(() => resolve([]), 1000))}
+					resourcesValue={[]}
+					warningLabel=""
+					singleWarningLabel=""
+					invalidInputErrorLabel="Invalid input"
+					duplicateChipsErrorLabel={'Duplicate input'}
+				/>,
+				{ store }
+			);
+
+			const input = screen.getByPlaceholderText('Test');
+			await user.type(input, 'Meeting Room');
+
+			await waitFor(() => {
+				expect(screen.getByTestId('dropdown-options-loader')).toBeInTheDocument();
+			});
+		});
+	});
+
+	describe('Input Validation', () => {
+		it('adds invalid chip manually and shows error', async () => {
+			const { user } = setupTest(
+				<EditorResourceComponent
+					placeholder="Test"
+					editorId={editor.id}
+					onChange={onChangeMock}
+					onSearchOptions={mockSearchOptions}
+					resourcesValue={[]}
+					warningLabel=""
+					singleWarningLabel=""
+					invalidInputErrorLabel="Invalid input"
+					duplicateChipsErrorLabel={'Duplicate input'}
+				/>,
+				{ store }
+			);
+			expect(screen.queryByText('Invalid input')).not.toBeInTheDocument();
+
+			const input = screen.getByPlaceholderText('Test');
+			await user.type(input, 'unknown-resource');
+			await user.keyboard('{Enter}');
+
+			await waitFor(() => {
+				expect(screen.getByText('Invalid input')).toBeInTheDocument();
+			});
+		});
+
+		it('should not add resource on Enter key if input is empty', async () => {
+			const { user } = setupTest(
+				<EditorResourceComponent
+					placeholder="Test"
+					editorId={editor.id}
+					onChange={onChangeMock}
+					onSearchOptions={mockSearchOptions}
+					resourcesValue={[]}
+					warningLabel=""
+					singleWarningLabel=""
+					invalidInputErrorLabel="Invalid input"
+					duplicateChipsErrorLabel={'Duplicate input'}
+				/>,
+				{ store }
+			);
+
+			await user.keyboard('[Enter]');
+
+			expect(onChangeMock).not.toHaveBeenCalled();
+			expect(screen.queryByText('Invalid input')).not.toBeInTheDocument();
+		});
+
+		it('shows duplicate error when adding a resource with the same id', async () => {
+			setupTest(
+				<EditorResourceComponent
+					placeholder="Test"
+					editorId={editor.id}
+					onChange={onChangeMock}
+					onSearchOptions={mockSearchOptions}
+					resourcesValue={[defaultResource, defaultResource]}
+					warningLabel=""
+					singleWarningLabel=""
+					invalidInputErrorLabel="Invalid input"
+					duplicateChipsErrorLabel={'Duplicate input'}
+				/>,
+				{ store }
+			);
+
+			await waitFor(async () => {
+				expect(screen.getByText('Duplicate input')).toBeInTheDocument();
+			});
+		});
+
+		it('shows invalid input error when there is at least one invalid input and multiple duplicate resource with the same id', async () => {
+			setupTest(
+				<EditorResourceComponent
+					placeholder="Test"
+					editorId={editor.id}
+					onChange={onChangeMock}
+					onSearchOptions={mockSearchOptions}
+					resourcesValue={[{ label: 'chip101', email: '' }, defaultResource, defaultResource]}
+					warningLabel=""
+					singleWarningLabel=""
+					invalidInputErrorLabel="Invalid input"
+					duplicateChipsErrorLabel={'Duplicate input'}
+				/>,
+				{ store }
+			);
+
+			await waitFor(() => {
+				expect(screen.getByText('Invalid input')).toBeInTheDocument();
+			});
+		});
+	});
+
+	describe('Duplicate Handling', () => {
+		it('allows duplicate entries onChange', async () => {
+			const { user } = setupTest(
+				<EditorResourceComponent
+					placeholder="Test"
+					editorId={editor.id}
+					onChange={onChangeMock}
+					onSearchOptions={mockSearchOptions}
+					resourcesValue={[defaultResource]}
+					warningLabel=""
+					singleWarningLabel=""
+					invalidInputErrorLabel="Invalid input"
+					duplicateChipsErrorLabel={'Duplicate input'}
+				/>,
+				{ store }
+			);
+
+			// existing default resource chip
+			const chip = screen.getByTestId('chip');
+			expect(chip).toHaveTextContent('DefaultResource');
+
+			// try to add the same resource again
+			const input = screen.getByPlaceholderText('Test');
+			await user.type(input, 'DefaultResource');
+
+			const dropDownItem = await screen.findByTestId('dropdown-item');
+			expect(dropDownItem).toHaveTextContent('DefaultResource');
+
+			await user.keyboard('{Enter}');
+
+			await waitFor(() => {
+				expect(onChangeMock).toHaveBeenCalled();
+				const [chips] = onChangeMock.mock.calls.at(-1)!;
+				expect(chips).toHaveLength(2);
+				expect(dropDownItem).not.toBeInTheDocument();
+			});
+		});
+	});
+
+	describe('Keyboard Interactions', () => {
+		it('should add resource chip when user presses NumberPadEnter after typing', async () => {
+			const { user } = setupTest(
+				<EditorResourceComponent
+					placeholder="Test"
+					editorId={editor.id}
+					onChange={onChangeMock}
+					onSearchOptions={mockSearchOptions}
+					resourcesValue={[]}
+					warningLabel=""
+					singleWarningLabel=""
+					invalidInputErrorLabel="Invalid input"
+					duplicateChipsErrorLabel={'Duplicate input'}
+				/>,
+				{ store }
+			);
+
+			const input = screen.getByPlaceholderText('Test');
+			await user.type(input, 'DefaultResource');
+			await waitFor(() => expect(mockSearchOptions).toHaveBeenCalledWith('DefaultResource'));
+
+			const dropDownItem = await screen.findByTestId('dropdown-item');
+			expect(dropDownItem).toHaveTextContent('DefaultResource');
+
+			fireEvent.keyDown(input, { code: 'NumpadEnter' });
+
+			await waitFor(async () => {
+				expect(onChangeMock).toHaveBeenCalledTimes(1);
+				const [resources] = onChangeMock.mock.calls[0];
+				expect(resources[0]).toMatchObject({
+					label: 'DefaultResource',
+					email: ''
+				});
+			});
+		});
+	});
+
+	describe('Chip Editing', () => {
+		it('shows edit action in added chip', async () => {
+			const { user } = setupTest(
+				<EditorResourceComponent
+					placeholder="Test"
+					editorId={editor.id}
+					onChange={onChangeMock}
+					onSearchOptions={mockSearchOptions}
+					resourcesValue={[defaultResource]}
+					warningLabel=""
+					singleWarningLabel=""
+					invalidInputErrorLabel="Invalid input"
+					duplicateChipsErrorLabel={'Duplicate input'}
+				/>,
+				{ store }
+			);
+
+			const chip = screen.getByTestId('chip');
+			expect(chip).toHaveTextContent('DefaultResource');
+
+			const editButton = within(chip).getByTestId('icon: EditOutline');
+			expect(editButton).toBeInTheDocument();
+
+			await user.click(editButton);
+			expect(onChangeMock).toHaveBeenCalledTimes(0); // No change on edit click
+		});
+
+		it('triggers onChange when user commit edit using edit chip action', async () => {
+			const { user } = setupTest(
+				<EditorResourceComponent
+					placeholder="Test"
+					editorId={editor.id}
+					onChange={onChangeMock}
+					onSearchOptions={mockSearchOptions}
+					resourcesValue={[defaultResource]}
+					warningLabel=""
+					singleWarningLabel=""
+					invalidInputErrorLabel="Invalid input"
+					duplicateChipsErrorLabel={'Duplicate input'}
+				/>,
+				{ store }
+			);
+
+			const chip = screen.getByTestId('chip');
+			expect(chip).toHaveTextContent('DefaultResource');
+
+			const editButton = within(chip).getByTestId('icon: EditOutline');
+			expect(editButton).toBeInTheDocument();
+
+			await user.click(editButton);
+			expect(onChangeMock).toHaveBeenCalledTimes(0);
+
+			const input = screen.getByPlaceholderText('Test');
+
+			await user.clear(input);
+			await user.type(input, 'UpdatedResource');
+			await user.keyboard('{Enter}');
+			await waitFor(() => {
+				expect(onChangeMock).toHaveBeenCalledTimes(1);
+				const [resources] = onChangeMock.mock.calls[0];
+				expect(resources[0]).toMatchObject({
+					label: 'UpdatedResource',
+					email: ''
+				});
+			});
+		});
+	});
+
+	describe('Options Management', () => {
+		it('should clear options after selecting a resource', async () => {
+			const { user } = setupTest(
+				<EditorResourceComponent
+					placeholder="Test"
+					editorId={editor.id}
+					onChange={onChangeMock}
+					onSearchOptions={mockSearchOptions}
+					resourcesValue={[]}
+					warningLabel=""
+					singleWarningLabel=""
+					invalidInputErrorLabel="Invalid input"
+					duplicateChipsErrorLabel={'Duplicate input'}
+				/>,
+				{ store }
+			);
+
+			const input = screen.getByPlaceholderText('Test');
+			await user.type(input, 'DefaultResource');
+			await waitFor(() => expect(mockSearchOptions).toHaveBeenCalledWith('DefaultResource'));
+
+			const dropDownItem = await screen.findByTestId('dropdown-item');
+			expect(dropDownItem).toHaveTextContent('DefaultResource');
+
+			await user.keyboard('{Control>}{Enter}{/Control}');
+
 			expect(dropDownItem).not.toBeInTheDocument();
-		});
-	});
-
-	it('adds invalid chip manually and shows error', async () => {
-		const { user } = setupTest(
-			<EditorResourceComponent
-				placeholder="Test"
-				editorId={editor.id}
-				onChange={onChangeMock}
-				onSearchOptions={mockSearchOptions}
-				resourcesValue={[]}
-				warningLabel=""
-				singleWarningLabel=""
-				invalidInputErrorLabel="Invalid input"
-				duplicateChipsErrorLabel={'Duplicate input'}
-			/>,
-			{ store }
-		);
-		expect(screen.queryByText('Invalid input')).not.toBeInTheDocument();
-
-		const input = screen.getByPlaceholderText('Test');
-		await user.type(input, 'unknown-resource');
-		await user.keyboard('{Enter}');
-
-		await waitFor(() => {
-			expect(screen.getByText('Invalid input')).toBeInTheDocument();
-		});
-	});
-
-	it('allows duplicate entries onChange', async () => {
-		const { user } = setupTest(
-			<EditorResourceComponent
-				placeholder="Test"
-				editorId={editor.id}
-				onChange={onChangeMock}
-				onSearchOptions={mockSearchOptions}
-				resourcesValue={[defaultResource]}
-				warningLabel=""
-				singleWarningLabel=""
-				invalidInputErrorLabel="Invalid input"
-				duplicateChipsErrorLabel={'Duplicate input'}
-			/>,
-			{ store }
-		);
-
-		// existing default resource chip
-		const chip = screen.getByTestId('chip');
-		expect(chip).toHaveTextContent('DefaultResource');
-
-		// try to add the same resource again
-		const input = screen.getByPlaceholderText('Test');
-		await user.type(input, 'DefaultResource');
-
-		const dropDownItem = await screen.findByTestId('dropdown-item');
-		expect(dropDownItem).toHaveTextContent('DefaultResource');
-
-		await user.keyboard('{Enter}');
-
-		await waitFor(() => {
-			expect(onChangeMock).toHaveBeenCalled();
-			const [chips] = onChangeMock.mock.calls.at(-1)!;
-			expect(chips).toHaveLength(2);
-			expect(dropDownItem).not.toBeInTheDocument();
-		});
-	});
-
-	it('should not add resource on Enter key if input is empty', async () => {
-		const { user } = setupTest(
-			<EditorResourceComponent
-				placeholder="Test"
-				editorId={editor.id}
-				onChange={onChangeMock}
-				onSearchOptions={mockSearchOptions}
-				resourcesValue={[]}
-				warningLabel=""
-				singleWarningLabel=""
-				invalidInputErrorLabel="Invalid input"
-				duplicateChipsErrorLabel={'Duplicate input'}
-			/>,
-			{ store }
-		);
-
-		await user.keyboard('[Enter]');
-
-		expect(onChangeMock).not.toHaveBeenCalled();
-		expect(screen.queryByText('Invalid input')).not.toBeInTheDocument();
-	});
-
-	it('should clear options after selecting a resource', async () => {
-		const { user } = setupTest(
-			<EditorResourceComponent
-				placeholder="Test"
-				editorId={editor.id}
-				onChange={onChangeMock}
-				onSearchOptions={mockSearchOptions}
-				resourcesValue={[]}
-				warningLabel=""
-				singleWarningLabel=""
-				invalidInputErrorLabel="Invalid input"
-				duplicateChipsErrorLabel={'Duplicate input'}
-			/>,
-			{ store }
-		);
-
-		const input = screen.getByPlaceholderText('Test');
-		await user.type(input, 'DefaultResource');
-		await waitFor(() => expect(mockSearchOptions).toHaveBeenCalledWith('DefaultResource'));
-
-		const dropDownItem = await screen.findByTestId('dropdown-item');
-		expect(dropDownItem).toHaveTextContent('DefaultResource');
-
-		await user.keyboard('{Control>}{Enter}{/Control}');
-
-		expect(dropDownItem).not.toBeInTheDocument();
-	});
-
-	it('should select the first option when user press Control+Enter', async () => {
-		const resource2: Resource = {
-			id: 'r2',
-			label: 'Room-B',
-			email: 'roomb@example.com',
-			type: 'Location'
-		};
-
-		const mockSearchOptions2 = jest.fn(async (_text: string) => [
-			{
-				id: '1',
-				label: 'DefaultResource',
-				value: defaultResource
-			},
-			{
-				id: '2',
-				label: 'Resource2',
-				value: resource2
-			}
-		]);
-
-		const { user } = setupTest(
-			<EditorResourceComponent
-				placeholder="Test"
-				editorId={editor.id}
-				onChange={onChangeMock}
-				onSearchOptions={mockSearchOptions2}
-				resourcesValue={[]}
-				warningLabel=""
-				singleWarningLabel=""
-				invalidInputErrorLabel="Invalid input"
-				duplicateChipsErrorLabel={'Duplicate input'}
-			/>,
-			{ store }
-		);
-
-		const input = screen.getByPlaceholderText('Test');
-		await user.type(input, 'Resource');
-
-		const dropDownItems = await screen.findAllByTestId('dropdown-item');
-		expect(dropDownItems).toHaveLength(2);
-
-		await user.keyboard('{Control>}{Enter}{/Control}');
-
-		await waitFor(async () => {
-			expect(onChangeMock).toHaveBeenCalledTimes(1);
-			const [resources] = onChangeMock.mock.calls[0];
-			expect(resources[0]).toMatchObject({
-				label: defaultResource.label,
-				email: defaultResource.email
-			});
-		});
-	});
-
-	it('shows loader while searching for options', async () => {
-		const { user } = setupTest(
-			<EditorResourceComponent
-				placeholder="Test"
-				editorId={editor.id}
-				onChange={onChangeMock}
-				onSearchOptions={() => new Promise((resolve) => setTimeout(() => resolve([]), 1000))}
-				resourcesValue={[]}
-				warningLabel=""
-				singleWarningLabel=""
-				invalidInputErrorLabel="Invalid input"
-				duplicateChipsErrorLabel={'Duplicate input'}
-			/>,
-			{ store }
-		);
-
-		const input = screen.getByPlaceholderText('Test');
-		await user.type(input, 'Meeting Room');
-
-		await waitFor(() => {
-			expect(screen.getByTestId('dropdown-options-loader')).toBeInTheDocument();
-		});
-	});
-
-	it('shows edit action in added chip', async () => {
-		const { user } = setupTest(
-			<EditorResourceComponent
-				placeholder="Test"
-				editorId={editor.id}
-				onChange={onChangeMock}
-				onSearchOptions={mockSearchOptions}
-				resourcesValue={[defaultResource]}
-				warningLabel=""
-				singleWarningLabel=""
-				invalidInputErrorLabel="Invalid input"
-				duplicateChipsErrorLabel={'Duplicate input'}
-			/>,
-			{ store }
-		);
-
-		const chip = screen.getByTestId('chip');
-		expect(chip).toHaveTextContent('DefaultResource');
-
-		const editButton = within(chip).getByTestId('icon: EditOutline');
-		expect(editButton).toBeInTheDocument();
-
-		await user.click(editButton);
-		expect(onChangeMock).toHaveBeenCalledTimes(0); // No change on edit click
-	});
-
-	it('triggers onChange when user commit edit using edit chip action', async () => {
-		const { user } = setupTest(
-			<EditorResourceComponent
-				placeholder="Test"
-				editorId={editor.id}
-				onChange={onChangeMock}
-				onSearchOptions={mockSearchOptions}
-				resourcesValue={[defaultResource]}
-				warningLabel=""
-				singleWarningLabel=""
-				invalidInputErrorLabel="Invalid input"
-				duplicateChipsErrorLabel={'Duplicate input'}
-			/>,
-			{ store }
-		);
-
-		const chip = screen.getByTestId('chip');
-		expect(chip).toHaveTextContent('DefaultResource');
-
-		const editButton = within(chip).getByTestId('icon: EditOutline');
-		expect(editButton).toBeInTheDocument();
-
-		await user.click(editButton);
-		expect(onChangeMock).toHaveBeenCalledTimes(0);
-
-		const input = screen.getByPlaceholderText('Test');
-
-		await user.clear(input);
-		await user.type(input, 'UpdatedResource');
-		await user.keyboard('{Enter}');
-		await waitFor(() => {
-			expect(onChangeMock).toHaveBeenCalledTimes(1);
-			const [resources] = onChangeMock.mock.calls[0];
-			expect(resources[0]).toMatchObject({
-				label: 'UpdatedResource',
-				email: ''
-			});
-		});
-	});
-
-	it('should add resource chip when user presses NumberPadEnter after typing', async () => {
-		const { user } = setupTest(
-			<EditorResourceComponent
-				placeholder="Test"
-				editorId={editor.id}
-				onChange={onChangeMock}
-				onSearchOptions={mockSearchOptions}
-				resourcesValue={[]}
-				warningLabel=""
-				singleWarningLabel=""
-				invalidInputErrorLabel="Invalid input"
-				duplicateChipsErrorLabel={'Duplicate input'}
-			/>,
-			{ store }
-		);
-
-		const input = screen.getByPlaceholderText('Test');
-		await user.type(input, 'DefaultResource');
-		await waitFor(() => expect(mockSearchOptions).toHaveBeenCalledWith('DefaultResource'));
-
-		const dropDownItem = await screen.findByTestId('dropdown-item');
-		expect(dropDownItem).toHaveTextContent('DefaultResource');
-
-		fireEvent.keyDown(input, { code: 'NumpadEnter' });
-
-		await waitFor(async () => {
-			expect(onChangeMock).toHaveBeenCalledTimes(1);
-			const [resources] = onChangeMock.mock.calls[0];
-			expect(resources[0]).toMatchObject({
-				label: 'DefaultResource',
-				email: ''
-			});
 		});
 	});
 });

--- a/src/view/editor/parts/tests/editor-resource-component.test.tsx
+++ b/src/view/editor/parts/tests/editor-resource-component.test.tsx
@@ -110,6 +110,7 @@ describe('EditorResourceComponent', () => {
 			/>,
 			{ store }
 		);
+		expect(screen.queryByText('Invalid input')).not.toBeInTheDocument();
 
 		const input = screen.getByPlaceholderText('Test');
 		await user.type(input, 'unknown-resource');
@@ -204,7 +205,7 @@ describe('EditorResourceComponent', () => {
 		expect(dropDownItem).not.toBeInTheDocument();
 	});
 
-	it('should select the first option when user press Enter', async () => {
+	it('should select the first option when user press Control+Enter', async () => {
 		const resource2: Resource = {
 			id: 'r2',
 			label: 'Room-B',

--- a/src/view/editor/parts/tests/utils.test.ts
+++ b/src/view/editor/parts/tests/utils.test.ts
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { generateResourceId } from '../utils';
+
+describe('Utils', () => {
+	it('returns trimmed email if present and non-empty', () => {
+		const resource = { email: '  user@example.com  ', id: '123', label: 'User' };
+		expect(generateResourceId(resource)).toBe('user@example.com');
+	});
+
+	it('returns trimmed id if email is missing or empty', () => {
+		const resource = { email: '   ', id: '  456  ', label: 'User' };
+		expect(generateResourceId(resource)).toBe('456');
+	});
+
+	it('returns label with timestamp if both email and id are missing or empty', () => {
+		const resource = { email: '', id: '', label: '  My Label  ' };
+		const result = generateResourceId(resource);
+		expect(result.startsWith('My Label-')).toBe(true);
+		expect(Number.isNaN(Number(result.split('-')[1]))).toBe(false);
+	});
+
+	it('returns unknown with timestamp if label is missing', () => {
+		const resource = { email: '', id: '', label: undefined as unknown as string };
+		const result = generateResourceId(resource);
+		expect(result.startsWith('unknown-')).toBe(true);
+		expect(Number.isNaN(Number(result.split('-')[1]))).toBe(false);
+	});
+});

--- a/src/view/editor/parts/tests/utils.test.ts
+++ b/src/view/editor/parts/tests/utils.test.ts
@@ -1,33 +1,77 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 /*
  * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { generateResourceId } from '../utils';
+import { generateResourceId, isValidResource } from '../utils';
 
 describe('Utils', () => {
-	it('returns trimmed email if present and non-empty', () => {
-		const resource = { email: '  user@example.com  ', id: '123', label: 'User' };
-		expect(generateResourceId(resource)).toBe('user@example.com');
+	describe('generateResourceId', () => {
+		it('returns trimmed email if present and non-empty', () => {
+			const resource = { email: '  user@example.com  ', id: '123', label: 'User' };
+			expect(generateResourceId(resource)).toBe('user@example.com');
+		});
+
+		it('returns trimmed id if email is missing or empty', () => {
+			const resource = { email: '   ', id: '  456  ', label: 'User' };
+			expect(generateResourceId(resource)).toBe('456');
+		});
+
+		it('returns label with timestamp if both email and id are missing or empty', () => {
+			const resource = { email: '', id: '', label: '  My Label  ' };
+			const result = generateResourceId(resource);
+			expect(result.startsWith('My Label-')).toBe(true);
+			expect(Number.isNaN(Number(result.split('-')[1]))).toBe(false);
+		});
+
+		it('returns unknown with timestamp if label is missing', () => {
+			const resource = { email: '', id: '', label: undefined as unknown as string };
+			const result = generateResourceId(resource);
+			expect(result.startsWith('unknown-')).toBe(true);
+			expect(Number.isNaN(Number(result.split('-')[1]))).toBe(false);
+		});
 	});
 
-	it('returns trimmed id if email is missing or empty', () => {
-		const resource = { email: '   ', id: '  456  ', label: 'User' };
-		expect(generateResourceId(resource)).toBe('456');
-	});
+	describe('isValidResource', () => {
+		it('returns true when resource has non-empty label and email', () => {
+			const resource = { label: 'Room', email: 'room@example.com', id: '1', type: 'Location' };
+			expect(isValidResource(resource)).toBe(true);
+		});
 
-	it('returns label with timestamp if both email and id are missing or empty', () => {
-		const resource = { email: '', id: '', label: '  My Label  ' };
-		const result = generateResourceId(resource);
-		expect(result.startsWith('My Label-')).toBe(true);
-		expect(Number.isNaN(Number(result.split('-')[1]))).toBe(false);
-	});
+		it('returns false when resource is undefined', () => {
+			expect(isValidResource(undefined)).toBe(false);
+		});
 
-	it('returns unknown with timestamp if label is missing', () => {
-		const resource = { email: '', id: '', label: undefined as unknown as string };
-		const result = generateResourceId(resource);
-		expect(result.startsWith('unknown-')).toBe(true);
-		expect(Number.isNaN(Number(result.split('-')[1]))).toBe(false);
+		it('returns false when label is empty', () => {
+			const resource = { label: '', email: 'room@example.com', id: '1', type: 'Location' };
+			expect(isValidResource(resource)).toBe(false);
+		});
+
+		it('returns false when email is empty', () => {
+			const resource = { label: 'Room', email: '', id: '1', type: 'Location' };
+			expect(isValidResource(resource)).toBe(false);
+		});
+
+		it('returns false when label is only whitespace', () => {
+			const resource = { label: '   ', email: 'room@example.com', id: '1', type: 'Location' };
+			expect(isValidResource(resource)).toBe(false);
+		});
+
+		it('returns false when email is only whitespace', () => {
+			const resource = { label: 'Room', email: '   ', id: '1', type: 'Location' };
+			expect(isValidResource(resource)).toBe(false);
+		});
+
+		it('returns true when label and email have leading/trailing whitespace', () => {
+			const resource = {
+				label: '  Room  ',
+				email: '  room@example.com  ',
+				id: '1',
+				type: 'Location'
+			};
+			expect(isValidResource(resource)).toBe(true);
+		});
 	});
 });

--- a/src/view/editor/parts/tests/utils.test.ts
+++ b/src/view/editor/parts/tests/utils.test.ts
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { generateResourceId, isValidResource } from '../utils';
+import { generateResourceId, getDuplicateResourceIds, isValidResource } from '../utils';
 
 describe('Utils', () => {
 	describe('generateResourceId', () => {
@@ -72,6 +72,45 @@ describe('Utils', () => {
 				type: 'Location'
 			};
 			expect(isValidResource(resource)).toBe(true);
+		});
+	});
+
+	describe('getDuplicateResourceIds', () => {
+		it('returns an empty set when given an empty array', () => {
+			expect(getDuplicateResourceIds([])).toEqual(new Set());
+		});
+
+		it('returns an empty set when all resources are unique', () => {
+			const resources = [
+				{ label: 'Room1', email: 'room1@example.com', id: '1', type: 'Location' },
+				{ label: 'Room2', email: 'room2@example.com', id: '2', type: 'Location' }
+			];
+			expect(getDuplicateResourceIds(resources)).toEqual(new Set());
+		});
+
+		it('returns a set with duplicate ids when resources share the same id', () => {
+			const resources = [
+				{ label: 'Room1', email: 'room1@example.com', id: '1', type: 'Location' },
+				{ label: 'Room2', email: 'room2@example.com', id: '1', type: 'Location' }
+			];
+			expect(getDuplicateResourceIds(resources)).toEqual(new Set(['1']));
+		});
+
+		it('returns a set with duplicate emails when resources share the same email and no id', () => {
+			const resources = [
+				{ label: 'Room1', email: 'room@example.com', id: '', type: 'Location' },
+				{ label: 'Room2', email: 'room@example.com', id: '', type: 'Location' }
+			];
+			expect(getDuplicateResourceIds(resources)).toEqual(new Set(['room@example.com']));
+		});
+
+		it('ignores invalid resources when checking for duplicates', () => {
+			const resources = [
+				{ label: '', email: 'room@example.com', id: '1', type: 'Location' },
+				{ label: 'Room2', email: 'room2@example.com', id: '2', type: 'Location' },
+				{ label: 'Room2', email: 'room2@example.com', id: '2', type: 'Location' }
+			];
+			expect(getDuplicateResourceIds(resources)).toEqual(new Set(['2']));
 		});
 	});
 });

--- a/src/view/editor/parts/utils.ts
+++ b/src/view/editor/parts/utils.ts
@@ -19,7 +19,7 @@ export const getDuplicateResourceIds = (resources: Resource[]): Set<string> => {
 	const seen = new Map<string, number>();
 	resources.forEach((r) => {
 		if (isValidResource(r)) {
-			const key = r.id?.trim() || r.email?.trim();
+			const key = [r.id, r.email].map((v) => v?.trim()).find(Boolean) ?? '';
 			seen.set(key, (seen.get(key) ?? 0) + 1);
 		}
 	});

--- a/src/view/editor/parts/utils.ts
+++ b/src/view/editor/parts/utils.ts
@@ -19,7 +19,7 @@ export const getDuplicateResourceIds = (resources: Resource[]): Set<string> => {
 	const seen = new Map<string, number>();
 	resources.forEach((r) => {
 		if (isValidResource(r)) {
-			const key = r.id ?? r.email;
+			const key = r.id?.trim() || r.email?.trim();
 			seen.set(key, (seen.get(key) ?? 0) + 1);
 		}
 	});

--- a/src/view/editor/parts/utils.ts
+++ b/src/view/editor/parts/utils.ts
@@ -11,3 +11,6 @@ export const generateResourceId = (resource: Resource): string => {
 	if (resource.id?.trim()) return resource.id.trim();
 	return `${resource.label?.trim() ?? 'unknown'}-${Date.now()}`;
 };
+
+export const isValidResource = (resource: Resource | undefined): boolean =>
+	!!resource?.label?.trim() && !!resource?.email?.trim();

--- a/src/view/editor/parts/utils.ts
+++ b/src/view/editor/parts/utils.ts
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Resource } from '../../../types/editor';
+
+export const generateResourceId = (resource: Resource): string => {
+	if (resource.email?.trim()) return resource.email.trim();
+	if (resource.id?.trim()) return resource.id.trim();
+	return `${resource.label?.trim() ?? '-unknown'}-${Date.now()}`;
+};

--- a/src/view/editor/parts/utils.ts
+++ b/src/view/editor/parts/utils.ts
@@ -9,5 +9,5 @@ import { Resource } from '../../../types/editor';
 export const generateResourceId = (resource: Resource): string => {
 	if (resource.email?.trim()) return resource.email.trim();
 	if (resource.id?.trim()) return resource.id.trim();
-	return `${resource.label?.trim() ?? '-unknown'}-${Date.now()}`;
+	return `${resource.label?.trim() ?? 'unknown'}-${Date.now()}`;
 };

--- a/src/view/editor/parts/utils.ts
+++ b/src/view/editor/parts/utils.ts
@@ -14,3 +14,18 @@ export const generateResourceId = (resource: Resource): string => {
 
 export const isValidResource = (resource: Resource | undefined): boolean =>
 	!!resource?.label?.trim() && !!resource?.email?.trim();
+
+export const getDuplicateResourceIds = (resources: Resource[]): Set<string> => {
+	const seen = new Map<string, number>();
+	resources.forEach((r) => {
+		if (isValidResource(r)) {
+			const key = r.id || r.email;
+			seen.set(key, (seen.get(key) || 0) + 1);
+		}
+	});
+	return new Set(
+		Array.from(seen.entries())
+			.filter(([, count]) => count > 1)
+			.map(([key]) => key)
+	);
+};

--- a/src/view/editor/parts/utils.ts
+++ b/src/view/editor/parts/utils.ts
@@ -19,8 +19,8 @@ export const getDuplicateResourceIds = (resources: Resource[]): Set<string> => {
 	const seen = new Map<string, number>();
 	resources.forEach((r) => {
 		if (isValidResource(r)) {
-			const key = r.id || r.email;
-			seen.set(key, (seen.get(key) || 0) + 1);
+			const key = r.id ?? r.email;
+			seen.set(key, (seen.get(key) ?? 0) + 1);
 		}
 	});
 	return new Set(


### PR DESCRIPTION
### Improved UX for Resources Input Chips in Editor

This PR introduces the following enhancements to improve user experience when interacting with the Resources input field:

- **Clear error feedback** for invalid inputs:  
  - The chip goes into error state, and the input fields shows error description guiding users to fix the issues. 
  
- **Action icons for all chips**:  
  - Both valid and invalid chips now show the **edit icon**, allowing users to modify the chip.
  - Edit action is even visible if the resource is unavailable 

- **Input enhancements**:  
  - Duplicate entries are **allowed during input** for flexibility. 
  - Inputs with **spaces** are now allowed, enabling users to paste or type more naturally.
  - Resource chip addition on exact match input

- **Enhanced validation**:
  - Chips are validated if user edits an existing appointment. The checks includes some simple validation that rely on presence of `label` and `email` prop. 
