### PR TITLE
Co 2270 reschedule appointment

### DIFF
--- a/src/shared/invite-response/invite-response.test.tsx
+++ b/src/shared/invite-response/invite-response.test.tsx
@@ -1031,6 +1031,22 @@ describe('invite response component', () => {
 				expect(titleString).toBeVisible();
 				expect(titleString).toHaveStyleRule('font-size', '1.125rem');
 			});
+			test('should show the correct start and end time', async () => {
+				setupFoldersStore();
+				const mailMsg = buildMailMessageType(MESSAGE_METHOD.COUNTER, MESSAGE_TYPE.SINGLE, false);
+				createSoapAPIInterceptor('GetAppointment', {});
+				const store = configureStore({ reducer: combineReducers(reducers) });
+				setupTest(<InviteResponse mailMsg={mailMsg} moveToTrash={jest.fn()} />, {
+					store
+				});
+				const titleString = await screen.findByText(mailMsg.subject);
+				expect(titleString).toBeVisible();
+				expect(titleString).toHaveStyleRule('font-size', '1.125rem');
+
+				expect(
+					screen.getByText('Tuesday, January 30, 2024, 9:00 – 9:30 AM GMT+01:00 Europe/Berlin')
+				).toBeVisible();
+			});
 			test('a string with the user local time of the event', async () => {
 				setupFoldersStore();
 				const mailMsg = buildMailMessageType(MESSAGE_METHOD.COUNTER, MESSAGE_TYPE.SINGLE, false);

--- a/src/shared/invite-response/invite-response.tsx
+++ b/src/shared/invite-response/invite-response.tsx
@@ -258,8 +258,10 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 							// eslint-disable-next-line react/jsx-indent
 							<ProposedTimeReply
 								id={invite?.apptId}
-								start={proposedStartTime ? moment(proposedStartTime).valueOf() : invite?.start?.u}
-								end={proposedEndTime ? moment(proposedEndTime).valueOf() : invite?.end?.u}
+								start={
+									proposedStartTime ? moment(proposedStartTime).valueOf() : (invite?.start?.u ?? 0)
+								}
+								end={proposedEndTime ? moment(proposedEndTime).valueOf() : (invite?.end?.u ?? 0)}
 								moveToTrash={moveToTrash}
 								title={mailMsg.subject}
 								to={to}

--- a/src/shared/invite-response/invite-response.tsx
+++ b/src/shared/invite-response/invite-response.tsx
@@ -258,7 +258,7 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 							// eslint-disable-next-line react/jsx-indent
 							<ProposedTimeReply
 								id={invite?.apptId}
-								start={moment(proposedStartTime).valueOf() ?? invite?.start?.u}
+								start={proposedStartTime ? moment(proposedStartTime).valueOf() : invite?.start?.u}
 								end={moment(proposedEndTime).valueOf() ?? invite?.end?.u}
 								moveToTrash={moveToTrash}
 								title={mailMsg.subject}

--- a/src/shared/invite-response/invite-response.tsx
+++ b/src/shared/invite-response/invite-response.tsx
@@ -157,13 +157,17 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 		timeZone: invite.tz
 	});
 
-	const proposedStartTime = moment(mailMsg.invite[0]?.comp?.[0]?.s?.[0]?.d).valueOf();
-	const proposedEndTime = moment(mailMsg.invite[0]?.comp?.[0]?.e?.[0]?.d).valueOf();
+	const proposedStartTime = mailMsg.invite[0]?.comp?.[0]?.s?.[0]?.d;
+	const proposedEndTime = mailMsg.invite[0]?.comp?.[0]?.e?.[0]?.d;
 
-	const counterDate = useGetDateRangeConvertedToTimezone(proposedStartTime, proposedEndTime, {
-		allDay: invite.allDay,
-		timeZone: invite.tz
-	});
+	const counterDate = useGetDateRangeConvertedToTimezone(
+		moment(proposedStartTime).valueOf(),
+		moment(proposedEndTime).valueOf(),
+		{
+			allDay: invite.allDay,
+			timeZone: invite.tz
+		}
+	);
 
 	const convertedDate = useGetDateRangeConvertedToTimezone(localStart, localEnd, {
 		allDay: invite.allDay
@@ -243,8 +247,8 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 					<AvailabilityChecker
 						email={email}
 						rootId={root.id}
-						start={invite?.start?.u ?? proposedStartTime}
-						end={invite?.end?.u ?? endOfDay(mailMsg.invite[0].comp[0].e[0].d)}
+						start={invite?.start?.u ?? moment(proposedStartTime).valueOf()}
+						end={invite?.end?.u ?? endOfDay(proposedEndTime)}
 						allDay={invite.allDay ?? false}
 						uid={invite.uid}
 					/>
@@ -254,8 +258,8 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 							// eslint-disable-next-line react/jsx-indent
 							<ProposedTimeReply
 								id={invite?.apptId}
-								start={proposedStartTime ?? invite?.start?.u}
-								end={proposedEndTime ?? invite?.end?.u}
+								start={moment(proposedStartTime).valueOf() ?? invite?.start?.u}
+								end={moment(proposedEndTime).valueOf() ?? invite?.end?.u}
 								moveToTrash={moveToTrash}
 								title={mailMsg.subject}
 								to={to}

--- a/src/shared/invite-response/invite-response.tsx
+++ b/src/shared/invite-response/invite-response.tsx
@@ -250,7 +250,7 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 						uid={invite.uid}
 					/>
 				)}
-				{method === MESSAGE_METHOD
+				{method === MESSAGE_METHOD.COUNTER
 					? mailMsg.parent !== FOLDERS.SENT && (
 							// eslint-disable-next-line react/jsx-indent
 							<ProposedTimeReply

--- a/src/shared/invite-response/invite-response.tsx
+++ b/src/shared/invite-response/invite-response.tsx
@@ -200,7 +200,7 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 		<InviteContainer data-testid={'invite-response'}>
 			<Container padding={{ horizontal: 'small', vertical: 'large' }} width="100%">
 				<Row width="fill" mainAlignment="flex-start" padding={{ bottom: 'extrasmall' }}>
-					{method === 'COUNTER' ? (
+					{method === MESSAGE_METHOD.COUNTER ? (
 						<Text weight="light" size="large">
 							{mailMsg.subject}
 						</Text>
@@ -220,8 +220,8 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 					)}
 				</Row>
 				<Row width="100%" mainAlignment="flex-start">
-					{method === 'COUNTER' ? (
-						mailMsg.parent !== '5' && (
+					{method === MESSAGE_METHOD.COUNTER ? (
+						mailMsg.parent !== FOLDERS.SENT && (
 							<Text overflow="ellipsis" color="secondary" weight="bold" size="small">
 								{counterDate}
 							</Text>
@@ -250,8 +250,8 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 						uid={invite.uid}
 					/>
 				)}
-				{method === 'COUNTER'
-					? mailMsg.parent !== '5' && (
+				{method === MESSAGE_METHOD
+					? mailMsg.parent !== FOLDERS.SENT && (
 							// eslint-disable-next-line react/jsx-indent
 							<ProposedTimeReply
 								id={invite?.apptId}

--- a/src/shared/invite-response/invite-response.tsx
+++ b/src/shared/invite-response/invite-response.tsx
@@ -203,11 +203,12 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 		<InviteContainer data-testid={'invite-response'}>
 			<Container padding={{ horizontal: 'small', vertical: 'large' }} width="100%">
 				<Row width="fill" mainAlignment="flex-start" padding={{ bottom: 'extrasmall' }}>
-					{method === MESSAGE_METHOD.COUNTER ? (
+					{method === MESSAGE_METHOD.COUNTER && (
 						<Text weight="light" size="large">
 							{mailMsg.subject}
 						</Text>
-					) : (
+					)}
+					{method !== MESSAGE_METHOD.COUNTER && (
 						<>
 							<Text weight="regular" size="large" style={{ fontSize: '1.125rem' }}>
 								{`${invite.organizer?.d ?? invite.organizer?.a} ${t(
@@ -215,7 +216,7 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 									'invited you to an event'
 								)}`}
 							</Text>
-							&nbsp;
+							<br />
 							<Text weight="bold" size="large" style={{ fontSize: '1.125rem' }}>
 								{mailMsg.subject ? mailMsg.subject : invite?.name}
 							</Text>
@@ -223,13 +224,12 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 					)}
 				</Row>
 				<Row width="100%" mainAlignment="flex-start">
-					{method === MESSAGE_METHOD.COUNTER ? (
-						mailMsg.parent !== FOLDERS.SENT && (
-							<Text overflow="ellipsis" color="secondary" weight="bold" size="small">
-								{counterDate}
-							</Text>
-						)
-					) : (
+					{method === MESSAGE_METHOD.COUNTER && mailMsg.parent !== FOLDERS.SENT && (
+						<Text overflow="ellipsis" color="secondary" weight="bold" size="small">
+							{counterDate}
+						</Text>
+					)}
+					{method !== MESSAGE_METHOD.COUNTER && (
 						<Text overflow="ellipsis" color="secondary" weight="bold" size="small">
 							{originalDate}
 						</Text>
@@ -253,23 +253,24 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 						uid={invite.uid}
 					/>
 				)}
-				{method === MESSAGE_METHOD.COUNTER
-					? mailMsg.parent !== FOLDERS.SENT && (
-							// eslint-disable-next-line react/jsx-indent
-							<ProposedTimeReply
-								id={invite?.apptId}
-								start={
-									proposedStartTime ? moment(proposedStartTime).valueOf() : (invite?.start?.u ?? 0)
-								}
-								end={proposedEndTime ? moment(proposedEndTime).valueOf() : (invite?.end?.u ?? 0)}
-								moveToTrash={moveToTrash}
-								title={mailMsg.subject}
-								to={to}
-								msg={mailMsg}
-								fragment={invite?.fragment}
-							/>
-						)
-					: isAttendee && <InviteReplyPart inviteId={inviteId} message={mailMsg} />}
+
+				{method === MESSAGE_METHOD.COUNTER && mailMsg.parent !== FOLDERS.SENT && (
+					<ProposedTimeReply
+						id={invite?.apptId}
+						start={
+							proposedStartTime ? moment(proposedStartTime).valueOf() : (invite?.start?.u ?? 0)
+						}
+						end={proposedEndTime ? moment(proposedEndTime).valueOf() : (invite?.end?.u ?? 0)}
+						moveToTrash={moveToTrash}
+						title={mailMsg.subject}
+						to={to}
+						msg={mailMsg}
+						fragment={invite?.fragment}
+					/>
+				)}
+				{method !== MESSAGE_METHOD.COUNTER && isAttendee && (
+					<InviteReplyPart inviteId={inviteId} message={mailMsg} />
+				)}
 
 				{invite?.location && (
 					<Row width="fill" mainAlignment="flex-start" padding={{ top: 'large' }}>
@@ -288,7 +289,6 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 						</Row>
 					</Row>
 				)}
-
 				{roomName && roomLink && (
 					<Row width="fill" mainAlignment="flex-start" padding={{ top: 'large' }}>
 						<Tooltip placement="top" label={t('tooltip.virtual_room', 'Virtual room')}>
@@ -307,7 +307,6 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 						</Row>
 					</Row>
 				)}
-
 				{meetingRooms && meetingRooms?.length > 0 && (
 					<Row width="fill" mainAlignment="flex-start" padding={{ top: 'large', bottom: 'small' }}>
 						<Tooltip placement="left" label={t('tooltip.meetingRooms', 'MeetingRooms')}>
@@ -324,7 +323,6 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 						</Row>
 					</Row>
 				)}
-
 				{equipments && equipments.length > 0 && (
 					<Row width="fill" mainAlignment="flex-start" padding={{ top: 'large', bottom: 'small' }}>
 						<Tooltip placement="left" label={t('tooltip.equipment', 'Equipment')}>
@@ -341,7 +339,6 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 						</Row>
 					</Row>
 				)}
-
 				<Row
 					width="100%"
 					mainAlignment="flex-start"

--- a/src/shared/invite-response/invite-response.tsx
+++ b/src/shared/invite-response/invite-response.tsx
@@ -158,8 +158,8 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 	});
 
 	const counterDate = useGetDateRangeConvertedToTimezone(
-		moment(mailMsg.invite[0].comp[0].e[0].d).valueOf(),
 		moment(mailMsg.invite[0].comp[0].s[0].d).valueOf(),
+		moment(mailMsg.invite[0].comp[0].e[0].d).valueOf(),
 		{
 			allDay: invite.allDay,
 			timeZone: invite.tz

--- a/src/shared/invite-response/invite-response.tsx
+++ b/src/shared/invite-response/invite-response.tsx
@@ -157,6 +157,15 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 		timeZone: invite.tz
 	});
 
+	const counterDate = useGetDateRangeConvertedToTimezone(
+		moment(mailMsg.invite[0].comp[0].e[0].d).valueOf(),
+		moment(mailMsg.invite[0].comp[0].s[0].d).valueOf(),
+		{
+			allDay: invite.allDay,
+			timeZone: invite.tz
+		}
+	);
+
 	const convertedDate = useGetDateRangeConvertedToTimezone(localStart, localEnd, {
 		allDay: invite.allDay
 	});
@@ -211,9 +220,18 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 					)}
 				</Row>
 				<Row width="100%" mainAlignment="flex-start">
-					<Text overflow="ellipsis" color="secondary" weight="bold" size="small">
-						{originalDate}
-					</Text>
+					{method === 'COUNTER' ? (
+						mailMsg.parent !== '5' && (
+							<Text overflow="ellipsis" color="secondary" weight="bold" size="small">
+								{counterDate}
+							</Text>
+						)
+					) : (
+						<Text overflow="ellipsis" color="secondary" weight="bold" size="small">
+							{originalDate}
+						</Text>
+					)}
+
 					{convertedDate !== originalDate && (
 						<Tooltip label={convertedDateTooltip}>
 							<Padding left="small">
@@ -237,8 +255,8 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 							// eslint-disable-next-line react/jsx-indent
 							<ProposedTimeReply
 								id={invite?.apptId}
-								start={invite?.start?.u ?? moment(mailMsg.invite[0].comp[0].s[0].d).valueOf()}
-								end={invite?.end?.u ?? moment(mailMsg.invite[0].comp[0].e[0].d).valueOf()}
+								start={moment(mailMsg.invite[0].comp[0].s[0].d).valueOf() ?? invite?.start?.u}
+								end={moment(mailMsg.invite[0].comp[0].e[0].d).valueOf() ?? invite?.end?.u}
 								moveToTrash={moveToTrash}
 								title={mailMsg.subject}
 								to={to}

--- a/src/shared/invite-response/invite-response.tsx
+++ b/src/shared/invite-response/invite-response.tsx
@@ -157,14 +157,13 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 		timeZone: invite.tz
 	});
 
-	const counterDate = useGetDateRangeConvertedToTimezone(
-		moment(mailMsg.invite[0].comp[0].s[0].d).valueOf(),
-		moment(mailMsg.invite[0].comp[0].e[0].d).valueOf(),
-		{
-			allDay: invite.allDay,
-			timeZone: invite.tz
-		}
-	);
+	const proposedStartTime = moment(mailMsg.invite[0]?.comp?.[0]?.s?.[0]?.d).valueOf();
+	const proposedEndTime = moment(mailMsg.invite[0]?.comp?.[0]?.e?.[0]?.d).valueOf();
+
+	const counterDate = useGetDateRangeConvertedToTimezone(proposedStartTime, proposedEndTime, {
+		allDay: invite.allDay,
+		timeZone: invite.tz
+	});
 
 	const convertedDate = useGetDateRangeConvertedToTimezone(localStart, localEnd, {
 		allDay: invite.allDay
@@ -244,7 +243,7 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 					<AvailabilityChecker
 						email={email}
 						rootId={root.id}
-						start={invite?.start?.u ?? moment(mailMsg.invite[0].comp[0].s[0].d).valueOf()}
+						start={invite?.start?.u ?? proposedStartTime}
 						end={invite?.end?.u ?? endOfDay(mailMsg.invite[0].comp[0].e[0].d)}
 						allDay={invite.allDay ?? false}
 						uid={invite.uid}
@@ -255,8 +254,8 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 							// eslint-disable-next-line react/jsx-indent
 							<ProposedTimeReply
 								id={invite?.apptId}
-								start={moment(mailMsg.invite[0].comp[0].s[0].d).valueOf() ?? invite?.start?.u}
-								end={moment(mailMsg.invite[0].comp[0].e[0].d).valueOf() ?? invite?.end?.u}
+								start={proposedStartTime ?? invite?.start?.u}
+								end={proposedEndTime ?? invite?.end?.u}
 								moveToTrash={moveToTrash}
 								title={mailMsg.subject}
 								to={to}

--- a/src/shared/invite-response/invite-response.tsx
+++ b/src/shared/invite-response/invite-response.tsx
@@ -259,7 +259,7 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 							<ProposedTimeReply
 								id={invite?.apptId}
 								start={proposedStartTime ? moment(proposedStartTime).valueOf() : invite?.start?.u}
-								end={moment(proposedEndTime).valueOf() ?? invite?.end?.u}
+								end={proposedEndTime ? moment(proposedEndTime).valueOf() : invite?.end?.u}
 								moveToTrash={moveToTrash}
 								title={mailMsg.subject}
 								to={to}


### PR DESCRIPTION
This PR fixes the functionality to reschedule appointments. The changes enable displaying proposed times for counter appointments and correctly showing the proposed start/end times rather than the original appointment times.

- Extracts proposed start/end times from counter invite messages
- Updates display logic to show counter dates for COUNTER method invites

