### PR TITLE
feat: [CO-2214] unify resource availability & validation errors reporting in editor

### DIFF
--- a/src/view/editor/parts/editor-equipments.tsx
+++ b/src/view/editor/parts/editor-equipments.tsx
@@ -66,6 +66,24 @@ export const EditorEquipments = ({ editorId }: { editorId: string }): ReactEleme
 		[]
 	);
 
+	const errorLabels = {
+		singleResourceUnavailable: t(
+			'attendee_equipment_unavailable',
+			'Equipment not available at the selected time of the event'
+		),
+		multipleResourcesUnavailable: t(
+			'attendees_equipments_unavailable',
+			'One or more Equipments are not available at the selected time of the event'
+		),
+		invalidResource: t(
+			'equipment_invalid',
+			'One or more items of equipment are invalid. Try editing them or entering a new one.'
+		),
+		duplicateResources: t(
+			'duplicate_equipment_error',
+			'One or more items of equipment were selected multiple times. Consider removing the duplicates.'
+		)
+	};
 	return (
 		<EditorResourceComponent
 			onChange={onChange}
@@ -73,23 +91,8 @@ export const EditorEquipments = ({ editorId }: { editorId: string }): ReactEleme
 			onSearchOptions={onSearchOptions}
 			placeholder={t('label.equipment', 'Equipment')}
 			resourcesValue={equipmentChipValue}
-			warningLabel={t(
-				'attendees_equipments_unavailable',
-				'One or more Equipments are not available at the selected time of the event'
-			)}
 			disabled={disabled?.equipment}
-			singleWarningLabel={t(
-				'attendee_equipment_unavailable',
-				'Equipment not available at the selected time of the event'
-			)}
-			invalidInputErrorLabel={t(
-				'equipment_invalid',
-				'One or more items of equipment are invalid. Try editing them or entering a new one.'
-			)}
-			duplicateChipsErrorLabel={t(
-				'duplicate_equipment_error',
-				'One or more items of equipment were selected multiple times. Consider removing the duplicates.'
-			)}
+			errorLabels={errorLabels}
 		/>
 	);
 };

--- a/src/view/editor/parts/editor-meeting-rooms.tsx
+++ b/src/view/editor/parts/editor-meeting-rooms.tsx
@@ -66,6 +66,24 @@ export const EditorMeetingRooms = ({ editorId }: { editorId: string }): ReactEle
 		[]
 	);
 
+	const errorLabels = {
+		singleResourceUnavailable: t(
+			'attendee_room_unavailable',
+			'Room not available at the selected time of the event'
+		),
+		multipleResourcesUnavailable: t(
+			'attendees_rooms_unavailable',
+			'One or more Meeting Rooms are not available at the selected time of the event'
+		),
+		invalidResource: t(
+			'rooms_invalid',
+			'One or more Meeting rooms are invalid. Try editing them or entering a new one.'
+		),
+		duplicateResources: t(
+			'duplicate_rooms_error',
+			'One or more Meeting rooms were selected multiple times. Consider removing the duplicates.'
+		)
+	};
 	return (
 		<EditorResourceComponent
 			onChange={onChange}
@@ -73,23 +91,8 @@ export const EditorMeetingRooms = ({ editorId }: { editorId: string }): ReactEle
 			onSearchOptions={onSearchOptions}
 			placeholder={t('label.meeting_room', 'Meeting room')}
 			resourcesValue={meetingRoomsChipValue ?? []}
-			warningLabel={t(
-				'attendees_rooms_unavailable',
-				'One or more Meeting Rooms are not available at the selected time of the event'
-			)}
 			disabled={disabled?.equipment}
-			singleWarningLabel={t(
-				'attendee_room_unavailable',
-				'Room not available at the selected time of the event'
-			)}
-			invalidInputErrorLabel={t(
-				'rooms_invalid',
-				'One or more Meeting rooms are invalid. Try editing them or entering a new one.'
-			)}
-			duplicateChipsErrorLabel={t(
-				'duplicate_rooms_error',
-				'One or more Meeting rooms were selected multiple times. Consider removing the duplicates.'
-			)}
+			errorLabels={errorLabels}
 		/>
 	);
 };

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -367,14 +367,14 @@ export const EditorResourceComponent = ({
 	}, [resourcesValue, attendeesAvailabilityList, start, end, allDay]);
 
 	const chipInputDescription = useMemo(() => {
+		if (hasUnavailableResources) {
+			return resourcesValue.length === 1 ? singleWarningLabel : warningLabel;
+		}
 		if (hasError) {
 			return invalidInputErrorLabel;
 		}
 		if (hasDuplicateValidChips) {
 			return duplicateChipsErrorLabel;
-		}
-		if (hasUnavailableResources) {
-			return resourcesValue.length === 1 ? singleWarningLabel : warningLabel;
 		}
 		return undefined;
 	}, [

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -86,16 +86,29 @@ export const normalizeResources = (r: Contact): Resource => ({
 });
 
 interface EditorResourceComponentProps {
+	/** The unique identifier for the editor instance */
 	editorId: string;
+	/** Callback fired when the resource selection changes */
 	onChange: (items: Array<Resource>) => void;
+	/** Function to search for resource options based on input string */
 	onSearchOptions: (stringToSearch: string) => Promise<Array<ResourceInputOption>>;
+	/** Placeholder text for the input field */
 	placeholder: string;
+	/** Currently selected resources */
 	resourcesValue: Array<Resource>;
-	warningLabel: string;
+	/** Whether the component is disabled */
 	disabled?: boolean;
-	singleWarningLabel: string;
-	invalidInputErrorLabel: string;
-	duplicateChipsErrorLabel: string;
+	/** Error message labels for different scenarios */
+	errorLabels: {
+		/** Label shown when a single resource is unavailable */
+		singleResourceUnavailable: string;
+		/** Label shown when multiple resources are unavailable */
+		multipleResourcesUnavailable: string;
+		/** Label shown when resources have invalid data */
+		invalidResource: string;
+		/** Label shown when duplicate resources are selected */
+		duplicateResources: string;
+	};
 }
 
 type ResourceChipItem = ChipItem<Resource> & {
@@ -111,11 +124,8 @@ export const EditorResourceComponent = ({
 	placeholder,
 	resourcesValue,
 	onSearchOptions,
-	warningLabel,
-	disabled,
-	singleWarningLabel,
-	invalidInputErrorLabel,
-	duplicateChipsErrorLabel
+	errorLabels,
+	disabled
 }: EditorResourceComponentProps): JSX.Element | null => {
 	const [t] = useTranslation();
 
@@ -306,7 +316,7 @@ export const EditorResourceComponent = ({
 
 					actions.unshift({
 						id: 'unavailable',
-						label: singleWarningLabel,
+						label: errorLabels.singleResourceUnavailable,
 						color: 'error',
 						type: 'icon',
 						icon: 'AlertTriangle'
@@ -327,7 +337,7 @@ export const EditorResourceComponent = ({
 		editingResource,
 		end,
 		resourcesValue,
-		singleWarningLabel,
+		errorLabels.singleResourceUnavailable,
 		start
 	]);
 
@@ -368,23 +378,25 @@ export const EditorResourceComponent = ({
 
 	const chipInputDescription = useMemo(() => {
 		if (hasUnavailableResources) {
-			return resourcesValue.length === 1 ? singleWarningLabel : warningLabel;
+			return resourcesValue.length === 1
+				? errorLabels.singleResourceUnavailable
+				: errorLabels.multipleResourcesUnavailable;
 		}
 		if (hasError) {
-			return invalidInputErrorLabel;
+			return errorLabels.invalidResource;
 		}
 		if (hasDuplicateValidChips) {
-			return duplicateChipsErrorLabel;
+			return errorLabels.duplicateResources;
 		}
 		return undefined;
 	}, [
 		hasError,
 		hasDuplicateValidChips,
 		hasUnavailableResources,
-		invalidInputErrorLabel,
-		duplicateChipsErrorLabel,
-		singleWarningLabel,
-		warningLabel,
+		errorLabels.invalidResource,
+		errorLabels.duplicateResources,
+		errorLabels.singleResourceUnavailable,
+		errorLabels.multipleResourcesUnavailable,
 		resourcesValue.length
 	]);
 

--- a/src/view/editor/parts/editor-resource-component.tsx
+++ b/src/view/editor/parts/editor-resource-component.tsx
@@ -21,10 +21,7 @@ import { find } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
-import {
-	EditorAvailabilityWarningRow,
-	getIsBusyAtTimeOfTheEvent
-} from './editor-availability-warning-row';
+import { getIsBusyAtTimeOfTheEvent } from './editor-availability-warning-row';
 import { generateResourceId, getDuplicateResourceIds, isValidResource } from './utils';
 import { useAttendeesAvailability } from '../../../hooks/use-attendees-availability';
 import { useAppSelector } from '../../../store/redux/hooks';
@@ -357,6 +354,18 @@ export const EditorResourceComponent = ({
 
 	useKeyboard(inputRef, onPressingEnterSelectFirstOption);
 
+	const hasUnavailableResources = useMemo(() => {
+		if (!resourcesValue?.length || !attendeesAvailabilityList) return false;
+
+		return resourcesValue.some((resource) => {
+			const roomInList = find(attendeesAvailabilityList, ['email', resource.email]);
+			return (
+				roomInList &&
+				getIsBusyAtTimeOfTheEvent(roomInList, start, end, attendeesAvailabilityList, allDay)
+			);
+		});
+	}, [resourcesValue, attendeesAvailabilityList, start, end, allDay]);
+
 	const chipInputDescription = useMemo(() => {
 		if (hasError) {
 			return invalidInputErrorLabel;
@@ -364,8 +373,20 @@ export const EditorResourceComponent = ({
 		if (hasDuplicateValidChips) {
 			return duplicateChipsErrorLabel;
 		}
+		if (hasUnavailableResources) {
+			return resourcesValue.length === 1 ? singleWarningLabel : warningLabel;
+		}
 		return undefined;
-	}, [hasError, hasDuplicateValidChips, invalidInputErrorLabel, duplicateChipsErrorLabel]);
+	}, [
+		hasError,
+		hasDuplicateValidChips,
+		hasUnavailableResources,
+		invalidInputErrorLabel,
+		duplicateChipsErrorLabel,
+		singleWarningLabel,
+		warningLabel,
+		resourcesValue.length
+	]);
 
 	return (
 		<Container width="100%" height="100%">
@@ -385,14 +406,8 @@ export const EditorResourceComponent = ({
 					{ code: 'NumpadEnter', ctrlKey: false }
 				]}
 				onInputType={handleInputType}
-				hasError={hasError || hasDuplicateValidChips}
+				hasError={hasError || hasDuplicateValidChips || hasUnavailableResources}
 				description={chipInputDescription}
-			/>
-			<EditorAvailabilityWarningRow
-				label={warningLabel}
-				list={attendeesAvailabilityList}
-				items={resourceAvailability}
-				editorId={editorId}
 			/>
 		</Container>
 	);

--- a/src/view/editor/parts/tests/editor-resource-component.test.tsx
+++ b/src/view/editor/parts/tests/editor-resource-component.test.tsx
@@ -13,8 +13,9 @@ import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { generateEditor } from '../../../../commons/editor-generator';
 import { reducers } from '../../../../store/redux';
 import { Resource } from '../../../../types/editor';
-import { EditorResourceComponent } from '../editor-resource-component';
 import { setupTest } from '@test-setup';
+
+import { EditorResourceComponent } from '../editor-resource-component';
 
 describe('EditorResourceComponent', () => {
 	let store: ReturnType<typeof configureStore>;
@@ -472,6 +473,110 @@ describe('EditorResourceComponent', () => {
 			await user.keyboard('{Control>}{Enter}{/Control}');
 
 			expect(dropDownItem).not.toBeInTheDocument();
+		});
+	});
+
+	describe('Unified Error Reporting', () => {
+		const availableResource: Resource = {
+			id: 'available-room',
+			label: 'Available Room',
+			email: 'availableroom@example.com',
+			type: 'Location'
+		};
+
+		const invalidResource: Resource = {
+			id: '',
+			label: 'Invalid Resource',
+			email: '',
+			type: 'Location'
+		};
+
+		it('shows validation error with highest priority when resource is invalid', async () => {
+			setupTest(
+				<EditorResourceComponent
+					placeholder="Test"
+					editorId={editor.id}
+					onChange={onChangeMock}
+					onSearchOptions={mockSearchOptions}
+					resourcesValue={[invalidResource]}
+					warningLabel="Multiple resources unavailable"
+					singleWarningLabel="Resource unavailable"
+					invalidInputErrorLabel="Invalid input detected"
+					duplicateChipsErrorLabel="Duplicate resources detected"
+				/>,
+				{ store }
+			);
+
+			await waitFor(() => {
+				expect(screen.getByText('Invalid input detected')).toBeInTheDocument();
+				expect(screen.queryByText('Multiple resources unavailable')).not.toBeInTheDocument();
+				expect(screen.queryByText('Duplicate resources detected')).not.toBeInTheDocument();
+			});
+		});
+
+		it('shows duplicate error when no validation errors exist', async () => {
+			setupTest(
+				<EditorResourceComponent
+					placeholder="Test"
+					editorId={editor.id}
+					onChange={onChangeMock}
+					onSearchOptions={mockSearchOptions}
+					resourcesValue={[defaultResource, defaultResource]}
+					warningLabel="Multiple resources unavailable"
+					singleWarningLabel="Resource unavailable"
+					invalidInputErrorLabel="Invalid input detected"
+					duplicateChipsErrorLabel="Duplicate resources detected"
+				/>,
+				{ store }
+			);
+
+			await waitFor(() => {
+				expect(screen.getByText('Duplicate resources detected')).toBeInTheDocument();
+				expect(screen.queryByText('Invalid input detected')).not.toBeInTheDocument();
+				expect(screen.queryByText('Multiple resources unavailable')).not.toBeInTheDocument();
+			});
+		});
+
+		it('shows no error when all resources are valid and available', async () => {
+			const mockUseAttendeesAvailability = jest.fn();
+
+			jest.mock('../../../../hooks/use-attendees-availability', () => ({
+				useAttendeesAvailability: () => mockUseAttendeesAvailability()
+			}));
+
+			mockUseAttendeesAvailability.mockReturnValue([
+				{
+					id: availableResource.id,
+					email: availableResource.email,
+					b: [],
+					f: [{ s: 1640995200000, e: 1641081600000 }],
+					t: []
+				}
+			]);
+
+			setupTest(
+				<EditorResourceComponent
+					placeholder="Test"
+					editorId={editor.id}
+					onChange={onChangeMock}
+					onSearchOptions={mockSearchOptions}
+					resourcesValue={[availableResource]}
+					warningLabel="Multiple resources unavailable"
+					singleWarningLabel="Resource unavailable"
+					invalidInputErrorLabel="Invalid input detected"
+					duplicateChipsErrorLabel="Duplicate resources detected"
+				/>,
+				{ store }
+			);
+
+			await waitFor(() => {
+				expect(screen.queryByText('Multiple resources unavailable')).not.toBeInTheDocument();
+				expect(screen.queryByText('Resource unavailable')).not.toBeInTheDocument();
+				expect(screen.queryByText('Invalid input detected')).not.toBeInTheDocument();
+				expect(screen.queryByText('Duplicate resources detected')).not.toBeInTheDocument();
+			});
+
+			jest.unmock('../../../../hooks/use-attendees-availability');
 		});
 	});
 });

--- a/src/view/editor/parts/tests/editor-resource-component.test.tsx
+++ b/src/view/editor/parts/tests/editor-resource-component.test.tsx
@@ -36,6 +36,13 @@ describe('EditorResourceComponent', () => {
 		}
 	]);
 
+	const defaultErrorLabels = {
+		singleResourceUnavailable: 'Resource unavailable',
+		multipleResourcesUnavailable: 'Multiple resources unavailable',
+		invalidResource: 'Invalid input',
+		duplicateResources: 'Duplicate input'
+	};
+
 	beforeEach(() => {
 		store = configureStore({ reducer: combineReducers(reducers) });
 		editor = generateEditor({ context: { dispatch: store.dispatch, folders: {} } });
@@ -52,10 +59,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={() => Promise.resolve([])}
 					resourcesValue={[defaultResource]}
-					warningLabel=""
-					singleWarningLabel=""
-					invalidInputErrorLabel="Invalid input"
-					duplicateChipsErrorLabel={'Duplicate input'}
+					errorLabels={defaultErrorLabels}
 				/>,
 				{ store }
 			);
@@ -75,10 +79,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[]}
-					warningLabel=""
-					singleWarningLabel=""
-					invalidInputErrorLabel="Invalid input"
-					duplicateChipsErrorLabel={'Duplicate input'}
+					errorLabels={defaultErrorLabels}
 				/>,
 				{ store }
 			);
@@ -130,10 +131,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions2}
 					resourcesValue={[]}
-					warningLabel=""
-					singleWarningLabel=""
-					invalidInputErrorLabel="Invalid input"
-					duplicateChipsErrorLabel={'Duplicate input'}
+					errorLabels={defaultErrorLabels}
 				/>,
 				{ store }
 			);
@@ -164,10 +162,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={() => new Promise((resolve) => setTimeout(() => resolve([]), 1000))}
 					resourcesValue={[]}
-					warningLabel=""
-					singleWarningLabel=""
-					invalidInputErrorLabel="Invalid input"
-					duplicateChipsErrorLabel={'Duplicate input'}
+					errorLabels={defaultErrorLabels}
 				/>,
 				{ store }
 			);
@@ -190,10 +185,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[]}
-					warningLabel=""
-					singleWarningLabel=""
-					invalidInputErrorLabel="Invalid input"
-					duplicateChipsErrorLabel={'Duplicate input'}
+					errorLabels={defaultErrorLabels}
 				/>,
 				{ store }
 			);
@@ -216,10 +208,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[]}
-					warningLabel=""
-					singleWarningLabel=""
-					invalidInputErrorLabel="Invalid input"
-					duplicateChipsErrorLabel={'Duplicate input'}
+					errorLabels={defaultErrorLabels}
 				/>,
 				{ store }
 			);
@@ -238,10 +227,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[defaultResource, defaultResource]}
-					warningLabel=""
-					singleWarningLabel=""
-					invalidInputErrorLabel="Invalid input"
-					duplicateChipsErrorLabel={'Duplicate input'}
+					errorLabels={defaultErrorLabels}
 				/>,
 				{ store }
 			);
@@ -259,10 +245,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[{ label: 'chip101', email: '' }, defaultResource, defaultResource]}
-					warningLabel=""
-					singleWarningLabel=""
-					invalidInputErrorLabel="Invalid input"
-					duplicateChipsErrorLabel={'Duplicate input'}
+					errorLabels={defaultErrorLabels}
 				/>,
 				{ store }
 			);
@@ -282,10 +265,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[defaultResource]}
-					warningLabel=""
-					singleWarningLabel=""
-					invalidInputErrorLabel="Invalid input"
-					duplicateChipsErrorLabel={'Duplicate input'}
+					errorLabels={defaultErrorLabels}
 				/>,
 				{ store }
 			);
@@ -321,10 +301,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={() => Promise.resolve([])}
 					resourcesValue={[]}
-					warningLabel=""
-					singleWarningLabel=""
-					invalidInputErrorLabel="Invalid input"
-					duplicateChipsErrorLabel={'Duplicate input'}
+					errorLabels={defaultErrorLabels}
 				/>,
 				{ store }
 			);
@@ -351,10 +328,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[]}
-					warningLabel=""
-					singleWarningLabel=""
-					invalidInputErrorLabel="Invalid input"
-					duplicateChipsErrorLabel={'Duplicate input'}
+					errorLabels={defaultErrorLabels}
 				/>,
 				{ store }
 			);
@@ -387,10 +361,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[defaultResource]}
-					warningLabel=""
-					singleWarningLabel=""
-					invalidInputErrorLabel="Invalid input"
-					duplicateChipsErrorLabel={'Duplicate input'}
+					errorLabels={defaultErrorLabels}
 				/>,
 				{ store }
 			);
@@ -413,10 +384,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[defaultResource]}
-					warningLabel=""
-					singleWarningLabel=""
-					invalidInputErrorLabel="Invalid input"
-					duplicateChipsErrorLabel={'Duplicate input'}
+					errorLabels={defaultErrorLabels}
 				/>,
 				{ store }
 			);
@@ -455,10 +423,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[]}
-					warningLabel=""
-					singleWarningLabel=""
-					invalidInputErrorLabel="Invalid input"
-					duplicateChipsErrorLabel={'Duplicate input'}
+					errorLabels={defaultErrorLabels}
 				/>,
 				{ store }
 			);
@@ -499,10 +464,12 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[invalidResource]}
-					warningLabel="Multiple resources unavailable"
-					singleWarningLabel="Resource unavailable"
-					invalidInputErrorLabel="Invalid input detected"
-					duplicateChipsErrorLabel="Duplicate resources detected"
+					errorLabels={{
+						singleResourceUnavailable: 'Resource unavailable',
+						multipleResourcesUnavailable: 'Multiple resources unavailable',
+						invalidResource: 'Invalid input detected',
+						duplicateResources: 'Duplicate resources detected'
+					}}
 				/>,
 				{ store }
 			);
@@ -522,10 +489,12 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[defaultResource, defaultResource]}
-					warningLabel="Multiple resources unavailable"
-					singleWarningLabel="Resource unavailable"
-					invalidInputErrorLabel="Invalid input detected"
-					duplicateChipsErrorLabel="Duplicate resources detected"
+					errorLabels={{
+						singleResourceUnavailable: 'Resource unavailable',
+						multipleResourcesUnavailable: 'Multiple resources unavailable',
+						invalidResource: 'Invalid input detected',
+						duplicateResources: 'Duplicate resources detected'
+					}}
 				/>,
 				{ store }
 			);
@@ -561,10 +530,12 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[availableResource]}
-					warningLabel="Multiple resources unavailable"
-					singleWarningLabel="Resource unavailable"
-					invalidInputErrorLabel="Invalid input detected"
-					duplicateChipsErrorLabel="Duplicate resources detected"
+					errorLabels={{
+						singleResourceUnavailable: 'Resource unavailable',
+						multipleResourcesUnavailable: 'Multiple resources unavailable',
+						invalidResource: 'Invalid input detected',
+						duplicateResources: 'Duplicate resources detected'
+					}}
 				/>,
 				{ store }
 			);

--- a/src/view/editor/parts/tests/editor-resource-component.test.tsx
+++ b/src/view/editor/parts/tests/editor-resource-component.test.tsx
@@ -36,7 +36,7 @@ describe('EditorResourceComponent', () => {
 		}
 	]);
 
-	const defaultErrorLabels = {
+	const errorLabelsForTesting = {
 		singleResourceUnavailable: 'Resource unavailable',
 		multipleResourcesUnavailable: 'Multiple resources unavailable',
 		invalidResource: 'Invalid input',
@@ -59,7 +59,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={() => Promise.resolve([])}
 					resourcesValue={[defaultResource]}
-					errorLabels={defaultErrorLabels}
+					errorLabels={errorLabelsForTesting}
 				/>,
 				{ store }
 			);
@@ -79,7 +79,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[]}
-					errorLabels={defaultErrorLabels}
+					errorLabels={errorLabelsForTesting}
 				/>,
 				{ store }
 			);
@@ -131,7 +131,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions2}
 					resourcesValue={[]}
-					errorLabels={defaultErrorLabels}
+					errorLabels={errorLabelsForTesting}
 				/>,
 				{ store }
 			);
@@ -162,7 +162,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={() => new Promise((resolve) => setTimeout(() => resolve([]), 1000))}
 					resourcesValue={[]}
-					errorLabels={defaultErrorLabels}
+					errorLabels={errorLabelsForTesting}
 				/>,
 				{ store }
 			);
@@ -185,7 +185,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[]}
-					errorLabels={defaultErrorLabels}
+					errorLabels={errorLabelsForTesting}
 				/>,
 				{ store }
 			);
@@ -208,7 +208,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[]}
-					errorLabels={defaultErrorLabels}
+					errorLabels={errorLabelsForTesting}
 				/>,
 				{ store }
 			);
@@ -227,7 +227,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[defaultResource, defaultResource]}
-					errorLabels={defaultErrorLabels}
+					errorLabels={errorLabelsForTesting}
 				/>,
 				{ store }
 			);
@@ -245,7 +245,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[{ label: 'chip101', email: '' }, defaultResource, defaultResource]}
-					errorLabels={defaultErrorLabels}
+					errorLabels={errorLabelsForTesting}
 				/>,
 				{ store }
 			);
@@ -265,7 +265,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[defaultResource]}
-					errorLabels={defaultErrorLabels}
+					errorLabels={errorLabelsForTesting}
 				/>,
 				{ store }
 			);
@@ -301,7 +301,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={() => Promise.resolve([])}
 					resourcesValue={[]}
-					errorLabels={defaultErrorLabels}
+					errorLabels={errorLabelsForTesting}
 				/>,
 				{ store }
 			);
@@ -328,7 +328,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[]}
-					errorLabels={defaultErrorLabels}
+					errorLabels={errorLabelsForTesting}
 				/>,
 				{ store }
 			);
@@ -361,7 +361,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[defaultResource]}
-					errorLabels={defaultErrorLabels}
+					errorLabels={errorLabelsForTesting}
 				/>,
 				{ store }
 			);
@@ -384,7 +384,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[defaultResource]}
-					errorLabels={defaultErrorLabels}
+					errorLabels={errorLabelsForTesting}
 				/>,
 				{ store }
 			);
@@ -423,7 +423,7 @@ describe('EditorResourceComponent', () => {
 					onChange={onChangeMock}
 					onSearchOptions={mockSearchOptions}
 					resourcesValue={[]}
-					errorLabels={defaultErrorLabels}
+					errorLabels={errorLabelsForTesting}
 				/>,
 				{ store }
 			);


### PR DESCRIPTION
### Summary
This PR unifies the error reporting mechanisms for ChipInput and availability checks into a single, consistent approach.

### Before
- **ChipInput description field** displayed validation errors (invalid inputs, duplicates).
- **EditorAvailabilityWarningRow** component displayed availability warnings separately as a row below the input.

### After
- **Unified ChipInput description field** now shows all errors in a single place

### Other changes
- refactor: enhance `EditorResourceComponentProps` interface introducing `errorLabel` to consolidate error label props in `EditorResourceComponent`



 :point_right:  **Sonar Note:** Duplicate line reported are false positives, those labels are different. The coverage is 96.2% [see](https://sonar.zextras.tools/dashboard?id=carbonio-calendars-ui&pullRequest=628) 