### PR TITLE
chore: update carbonio-ui-commons version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@types/webpack-env": "^1.18.5",
 				"@zextras/carbonio-design-system": "^10.1.1",
 				"@zextras/carbonio-shell-ui": "^11.0.1",
-				"@zextras/carbonio-ui-commons": "1.1.0-devel.1",
+				"@zextras/carbonio-ui-commons": "1.1.0-devel.2",
 				"@zextras/carbonio-ui-preview": "^3.2.1",
 				"core-js": "^3.39.0",
 				"darkreader": "^4.9.79",
@@ -4442,6 +4442,11 @@
 			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
 			"dev": true
 		},
+		"node_modules/@types/ua-parser-js": {
+			"version": "0.7.39",
+			"resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.39.tgz",
+			"integrity": "sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg=="
+		},
 		"node_modules/@types/use-sync-external-store": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
@@ -5190,18 +5195,18 @@
 			}
 		},
 		"node_modules/@zextras/carbonio-ui-commons": {
-			"version": "1.1.0-devel.1",
-			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-commons/-/carbonio-ui-commons-1.1.0-devel.1.tgz",
-			"integrity": "sha512-iXNLTcih5MuyyGTh7/a0B9Vk408GMmkyHUVqWQ0psk7ffvcOWLaIDG564mYJgheb9jr66Z/OwkthB/QPU5cXqw==",
-			"license": "AGPL-3.0-only",
+			"version": "1.1.0-devel.2",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-commons/-/carbonio-ui-commons-1.1.0-devel.2.tgz",
+			"integrity": "sha512-RbNAp5Pp98FCMfw3UneMYwiH8z0q2n0pxISApwAHMl9Q9DnXjUoCZspT/uFb9dqW44nR4m0eNaHqgW4GRO/M5A==",
 			"dependencies": {
 				"@emotion/react": "^11.11.4",
 				"@emotion/styled": "^11.10.5",
 				"@mui/icons-material": "^5.15.12",
 				"@mui/material": "^5.15.12",
 				"@zextras/carbonio-design-system": "^10.1.1",
-				"@zextras/carbonio-shell-ui": "^11.0.1",
+				"@zextras/carbonio-shell-ui": "11.0.2-devel.1752670950499",
 				"@zextras/carbonio-ui-preview": "^3.2.1",
+				"@zextras/carbonio-ui-soap-lib": "^1.0.3",
 				"core-js": "^3.36.0",
 				"eslint": "^8.57.0",
 				"i18next": "^22.4.13",
@@ -5219,6 +5224,111 @@
 			"engines": {
 				"node": "v20",
 				"npm": "v10"
+			}
+		},
+		"node_modules/@zextras/carbonio-ui-commons/node_modules/@zextras/carbonio-shell-ui": {
+			"version": "11.0.2-devel.1752670950499",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-shell-ui/-/carbonio-shell-ui-11.0.2-devel.1752670950499.tgz",
+			"integrity": "sha512-6uyCPEP5fgXLmq1E5Vm8g9cPfacUsicar27mRw55Sb84fjFRrrc4jWsJ0nHfidBShYvYxZ465nNAPH8SBNgRzw==",
+			"dependencies": {
+				"@fontsource/roboto": "^5.0.8",
+				"@tinymce/tinymce-react": "^4.3.2",
+				"@zextras/carbonio-design-system": "^10.1.1",
+				"@zextras/carbonio-ui-preview": "^3.2.0",
+				"@zextras/carbonio-ui-soap-lib": "1.0.3",
+				"darkreader": "^4.9.79",
+				"date-fns": "^4.1.0",
+				"i18next": "^22.5.1",
+				"i18next-chained-backend": "^4.6.2",
+				"i18next-http-backend": "^2.5.0",
+				"immer": "^10.0.3",
+				"lodash": "^4.17.21",
+				"posthog-js": "^1.234.4",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1",
+				"react-i18next": "^12.3.1",
+				"react-router-dom": "^6.30.0",
+				"styled-components": "^6.1.13",
+				"tinymce": "^6.8.4",
+				"zustand": "^5.0.3"
+			},
+			"engines": {
+				"node": "v20",
+				"npm": "v10"
+			},
+			"peerDependencies": {
+				"@zextras/carbonio-design-system": "^10.0.0",
+				"@zextras/carbonio-ui-preview": "^3.2.0",
+				"core-js": "^3.39.0",
+				"lodash": "^4.17.21",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1",
+				"react-i18next": "^12.3.1",
+				"react-router-dom": "^6.30.0",
+				"styled-components": "^6.1.13"
+			},
+			"peerDependenciesMeta": {
+				"@zextras/carbonio-design-system": {
+					"optional": true
+				},
+				"@zextras/carbonio-ui-preview": {
+					"optional": true
+				},
+				"lodash": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				},
+				"react-i18next": {
+					"optional": true
+				},
+				"react-router-dom": {
+					"optional": true
+				},
+				"styled-components": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@zextras/carbonio-ui-commons/node_modules/@zextras/carbonio-shell-ui/node_modules/immer": {
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+			"integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/immer"
+			}
+		},
+		"node_modules/@zextras/carbonio-ui-commons/node_modules/@zextras/carbonio-shell-ui/node_modules/zustand": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.6.tgz",
+			"integrity": "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==",
+			"engines": {
+				"node": ">=12.20.0"
+			},
+			"peerDependencies": {
+				"@types/react": ">=18.0.0",
+				"immer": ">=9.0.6",
+				"react": ">=18.0.0",
+				"use-sync-external-store": ">=1.2.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"immer": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"use-sync-external-store": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@zextras/carbonio-ui-commons/node_modules/uuid": {
@@ -5871,6 +5981,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/@zextras/carbonio-ui-soap-lib": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-soap-lib/-/carbonio-ui-soap-lib-1.0.3.tgz",
+			"integrity": "sha512-is06UdbiC+ZPn+61e/1/5qpv5XsKPQwJAQzYRMftJpHMpGPR43Ll1QGdUsGFfeKr7T1jDhfuZz8Pa8L1p3HC7A==",
+			"dependencies": {
+				"@types/ua-parser-js": "^0.7.39",
+				"ua-parser-js": "^1.0.37"
 			}
 		},
 		"node_modules/abab": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
 		"@types/webpack-env": "^1.18.5",
 		"@zextras/carbonio-design-system": "^10.1.1",
 		"@zextras/carbonio-shell-ui": "^11.0.1",
-		"@zextras/carbonio-ui-commons": "1.1.0-devel.1",
+		"@zextras/carbonio-ui-commons": "1.1.0-devel.2",
 		"@zextras/carbonio-ui-preview": "^3.2.1",
 		"core-js": "^3.39.0",
 		"darkreader": "^4.9.79",


### PR DESCRIPTION
Update @zextras/carbonio-ui-commons to 1.1.0-devel.2 in package.json and package-lock.json. Refresh lockfile with new dependencies and versions.