### PR TITLE
feat: [CO-2216] Dynamic sharing options based on user settings in ShareCalendarModal

### DIFF
--- a/src/settings/components/utils.test.ts
+++ b/src/settings/components/utils.test.ts
@@ -1,30 +1,34 @@
-import {getShareCalendarWithOptions} from "./utils";
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { getShareCalendarWithOptions } from './utils';
 import defaultSettings from '@test-utils/settings/default-settings';
 
 describe('Utils', () => {
-  describe('getShareCalendarWithOptions', () => {
+	describe('getShareCalendarWithOptions', () => {
+		test('returns public and internal sharing options if publicSharingEnabled TRUE', () => {
+			const shareCalendarWithOptions = getShareCalendarWithOptions({
+				...defaultSettings,
+				attrs: {
+					zimbraPublicSharingEnabled: 'TRUE'
+				}
+			});
+			expect(shareCalendarWithOptions).toHaveLength(2);
+			expect(shareCalendarWithOptions[0].value).toEqual('usr');
+			expect(shareCalendarWithOptions[1].value).toEqual('pub');
+		});
 
-    test('returns public and internal sharing options if publicSharingEnabled TRUE', () =>{
-      let shareCalendarWithOptions = getShareCalendarWithOptions({
-        ...defaultSettings,
-        attrs: {
-          zimbraPublicSharingEnabled: 'TRUE',
-        }
-      });
-      expect(shareCalendarWithOptions).toHaveLength(2);
-      expect(shareCalendarWithOptions[0].value).toEqual('usr');
-      expect(shareCalendarWithOptions[1].value).toEqual('pub');
-    });
-
-    test('returns only internal sharing option if publicSharingEnabled FALSE', () =>{
-      let shareCalendarWithOptions = getShareCalendarWithOptions({
-        ...defaultSettings,
-        attrs: {
-          zimbraPublicSharingEnabled: 'FALSE',
-        }
-      });
-      expect(shareCalendarWithOptions).toHaveLength(1);
-      expect(shareCalendarWithOptions[0].value).toEqual('usr');
-    })
-  })
-})
+		test('returns only internal sharing option if publicSharingEnabled FALSE', () => {
+			const shareCalendarWithOptions = getShareCalendarWithOptions({
+				...defaultSettings,
+				attrs: {
+					zimbraPublicSharingEnabled: 'FALSE'
+				}
+			});
+			expect(shareCalendarWithOptions).toHaveLength(1);
+			expect(shareCalendarWithOptions[0].value).toEqual('usr');
+		});
+	});
+});

--- a/src/settings/components/utils.test.ts
+++ b/src/settings/components/utils.test.ts
@@ -1,0 +1,27 @@
+import {getShareCalendarWithOptions} from "./utils";
+import defaultSettings from '@test-utils/settings/default-settings';
+
+describe('Utils', () => {
+  describe('getShareCalendarWithOptions', () => {
+    test('returns public sharing option if publicSharingEnabled TRUE', () =>{
+      let shareCalendarWithOptions = getShareCalendarWithOptions({
+        ...defaultSettings,
+        attrs: {
+          zimbraPublicSharingEnabled: 'TRUE',
+        }
+      });
+      expect(shareCalendarWithOptions[1].value).toEqual('pub');
+    });
+
+    test('does not return public sharing option if publicSharingEnabled FALSE', () =>{
+      let shareCalendarWithOptions = getShareCalendarWithOptions({
+        ...defaultSettings,
+        attrs: {
+          zimbraPublicSharingEnabled: 'FALSE',
+        }
+      });
+      expect(shareCalendarWithOptions).toHaveLength(1);
+      expect(shareCalendarWithOptions[0].value).toEqual('usr');
+    })
+  })
+})

--- a/src/settings/components/utils.test.ts
+++ b/src/settings/components/utils.test.ts
@@ -3,17 +3,20 @@ import defaultSettings from '@test-utils/settings/default-settings';
 
 describe('Utils', () => {
   describe('getShareCalendarWithOptions', () => {
-    test('returns public sharing option if publicSharingEnabled TRUE', () =>{
+
+    test('returns public and internal sharing options if publicSharingEnabled TRUE', () =>{
       let shareCalendarWithOptions = getShareCalendarWithOptions({
         ...defaultSettings,
         attrs: {
           zimbraPublicSharingEnabled: 'TRUE',
         }
       });
+      expect(shareCalendarWithOptions).toHaveLength(2);
+      expect(shareCalendarWithOptions[0].value).toEqual('usr');
       expect(shareCalendarWithOptions[1].value).toEqual('pub');
     });
 
-    test('does not return public sharing option if publicSharingEnabled FALSE', () =>{
+    test('returns only internal sharing option if publicSharingEnabled FALSE', () =>{
       let shareCalendarWithOptions = getShareCalendarWithOptions({
         ...defaultSettings,
         attrs: {

--- a/src/settings/components/utils.ts
+++ b/src/settings/components/utils.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { SelectItem } from '@zextras/carbonio-design-system';
-import {AccountSettings, t, useUserSettings} from '@zextras/carbonio-shell-ui';
+import { AccountSettings, t } from '@zextras/carbonio-shell-ui';
 import { isEqual, transform, isObject, find } from 'lodash';
 
 export const ShowReminderOptions = (): SelectItem<`${number}`>[] => [
@@ -765,9 +765,11 @@ export const getWeekDay = (day: `${number}`): string => {
 	}
 };
 
-export const getShareCalendarWithOptions = (accountSettings: AccountSettings): SelectItem<'usr' | 'pub'>[] => {
+export const getShareCalendarWithOptions = (
+	accountSettings: AccountSettings
+): SelectItem<'usr' | 'pub'>[] => {
 	const publicSharingEnabled =
-			(accountSettings.attrs.zimbraPublicSharingEnabled as string) === 'TRUE';
+		(accountSettings.attrs.zimbraPublicSharingEnabled as string) === 'TRUE';
 
 	const defaultOptions = [
 		{

--- a/src/settings/components/utils.ts
+++ b/src/settings/components/utils.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { SelectItem } from '@zextras/carbonio-design-system';
-import { t, useUserSettings } from '@zextras/carbonio-shell-ui';
+import {AccountSettings, t, useUserSettings} from '@zextras/carbonio-shell-ui';
 import { isEqual, transform, isObject, find } from 'lodash';
 
 export const ShowReminderOptions = (): SelectItem<`${number}`>[] => [
@@ -765,10 +765,9 @@ export const getWeekDay = (day: `${number}`): string => {
 	}
 };
 
-export const useShareCalendarWithOptions = (): SelectItem<'usr' | 'pub'>[] => {
-	const accountSettings = useUserSettings();
+export const getShareCalendarWithOptions = (accountSettings: AccountSettings): SelectItem<'usr' | 'pub'>[] => {
 	const publicSharingEnabled =
-		(accountSettings.attrs.zimbraPublicSharingEnabled as string) === 'TRUE';
+			(accountSettings.attrs.zimbraPublicSharingEnabled as string) === 'TRUE';
 
 	const defaultOptions = [
 		{

--- a/src/settings/components/utils.ts
+++ b/src/settings/components/utils.ts
@@ -765,7 +765,7 @@ export const getWeekDay = (day: `${number}`): string => {
 	}
 };
 
-export const ShareCalendarWithOptions = (): SelectItem<'usr' | 'pub'>[] => [
+export const getShareCalendarWithOptions = (): SelectItem<'usr' | 'pub'>[] => [
 	{
 		label: t('share.options.share_calendar_with.internal_users_groups', 'Internal Users or Groups'),
 		value: 'usr'

--- a/src/settings/components/utils.ts
+++ b/src/settings/components/utils.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { SelectItem } from '@zextras/carbonio-design-system';
-import { t } from '@zextras/carbonio-shell-ui';
+import { t, useUserSettings } from '@zextras/carbonio-shell-ui';
 import { isEqual, transform, isObject, find } from 'lodash';
 
 export const ShowReminderOptions = (): SelectItem<`${number}`>[] => [
@@ -765,19 +765,30 @@ export const getWeekDay = (day: `${number}`): string => {
 	}
 };
 
-export const getShareCalendarWithOptions = (): SelectItem<'usr' | 'pub'>[] => [
-	{
-		label: t('share.options.share_calendar_with.internal_users_groups', 'Internal Users or Groups'),
-		value: 'usr'
-	},
-	{
-		label: t(
-			'share.options.share_calendar_with.public',
-			'Public (view only, no password required)'
-		),
-		value: 'pub'
-	}
-];
+export const useShareCalendarWithOptions = (): SelectItem<'usr' | 'pub'>[] => {
+	const accountSettings = useUserSettings();
+	const publicSharingEnabled =
+		(accountSettings.attrs.zimbraPublicSharingEnabled as string) === 'TRUE';
+
+	const defaultOptions = [
+		{
+			label: t(
+				'share.options.share_calendar_with.internal_users_groups',
+				'Internal Users or Groups'
+			),
+			value: 'usr' as const
+		}
+	];
+	return publicSharingEnabled
+		? [
+				...defaultOptions,
+				{
+					label: t('share.options.share_calendar_with.public', 'Public'),
+					value: 'pub' as const
+				}
+			]
+		: defaultOptions;
+};
 
 export const ShareCalendarRoleOptions = (canViewPrvtAppt: boolean | undefined): SelectItem[] => [
 	{ label: t('share.options.share_calendar_role.none', 'None'), value: '' },

--- a/src/view/sidebar/share-calendar-modal.tsx
+++ b/src/view/sidebar/share-calendar-modal.tsx
@@ -33,7 +33,7 @@ import { SHARE_USER_TYPE } from '../../constants';
 import { FOLDER_OPERATIONS } from '../../constants/api';
 import {
 	ShareCalendarRoleOptions,
-	ShareCalendarWithOptions,
+	getShareCalendarWithOptions,
 	findLabel
 } from '../../settings/components/utils';
 import { folderAction } from '../../store/actions/calendar-actions';
@@ -349,7 +349,7 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 	grant
 }): ReactElement => {
 	const [t] = useTranslation();
-	const shareCalendarWithOptions = useMemo(() => ShareCalendarWithOptions(), []);
+	const shareCalendarWithOptions = useMemo(() => getShareCalendarWithOptions(), []);
 
 	const [shareWithUserType, setShareWithUserType] = useState<'usr' | 'pub' | null>(
 		SHARE_USER_TYPE.USER

--- a/src/view/sidebar/share-calendar-modal.tsx
+++ b/src/view/sidebar/share-calendar-modal.tsx
@@ -19,7 +19,7 @@ import {
 	Tooltip,
 	useSnackbar
 } from '@zextras/carbonio-design-system';
-import { useUserAccounts } from '@zextras/carbonio-shell-ui';
+import {useUserAccounts, useUserSettings} from '@zextras/carbonio-shell-ui';
 import {
 	ContactInputItem,
 	ModalFooter,
@@ -33,7 +33,7 @@ import { SHARE_USER_TYPE } from '../../constants';
 import { FOLDER_OPERATIONS } from '../../constants/api';
 import {
 	findLabel,
-	useShareCalendarWithOptions,
+	getShareCalendarWithOptions,
 	ShareCalendarRoleOptions
 } from '../../settings/components/utils';
 import { folderAction } from '../../store/actions/calendar-actions';
@@ -349,7 +349,8 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 	grant
 }): ReactElement => {
 	const [t] = useTranslation();
-	const shareCalendarWithOptions = useShareCalendarWithOptions();
+	const accountSettings = useUserSettings();
+	const shareCalendarWithOptions = useMemo(() => getShareCalendarWithOptions(accountSettings), [accountSettings]);
 
 	const [shareWithUserType, setShareWithUserType] = useState<'usr' | 'pub' | null>(
 		SHARE_USER_TYPE.USER

--- a/src/view/sidebar/share-calendar-modal.tsx
+++ b/src/view/sidebar/share-calendar-modal.tsx
@@ -21,10 +21,10 @@ import {
 } from '@zextras/carbonio-design-system';
 import { useUserAccounts } from '@zextras/carbonio-shell-ui';
 import {
-	useContactInput,
 	ContactInputItem,
 	ModalFooter,
-	ModalHeader
+	ModalHeader,
+	useContactInput
 } from '@zextras/carbonio-ui-commons';
 import { map, some } from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -32,9 +32,9 @@ import { useTranslation } from 'react-i18next';
 import { SHARE_USER_TYPE } from '../../constants';
 import { FOLDER_OPERATIONS } from '../../constants/api';
 import {
-	ShareCalendarRoleOptions,
-	getShareCalendarWithOptions,
-	findLabel
+	findLabel,
+	useShareCalendarWithOptions,
+	ShareCalendarRoleOptions
 } from '../../settings/components/utils';
 import { folderAction } from '../../store/actions/calendar-actions';
 import { sendShareCalendarNotification } from '../../store/actions/send-share-calendar-notification';
@@ -349,7 +349,7 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 	grant
 }): ReactElement => {
 	const [t] = useTranslation();
-	const shareCalendarWithOptions = useMemo(() => getShareCalendarWithOptions(), []);
+	const shareCalendarWithOptions = useShareCalendarWithOptions();
 
 	const [shareWithUserType, setShareWithUserType] = useState<'usr' | 'pub' | null>(
 		SHARE_USER_TYPE.USER

--- a/src/view/sidebar/share-calendar-modal.tsx
+++ b/src/view/sidebar/share-calendar-modal.tsx
@@ -19,7 +19,7 @@ import {
 	Tooltip,
 	useSnackbar
 } from '@zextras/carbonio-design-system';
-import {useUserAccounts, useUserSettings} from '@zextras/carbonio-shell-ui';
+import { useUserAccounts, useUserSettings } from '@zextras/carbonio-shell-ui';
 import {
 	ContactInputItem,
 	ModalFooter,
@@ -350,7 +350,10 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 }): ReactElement => {
 	const [t] = useTranslation();
 	const accountSettings = useUserSettings();
-	const shareCalendarWithOptions = useMemo(() => getShareCalendarWithOptions(accountSettings), [accountSettings]);
+	const shareCalendarWithOptions = useMemo(
+		() => getShareCalendarWithOptions(accountSettings),
+		[accountSettings]
+	);
 
 	const [shareWithUserType, setShareWithUserType] = useState<'usr' | 'pub' | null>(
 		SHARE_USER_TYPE.USER

--- a/src/view/sidebar/tests/share-calendar-modal.test.tsx
+++ b/src/view/sidebar/tests/share-calendar-modal.test.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import { act, screen, waitFor, within } from '@testing-library/react';
+import * as shell from '@zextras/carbonio-shell-ui';
 import { Grant } from '@zextras/carbonio-ui-commons';
 
 import { SHARE_USER_TYPE } from '../../../constants';
@@ -17,10 +18,17 @@ import * as SendShare from '../../../store/actions/send-share-calendar-notificat
 import { reducers } from '../../../store/redux';
 import { ShareCalendarModal } from '../share-calendar-modal';
 import { setupTest } from '@test-setup';
+import defaultSettings from '@test-utils/settings/default-settings';
 
 const checkedIcon = 'icon: CheckmarkSquare';
 
 describe('Shared Calendar modal', () => {
+	beforeEach(() => {
+		jest.spyOn(shell, 'useUserSettings').mockReturnValue(defaultSettings);
+	});
+
+	const store = configureStore({ reducer: combineReducers(reducers) });
+
 	describe('Modal header', () => {
 		it('should display the title "Share" followed by the calendar name', () => {
 			const closeFn = jest.fn();
@@ -31,7 +39,7 @@ describe('Shared Calendar modal', () => {
 					perm: 'r'
 				} as const
 			];
-			const store = configureStore({ reducer: combineReducers(reducers) });
+
 			const title = 'testName';
 			setupTest(
 				<ShareCalendarModal
@@ -53,7 +61,6 @@ describe('Shared Calendar modal', () => {
 					perm: 'r'
 				} as const
 			];
-			const store = configureStore({ reducer: combineReducers(reducers) });
 			const { user } = setupTest(
 				<ShareCalendarModal
 					folderName={'testName'}
@@ -74,6 +81,53 @@ describe('Shared Calendar modal', () => {
 	});
 	describe('Modal body', () => {
 		describe('"share with" selector', () => {
+			it('should display no field when public share type is selected', async () => {
+				const closeFn = jest.fn();
+				const grant = [
+					{
+						zid: '1',
+						gt: 'usr',
+						perm: 'r'
+					} as const
+				];
+
+				const { user } = setupTest(
+					<ShareCalendarModal
+						folderName={'testName'}
+						folderId={'testId1'}
+						closeFn={closeFn}
+						grant={grant}
+					/>,
+					{ store }
+				);
+
+				await user.click(screen.getByText(/share with/i));
+
+				const dropdownPublicOption = within(screen.getByTestId(TEST_SELECTORS.DROPDOWN)).getByText(
+					/share\.options\.share_calendar_with\.public/i
+				);
+
+				await user.click(dropdownPublicOption);
+
+				const chipInput = screen.queryByRole('textbox', {
+					name: /Recipients e-mail addresses/i
+				});
+				const privateCheckbox = screen.queryByText(
+					/allow user\(s\) to see private appointments’ detail/i
+				);
+				const roleSelector = screen.queryByText('Role');
+				const notificationCheckbox = screen.queryByText(/send notification about this share/i);
+				const standardMessage = screen.queryByRole('textbox', {
+					name: /Add a note to standard message/i
+				});
+				const shareNotes = screen.queryByText(/note:/i);
+				expect(chipInput).not.toBeInTheDocument();
+				expect(privateCheckbox).not.toBeInTheDocument();
+				expect(roleSelector).not.toBeInTheDocument();
+				expect(notificationCheckbox).not.toBeInTheDocument();
+				expect(standardMessage).not.toBeInTheDocument();
+				expect(shareNotes).not.toBeInTheDocument();
+			});
 			test('has the label "Share with"', () => {
 				const closeFn = jest.fn();
 				const grant = [
@@ -83,7 +137,7 @@ describe('Shared Calendar modal', () => {
 						perm: 'r'
 					} as const
 				];
-				const store = configureStore({ reducer: combineReducers(reducers) });
+
 				setupTest(
 					<ShareCalendarModal
 						folderName={'testName'}
@@ -105,7 +159,7 @@ describe('Shared Calendar modal', () => {
 						perm: 'r'
 					} as const
 				];
-				const store = configureStore({ reducer: combineReducers(reducers) });
+
 				const { user } = setupTest(
 					<ShareCalendarModal
 						folderName={'testName'}
@@ -138,7 +192,7 @@ describe('Shared Calendar modal', () => {
 						perm: 'r'
 					} as const
 				];
-				const store = configureStore({ reducer: combineReducers(reducers) });
+
 				setupTest(
 					<ShareCalendarModal
 						folderName={'testName'}
@@ -153,54 +207,29 @@ describe('Shared Calendar modal', () => {
 					screen.getByText(/share\.options\.share_calendar_with\.internal_users_groups/i)
 				).toBeVisible();
 			});
-		});
-		it('should display no field when public share type is selected', async () => {
-			const closeFn = jest.fn();
-			const grant = [
-				{
-					zid: '1',
-					gt: 'usr',
-					perm: 'r'
-				} as const
-			];
-			const store = configureStore({ reducer: combineReducers(reducers) });
-			const { user } = setupTest(
-				<ShareCalendarModal
-					folderName={'testName'}
-					folderId={'testId1'}
-					closeFn={closeFn}
-					grant={grant}
-				/>,
-				{ store }
-			);
 
-			await user.click(screen.getByText(/share with/i));
+			test('when zimbraPublicSharingEnabled is FALSE the option "public" is not displayed', async () => {
+				jest.spyOn(shell, 'useUserSettings').mockReturnValue({
+					...defaultSettings,
+					attrs: { zimbraPublicSharingEnabled: 'FALSE' }
+				});
 
-			const dropdownPublicOption = within(screen.getByTestId(TEST_SELECTORS.DROPDOWN)).getByText(
-				/share\.options\.share_calendar_with\.public/i
-			);
+				const { user } = setupTest(
+					<ShareCalendarModal folderName={'testName'} folderId={'testId1'} />,
+					{ store }
+				);
 
-			await user.click(dropdownPublicOption);
+				const selector = await screen.findByText(/share with/i);
+				await user.click(selector);
 
-			const chipInput = screen.queryByRole('textbox', {
-				name: /Recipients e-mail addresses/i
+				const dropdownPublicOption = within(
+					screen.getByTestId(TEST_SELECTORS.DROPDOWN)
+				).queryByText(/share\.options\.share_calendar_with\.public/i);
+
+				expect(dropdownPublicOption).not.toBeInTheDocument();
 			});
-			const privateCheckbox = screen.queryByText(
-				/allow user\(s\) to see private appointments’ detail/i
-			);
-			const roleSelector = screen.queryByText('Role');
-			const notificationCheckbox = screen.queryByText(/send notification about this share/i);
-			const standardMessage = screen.queryByRole('textbox', {
-				name: /Add a note to standard message/i
-			});
-			const shareNotes = screen.queryByText(/note:/i);
-			expect(chipInput).not.toBeInTheDocument();
-			expect(privateCheckbox).not.toBeInTheDocument();
-			expect(roleSelector).not.toBeInTheDocument();
-			expect(notificationCheckbox).not.toBeInTheDocument();
-			expect(standardMessage).not.toBeInTheDocument();
-			expect(shareNotes).not.toBeInTheDocument();
 		});
+
 		describe('when internal is selected', () => {
 			it('should render other fields', async () => {
 				const closeFn = jest.fn();
@@ -211,7 +240,7 @@ describe('Shared Calendar modal', () => {
 						perm: 'r'
 					} as const
 				];
-				const store = configureStore({ reducer: combineReducers(reducers) });
+
 				setupTest(
 					<ShareCalendarModal
 						folderName={'testName'}
@@ -250,7 +279,7 @@ describe('Shared Calendar modal', () => {
 						perm: 'r'
 					} as const
 				];
-				const store = configureStore({ reducer: combineReducers(reducers) });
+
 				setupTest(
 					<ShareCalendarModal
 						folderName={'testName'}
@@ -276,7 +305,7 @@ describe('Shared Calendar modal', () => {
 							perm: 'r'
 						} as const
 					];
-					const store = configureStore({ reducer: combineReducers(reducers) });
+
 					setupTest(
 						<ShareCalendarModal
 							folderName={'testName'}
@@ -302,7 +331,7 @@ describe('Shared Calendar modal', () => {
 							perm: 'r'
 						} as const
 					];
-					const store = configureStore({ reducer: combineReducers(reducers) });
+
 					const { user } = setupTest(
 						<ShareCalendarModal
 							folderName={'testName'}
@@ -334,7 +363,7 @@ describe('Shared Calendar modal', () => {
 							perm: 'r'
 						} as const
 					];
-					const store = configureStore({ reducer: combineReducers(reducers) });
+
 					const { user } = setupTest(
 						<ShareCalendarModal
 							folderName={'testName'}
@@ -365,7 +394,7 @@ describe('Shared Calendar modal', () => {
 							perm: 'r'
 						} as const
 					];
-					const store = configureStore({ reducer: combineReducers(reducers) });
+
 					setupTest(
 						<ShareCalendarModal
 							folderName={'testName'}
@@ -386,7 +415,7 @@ describe('Shared Calendar modal', () => {
 							perm: 'r'
 						} as const
 					];
-					const store = configureStore({ reducer: combineReducers(reducers) });
+
 					const { user } = setupTest(
 						<ShareCalendarModal
 							folderName={'testName'}
@@ -434,7 +463,7 @@ describe('Shared Calendar modal', () => {
 							perm: 'r'
 						} as const
 					];
-					const store = configureStore({ reducer: combineReducers(reducers) });
+
 					setupTest(
 						<ShareCalendarModal
 							folderName={'testName'}
@@ -460,7 +489,7 @@ describe('Shared Calendar modal', () => {
 							perm: 'r'
 						} as const
 					];
-					const store = configureStore({ reducer: combineReducers(reducers) });
+
 					setupTest(
 						<ShareCalendarModal
 							folderName={'testName'}
@@ -493,7 +522,7 @@ describe('Shared Calendar modal', () => {
 							perm: 'r'
 						} as const
 					];
-					const store = configureStore({ reducer: combineReducers(reducers) });
+
 					const { user } = setupTest(
 						<ShareCalendarModal
 							folderName={'testName'}
@@ -528,7 +557,7 @@ describe('Shared Calendar modal', () => {
 							perm: 'r'
 						} as const
 					];
-					const store = configureStore({ reducer: combineReducers(reducers) });
+
 					setupTest(
 						<ShareCalendarModal
 							folderName={'testName'}
@@ -554,7 +583,7 @@ describe('Shared Calendar modal', () => {
 							perm: 'r'
 						} as const
 					];
-					const store = configureStore({ reducer: combineReducers(reducers) });
+
 					setupTest(
 						<ShareCalendarModal
 							folderName={'testName'}
@@ -581,7 +610,7 @@ describe('Shared Calendar modal', () => {
 						perm: 'r'
 					} as const
 				];
-				const store = configureStore({ reducer: combineReducers(reducers) });
+
 				setupTest(
 					<ShareCalendarModal
 						folderName={'testName'}
@@ -608,7 +637,7 @@ describe('Shared Calendar modal', () => {
 					perm: 'r'
 				} as const
 			];
-			const store = configureStore({ reducer: combineReducers(reducers) });
+
 			const { user } = setupTest(
 				<ShareCalendarModal
 					folderName={'testName'}
@@ -642,7 +671,7 @@ describe('Shared Calendar modal', () => {
 					perm: 'r'
 				} as const
 			];
-			const store = configureStore({ reducer: combineReducers(reducers) });
+
 			setupTest(
 				<ShareCalendarModal
 					folderName={'testName'}
@@ -668,7 +697,7 @@ describe('Shared Calendar modal', () => {
 					perm: 'r'
 				} as const
 			];
-			const store = configureStore({ reducer: combineReducers(reducers) });
+
 			const { user } = setupTest(
 				<ShareCalendarModal
 					folderName={'testName'}
@@ -704,7 +733,7 @@ describe('Shared Calendar modal', () => {
 				const spy = jest.spyOn(FolderAction, 'folderActionRequest');
 				const closeFn = jest.fn();
 				const grant: Grant[] | undefined = [];
-				const store = configureStore({ reducer: combineReducers(reducers) });
+
 				const { user } = setupTest(
 					<ShareCalendarModal
 						folderName={'testName'}
@@ -739,7 +768,7 @@ describe('Shared Calendar modal', () => {
 					const spy = jest.spyOn(FolderAction, 'folderActionRequest');
 					const closeFn = jest.fn();
 					const grant: Grant[] | undefined = [];
-					const store = configureStore({ reducer: combineReducers(reducers) });
+
 					const { user } = setupTest(
 						<ShareCalendarModal
 							folderName={'testName'}
@@ -774,7 +803,7 @@ describe('Shared Calendar modal', () => {
 					const spy = jest.spyOn(FolderAction, 'folderActionRequest');
 					const closeFn = jest.fn();
 					const grant: Grant[] | undefined = [];
-					const store = configureStore({ reducer: combineReducers(reducers) });
+
 					const { user } = setupTest(
 						<ShareCalendarModal
 							folderName={'testName'}
@@ -812,7 +841,7 @@ describe('Shared Calendar modal', () => {
 					const spy = jest.spyOn(FolderAction, 'folderActionRequest');
 					const closeFn = jest.fn();
 					const grant: Grant[] | undefined = [];
-					const store = configureStore({ reducer: combineReducers(reducers) });
+
 					const { user } = setupTest(
 						<ShareCalendarModal
 							folderName={'testName'}
@@ -854,7 +883,7 @@ describe('Shared Calendar modal', () => {
 					const spy = jest.spyOn(FolderAction, 'folderActionRequest');
 					const closeFn = jest.fn();
 					const grant: Grant[] | undefined = [];
-					const store = configureStore({ reducer: combineReducers(reducers) });
+
 					const { user } = setupTest(
 						<ShareCalendarModal
 							folderName={'testName'}
@@ -896,7 +925,7 @@ describe('Shared Calendar modal', () => {
 					const spy = jest.spyOn(FolderAction, 'folderActionRequest');
 					const closeFn = jest.fn();
 					const grant: Grant[] | undefined = [];
-					const store = configureStore({ reducer: combineReducers(reducers) });
+
 					const { user } = setupTest(
 						<ShareCalendarModal
 							folderName={'testName'}
@@ -938,7 +967,7 @@ describe('Shared Calendar modal', () => {
 					const spy = jest.spyOn(FolderAction, 'folderActionRequest');
 					const closeFn = jest.fn();
 					const grant: Grant[] | undefined = [];
-					const store = configureStore({ reducer: combineReducers(reducers) });
+
 					const { user } = setupTest(
 						<ShareCalendarModal
 							folderName={'testName'}
@@ -981,7 +1010,6 @@ describe('Shared Calendar modal', () => {
 						const sendSpy = jest.spyOn(SendShare, 'sendShareCalendarNotification');
 						const closeFn = jest.fn();
 						const grant: Grant[] | undefined = [];
-						const store = configureStore({ reducer: combineReducers(reducers) });
 
 						const { user } = setupTest(
 							<ShareCalendarModal
@@ -1010,7 +1038,6 @@ describe('Shared Calendar modal', () => {
 						const sendSpy = jest.spyOn(SendShare, 'sendShareCalendarNotification');
 						const closeFn = jest.fn();
 						const grant: Grant[] | undefined = [];
-						const store = configureStore({ reducer: combineReducers(reducers) });
 
 						const { user } = setupTest(
 							<ShareCalendarModal


### PR DESCRIPTION
## 📦 Summary

This PR enhances the user experience and improves clarity in the calendar sharing UI by refactoring key logic and introducing dynamic behavior based on user permissions.

## ✅ Changes Introduced

### ✨ Feature
- Implemented **dynamic sharing options** in `ShareCalendarModal` based on the user’s settings.
  - When the `zimbraPublicSharingEnabled` attribute is set to `FALSE`, the "Public" sharing option is now **hidden** from the UI.

### 🔄 Refactor
- Renamed `ShareCalendarWithOptions` to `getShareCalendarWithOptions` to reflect its functional nature and improve code semantics.
- Updated `share-calendar-modal.tsx` to use a pure function for generating sharing select options, increasing readability and testability.
