### PR TITLE
fix: imported ICS cannot be deleted

### DIFF
--- a/src/soap/cancel-appointment-request.ts
+++ b/src/soap/cancel-appointment-request.ts
@@ -12,6 +12,7 @@ type Props = {
 	isOrganizer: boolean;
 	m: any;
 	s: number;
+	comp: number;
 };
 
 export type CancelAppointmentRejectedType = { error: boolean; m?: never; Fault: any };
@@ -26,21 +27,22 @@ export const cancelAppointmentRequest = async ({
 	id,
 	isOrganizer,
 	m,
-	s
+	s,
+	comp
 }: Props): Promise<CancelAppointmentReturnType> => {
 	const body = deleteSingleInstance
 		? {
 				_jsns: 'urn:zimbraMail',
 				inst,
 				id,
-				comp: '0',
+				comp,
 				s,
 				m: isOrganizer ? m : { ...m, e: [] }
 			}
 		: {
 				_jsns: 'urn:zimbraMail',
 				id,
-				comp: '0',
+				comp,
 				m: isOrganizer ? m : { ...m, e: [] }
 			};
 	const response: CancelAppointmentReturnType = await legacySoapFetch('CancelAppointment', body);

--- a/src/soap/counter-appointment-request.ts
+++ b/src/soap/counter-appointment-request.ts
@@ -31,7 +31,7 @@ export const counterAppointmentRequest = async ({
 }): Promise<CounterAppointmentReturnType> => {
 	const res: CounterAppointmentReturnType = await legacySoapFetch('CounterAppointment', {
 		_jsns: 'urn:zimbraMail',
-		comp: '0',
+		comp: appt.compNum ?? 0,
 		id: appt.inviteId?.includes('-') ? appt.inviteId : undefined,
 		m: {
 			e: generateParticipantInformation(appt),

--- a/src/soap/tests/counter-appointment-request.test.ts
+++ b/src/soap/tests/counter-appointment-request.test.ts
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { faker } from '@faker-js/faker';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
+import { JSNS } from '@zextras/carbonio-shell-ui';
+
+import { generateFolder } from '../../__test__/mocks/folders/folders-generator';
+import { createSoapAPIInterceptor } from '../../__test__/mocks/network/msw/create-api-interceptor';
+import { generateEditor } from '../../commons/editor-generator';
+import { reducers } from '../../store/redux';
+import mockedData from '../../test/generators';
+import { generateSoapErrorResponseBody } from '../../test/generators/utils';
+import { counterAppointmentRequest } from '../counter-appointment-request';
+
+describe('counterAppointmentRequest', () => {
+	const folder = generateFolder({ view: 'appointment' });
+	const folders = mockedData.calendars.getCalendarsMap({ folders: [folder] });
+
+	it('returns fulfilled response when no Fault', async () => {
+		const store = configureStore({ reducer: combineReducers(reducers) });
+		const event = mockedData.getEvent();
+		const invite = mockedData.getInvite({ event });
+		const context = { folders, dispatch: store.dispatch };
+		const editor = generateEditor({ invite, context });
+		const response = { jsns: JSNS.mail };
+
+		createSoapAPIInterceptor('CounterAppointment', response);
+
+		const result = await counterAppointmentRequest({ appt: editor });
+		expect(result).toEqual(response);
+	});
+
+	it('returns rejected response when Fault is present', async () => {
+		const store = configureStore({ reducer: combineReducers(reducers) });
+		const event = mockedData.getEvent();
+		const invite = mockedData.getInvite({ event });
+		const context = { folders, dispatch: store.dispatch };
+		const editor = generateEditor({ invite, context });
+		const faultResponse = generateSoapErrorResponseBody();
+		createSoapAPIInterceptor('CounterAppointment', faultResponse);
+
+		const result = await counterAppointmentRequest({ appt: editor });
+
+		expect(result).toEqual({ ...faultResponse.Fault, error: true });
+	});
+
+	it('should send the compNum of the appointment', async () => {
+		const store = configureStore({ reducer: combineReducers(reducers) });
+		const event = mockedData.getEvent({ id: faker.string.uuid() });
+		const invite = mockedData.getInvite({ event });
+
+		const context = { folders, dispatch: store.dispatch };
+		const editor = generateEditor({ invite, context });
+		const response = { jsns: JSNS.mail };
+
+		const apiInterceptor = createSoapAPIInterceptor('CounterAppointment', response);
+
+		await counterAppointmentRequest({ appt: editor });
+		const requestParams = await apiInterceptor;
+		expect(requestParams).toEqual(expect.objectContaining({ comp: invite.compNum }));
+	});
+});

--- a/src/store/actions/move-appointment-to-trash.ts
+++ b/src/store/actions/move-appointment-to-trash.ts
@@ -192,7 +192,8 @@ export const moveAppointmentToTrash = createAsyncThunk<
 			inst,
 			s,
 			m,
-			isOrganizer
+			isOrganizer,
+			comp: invite?.compNum ?? 0
 		});
 		if (response?.error) {
 			return rejectWithValue(response);

--- a/src/store/actions/tests/move-appointment-to-trash.test.ts
+++ b/src/store/actions/tests/move-appointment-to-trash.test.ts
@@ -29,9 +29,11 @@ const defaultParticipant: InviteParticipant = {
 };
 
 const generateMockState = ({
-	organizer = defaultOrganizer
+	organizer = defaultOrganizer,
+	compNum = 0
 }: {
 	organizer?: InviteOrganizer;
+	compNum?: number;
 }): Partial<RootState> => ({
 	invites: {
 		invites: {
@@ -40,7 +42,8 @@ const generateMockState = ({
 				organizer,
 				participants: {
 					AC: [defaultParticipant]
-				}
+				},
+				compNum
 			}
 		},
 		status: ''
@@ -124,7 +127,26 @@ describe('moveAppointmentToTrash', () => {
 		);
 	});
 
-	it.todo(
-		'should call CancelAppointmentRequest with the correct comp number when invite has compNum defined'
-	);
+	it('should call CancelAppointmentRequest with the correct comp number when invite has compNum defined', async () => {
+		const mockStateWithCompNum: Partial<RootState> = generateMockState({
+			organizer: {
+				...defaultOrganizer
+			},
+			compNum: 42
+		});
+		const mockDispatch = jest.fn();
+		const mockGetState = jest.fn(() => mockStateWithCompNum as RootState);
+
+		const thunk = moveAppointmentToTrash(moveAppointmentToTrashParam);
+
+		const cancelAppointmentAPIInterceptor = createSoapAPIInterceptor('CancelAppointment', {});
+		await thunk(mockDispatch, mockGetState, undefined);
+		const request = await cancelAppointmentAPIInterceptor;
+		expect(request).toEqual(
+			expect.objectContaining({
+				id: defaultInviteId,
+				comp: 42
+			})
+		);
+	});
 });

--- a/src/store/actions/tests/move-appointment-to-trash.test.ts
+++ b/src/store/actions/tests/move-appointment-to-trash.test.ts
@@ -123,4 +123,8 @@ describe('moveAppointmentToTrash', () => {
 			})
 		);
 	});
+
+	it.todo(
+		'should call CancelAppointmentRequest with the correct comp number when invite has compNum defined'
+	);
 });


### PR DESCRIPTION
Set the `comp` field with the correct value set on the invite, on the `CancelAppointment` and `CounterAppointment` requests

Refs: CO-2180