### PR TITLE
fix: [CO-2956] Allow selecting different Calendar for scheduling received appointment

### DIFF
--- a/src/shared/invite-response/parts/invite-reply-part.test.tsx
+++ b/src/shared/invite-response/parts/invite-reply-part.test.tsx
@@ -1,0 +1,238 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import React from 'react';
+
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
+import { screen, waitFor } from '@testing-library/react';
+import { useFolderStore } from '@zextras/carbonio-ui-commons';
+import { keyBy } from 'lodash';
+
+import { buildMailMessageType, MESSAGE_TYPE } from '../invite-test-utils';
+import InviteReplyPart from './invite-reply-part';
+import { setupTest } from '@test-setup';
+import { generateRoots } from '@test-utils/folders/roots-generator';
+import { MESSAGE_METHOD } from 'constants/api';
+import { reducers } from 'store/redux';
+import mockedData from 'test/generators';
+
+const SECONDARY_CALENDAR_NAME = 'Secondary Calendar';
+const SHARED_CALENDAR_NAME = 'Shared Calendar';
+const CALENDAR_SELECTOR_TEST_ID = 'calendar-selector';
+
+const store = configureStore({ reducer: combineReducers(reducers) });
+const roots = generateRoots();
+const { defaultCalendar } = mockedData.calendars;
+const secondaryCalendar = mockedData.calendars.getCalendar({
+	id: '11',
+	name: SECONDARY_CALENDAR_NAME,
+	color: 3,
+	perm: 'rwidx'
+});
+const sharedCalendar = mockedData.calendars.getCalendar({
+	id: '12',
+	name: SHARED_CALENDAR_NAME,
+	owner: 'owner@example.com',
+	perm: 'rwidx',
+	isLink: true
+});
+
+const setupFoldersStore = (): void => {
+	useFolderStore.setState(() => ({
+		folders: {
+			...keyBy(roots, 'id'),
+			[defaultCalendar.id]: defaultCalendar,
+			[secondaryCalendar.id]: secondaryCalendar,
+			[sharedCalendar.id]: sharedCalendar
+		}
+	}));
+};
+
+describe('InviteReplyPart - Calendar Selection', () => {
+	beforeEach(() => {
+		setupFoldersStore();
+	});
+
+	describe('Calendar selector rendering', () => {
+		test('renders calendar selector component', async () => {
+			const mailMsg = buildMailMessageType(MESSAGE_METHOD.REQUEST, MESSAGE_TYPE.SINGLE, false);
+
+			setupTest(<InviteReplyPart inviteId={mailMsg.id} message={mailMsg} />, { store });
+
+			const calendarSelector = await screen.findByTestId(CALENDAR_SELECTOR_TEST_ID);
+			expect(calendarSelector).toBeVisible();
+		});
+
+		test('displays "Scheduled in" label for calendar selector', async () => {
+			const mailMsg = buildMailMessageType(MESSAGE_METHOD.REQUEST, MESSAGE_TYPE.SINGLE, false);
+
+			setupTest(<InviteReplyPart inviteId={mailMsg.id} message={mailMsg} />, { store });
+
+			const scheduledInLabel = await screen.findByText('Scheduled in');
+			expect(scheduledInLabel).toBeVisible();
+		});
+
+		test('displays the parent calendar as initially selected', async () => {
+			const mailMsg = buildMailMessageType(MESSAGE_METHOD.REQUEST, MESSAGE_TYPE.SINGLE, false, {
+				parent: defaultCalendar.id
+			});
+
+			setupTest(<InviteReplyPart inviteId={mailMsg.id} message={mailMsg} />, { store });
+
+			const calendarSelector = await screen.findByTestId(CALENDAR_SELECTOR_TEST_ID);
+			expect(calendarSelector).toBeVisible();
+
+			await waitFor(() => {
+				expect(screen.getByText('Calendar')).toBeVisible();
+			});
+		});
+	});
+
+	describe('Calendar selection interaction', () => {
+		test('allows user to select a different calendar', async () => {
+			const mailMsg = buildMailMessageType(MESSAGE_METHOD.REQUEST, MESSAGE_TYPE.SINGLE, false, {
+				parent: defaultCalendar.id
+			});
+
+			const { user } = setupTest(<InviteReplyPart inviteId={mailMsg.id} message={mailMsg} />, {
+				store
+			});
+
+			const calendarSelector = await screen.findByTestId(CALENDAR_SELECTOR_TEST_ID);
+			expect(calendarSelector).toBeVisible();
+
+			await user.click(screen.getByText(/^Calendar$/i));
+			await user.click(screen.getAllByText(/secondary calendar/i)[0]);
+
+			await waitFor(() => {
+				expect(screen.getByText('Secondary Calendar')).toBeVisible();
+			});
+		});
+
+		test('shows shared calendars with write permission in calendar list', async () => {
+			const mailMsg = buildMailMessageType(MESSAGE_METHOD.REQUEST, MESSAGE_TYPE.SINGLE, false, {
+				parent: defaultCalendar.id
+			});
+
+			const { user } = setupTest(<InviteReplyPart inviteId={mailMsg.id} message={mailMsg} />, {
+				store
+			});
+
+			await user.click(screen.getByText(/^Calendar$/i));
+
+			const sharedCalOptions = await screen.findAllByText(/Shared Calendar/i);
+			expect(sharedCalOptions[0]).toBeVisible();
+		});
+
+		test('persists calendar selection across multiple changes', async () => {
+			const mailMsg = buildMailMessageType(MESSAGE_METHOD.REQUEST, MESSAGE_TYPE.SINGLE, false, {
+				parent: defaultCalendar.id
+			});
+
+			const { user } = setupTest(<InviteReplyPart inviteId={mailMsg.id} message={mailMsg} />, {
+				store
+			});
+
+			await user.click(screen.getByText(/^Calendar$/i));
+			await user.click((await screen.findAllByText(/Secondary Calendar/i))[0]);
+			await waitFor(() => {
+				expect(screen.getByText('Secondary Calendar')).toBeVisible();
+			});
+
+			await user.click(screen.getAllByText(/Secondary Calendar/i)[0]);
+			await user.click((await screen.findAllByText(/Shared Calendar/i))[0]);
+			await waitFor(() => {
+				expect(screen.getByText('Shared Calendar')).toBeVisible();
+			});
+
+			await user.click(screen.getAllByText(/Shared Calendar/i)[0]);
+			await user.click(await screen.findByText(/^Calendar$/i));
+			await waitFor(() => {
+				expect(screen.getByText('Calendar')).toBeVisible();
+			});
+		});
+	});
+
+	describe('Component features', () => {
+		test('renders notify organizer checkbox that is checked by default', async () => {
+			const mailMsg = buildMailMessageType(MESSAGE_METHOD.REQUEST, MESSAGE_TYPE.SINGLE, false);
+
+			setupTest(<InviteReplyPart inviteId={mailMsg.id} message={mailMsg} />, { store });
+
+			expect(await screen.findByText(/Notify Organizer/i)).toBeVisible();
+			expect(await screen.findByTestId('icon: CheckmarkSquare')).toBeVisible();
+		});
+
+		test('renders action buttons for accept, tentative, decline, and propose new time', async () => {
+			const mailMsg = buildMailMessageType(MESSAGE_METHOD.REQUEST, MESSAGE_TYPE.SINGLE, false);
+
+			setupTest(<InviteReplyPart inviteId={mailMsg.id} message={mailMsg} />, { store });
+
+			expect(await screen.findByRole('button', { name: /Accept/i })).toBeVisible();
+			expect(screen.getByRole('button', { name: /Tentative/i })).toBeVisible();
+			expect(screen.getByRole('button', { name: /Decline/i })).toBeVisible();
+			expect(screen.getByRole('button', { name: /Propose new time/i })).toBeVisible();
+		});
+
+		test('calendar selection state is independent of notify organizer checkbox state', async () => {
+			const mailMsg = buildMailMessageType(MESSAGE_METHOD.REQUEST, MESSAGE_TYPE.SINGLE, false, {
+				parent: defaultCalendar.id
+			});
+
+			const { user } = setupTest(<InviteReplyPart inviteId={mailMsg.id} message={mailMsg} />, {
+				store
+			});
+
+			await user.click(screen.getByText(/^Calendar$/i));
+			await user.click((await screen.findAllByText(/Secondary Calendar/i))[0]);
+			await waitFor(() => {
+				expect(screen.getByText('Secondary Calendar')).toBeVisible();
+			});
+
+			const notifyCheckbox = screen.getByTestId('checkbox');
+			await user.click(notifyCheckbox);
+
+			expect(screen.getByText('Secondary Calendar')).toBeVisible();
+			await waitFor(() => {
+				expect(screen.getByTestId('icon: Square')).toBeVisible();
+			});
+
+			await user.click(notifyCheckbox);
+
+			expect(screen.getByText('Secondary Calendar')).toBeVisible();
+			await waitFor(() => {
+				expect(screen.getByTestId('icon: CheckmarkSquare')).toBeVisible();
+			});
+		});
+	});
+
+	describe('Calendar selector configuration', () => {
+		test('excludes trash calendars from calendar selector options', async () => {
+			const trashCalendar = mockedData.calendars.getCalendar({
+				id: '3',
+				name: 'Trash',
+				absFolderPath: '/Trash'
+			});
+
+			useFolderStore.setState((state) => ({
+				folders: {
+					...state.folders,
+					[trashCalendar.id]: trashCalendar
+				}
+			}));
+
+			const mailMsg = buildMailMessageType(MESSAGE_METHOD.REQUEST, MESSAGE_TYPE.SINGLE, false);
+
+			const { user } = setupTest(<InviteReplyPart inviteId={mailMsg.id} message={mailMsg} />, {
+				store
+			});
+
+			await user.click(screen.getByText(/^Calendar$/i));
+
+			expect(screen.queryByText(/^Trash$/i)).not.toBeInTheDocument();
+		});
+	});
+});

--- a/src/shared/invite-response/parts/invite-reply-part.test.tsx
+++ b/src/shared/invite-response/parts/invite-reply-part.test.tsx
@@ -59,7 +59,7 @@ describe('InviteReplyPart - Calendar Selection', () => {
 	describe('Calendar selector rendering', () => {
 		test('renders calendar selector component', async () => {
 			const mailMsg = buildMailMessageType(MESSAGE_METHOD.REQUEST, MESSAGE_TYPE.SINGLE, false);
-
+			const store = configureStore({ reducer: combineReducers(reducers) });
 			setupTest(<InviteReplyPart inviteId={mailMsg.id} message={mailMsg} />, { store });
 
 			const calendarSelector = await screen.findByTestId(CALENDAR_SELECTOR_TEST_ID);
@@ -68,7 +68,7 @@ describe('InviteReplyPart - Calendar Selection', () => {
 
 		test('displays "Scheduled in" label for calendar selector', async () => {
 			const mailMsg = buildMailMessageType(MESSAGE_METHOD.REQUEST, MESSAGE_TYPE.SINGLE, false);
-
+			const store = configureStore({ reducer: combineReducers(reducers) });
 			setupTest(<InviteReplyPart inviteId={mailMsg.id} message={mailMsg} />, { store });
 
 			const scheduledInLabel = await screen.findByText('Scheduled in');
@@ -92,6 +92,21 @@ describe('InviteReplyPart - Calendar Selection', () => {
 	});
 
 	describe('Calendar selection interaction', () => {
+		test('initializes with parent calendar selected and maintains state when accepting without calendar change', async () => {
+			const mailMsg = buildMailMessageType(MESSAGE_METHOD.REQUEST, MESSAGE_TYPE.SINGLE, false, {
+				parent: defaultCalendar.id
+			});
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			setupTest(<InviteReplyPart inviteId={mailMsg.id} message={mailMsg} />, { store });
+
+			await waitFor(() => {
+				expect(screen.getByText('Calendar')).toBeVisible();
+			});
+
+			const acceptButton = await screen.findByRole('button', { name: /Accept/i });
+			expect(acceptButton).toBeEnabled();
+		});
+
 		test('allows user to select a different calendar', async () => {
 			const mailMsg = buildMailMessageType(MESSAGE_METHOD.REQUEST, MESSAGE_TYPE.SINGLE, false, {
 				parent: defaultCalendar.id

--- a/src/shared/invite-response/parts/invite-reply-part.tsx
+++ b/src/shared/invite-response/parts/invite-reply-part.tsx
@@ -73,6 +73,7 @@ const normalizeEditorFromMailMessage = (
 const InviteReplyPart: FC<InviteReplyPartArguments> = ({ inviteId, message }): ReactElement => {
 	const [notifyOrganizer, setNotifyOrganizer] = useState(true);
 	const [activeCalendar, setActiveCalendar] = useState<Folder | null>(null);
+	const [selectedCalendarId, setSelectedCalendarId] = useState<string>(message.parent);
 	const createSnackbar = useSnackbar();
 	const [t] = useTranslation();
 	const dispatch = useAppDispatch();
@@ -168,8 +169,11 @@ const InviteReplyPart: FC<InviteReplyPartArguments> = ({ inviteId, message }): R
 				</Container>
 				<Container width="65%" mainAlignment="flex-start">
 					<CalendarSelector
-						calendarId={message.parent}
-						onCalendarChange={(cal): void => setActiveCalendar(cal)}
+						calendarId={selectedCalendarId}
+						onCalendarChange={(cal): void => {
+							setActiveCalendar(cal);
+							setSelectedCalendarId(cal.id);
+						}}
 						label={t('label.scheduled_in', 'Scheduled in')}
 						excludeTrash
 					/>

--- a/src/shared/invite-response/parts/invite-reply-part.tsx
+++ b/src/shared/invite-response/parts/invite-reply-part.tsx
@@ -19,22 +19,15 @@ import { useHistoryNavigation, useFoldersMap, Folder } from '@zextras/carbonio-u
 import moment from 'moment';
 import { useTranslation } from 'react-i18next';
 
-import { generateEditor } from '../../../commons/editor-generator';
-import { CALENDAR_BOARD_ID } from '../../../constants';
-import { PARTICIPATION_STATUS } from '../../../constants/api';
-import {
-	getEquipments,
-	getMeetingRooms,
-	getVirtualRoom
-} from '../../../normalizations/normalize-editor';
-import { useAppDispatch } from '../../../store/redux/hooks';
-import { Editor } from '../../../types/editor';
-import type {
-	InviteReplyPartArguments,
-	InviteResponseArguments
-} from '../../../types/integrations';
-import { CalendarSelector } from '../../../view/editor/parts/calendar-selector';
 import { sendResponse } from '../invite-reply-actions';
+import { generateEditor } from 'commons/editor-generator';
+import { PARTICIPATION_STATUS } from 'constants/api';
+import { CALENDAR_BOARD_ID } from 'constants/index';
+import { getEquipments, getMeetingRooms, getVirtualRoom } from 'normalizations/normalize-editor';
+import { useAppDispatch } from 'store/redux/hooks';
+import { Editor } from 'types/editor';
+import type { InviteReplyPartArguments, InviteResponseArguments } from 'types/integrations';
+import { CalendarSelector } from 'view/editor/parts/calendar-selector';
 
 const normalizeEditorFromMailMessage = (
 	messageData: InviteResponseArguments['mailMsg']
@@ -72,13 +65,16 @@ const normalizeEditorFromMailMessage = (
 
 const InviteReplyPart: FC<InviteReplyPartArguments> = ({ inviteId, message }): ReactElement => {
 	const [notifyOrganizer, setNotifyOrganizer] = useState(true);
-	const [activeCalendar, setActiveCalendar] = useState<Folder | null>(null);
-	const [selectedCalendarId, setSelectedCalendarId] = useState<string>(message.parent);
 	const createSnackbar = useSnackbar();
 	const [t] = useTranslation();
 	const dispatch = useAppDispatch();
 	const calendarFolders = useFoldersMap();
 	const { replaceHistory } = useHistoryNavigation();
+
+	const [selectedCalendarId, setSelectedCalendarId] = useState<string>(message.parent);
+	const [activeCalendar, setActiveCalendar] = useState<Folder | null>(
+		() => calendarFolders[message.parent] ?? null
+	);
 
 	const proposeNewTimeCb = useCallback(() => {
 		const messageData = message.invite[0].comp[0];


### PR DESCRIPTION
This PR enables users to select a different calendar when scheduling received appointments. Previously, the calendar selector was bound to the message's parent calendar without the ability to change it.

**Key Changes:**
- Added state management for tracking the selected calendar ID independently from the message parent
- Updated the CalendarSelector component to support dynamic calendar selection with proper state updates
