### PR TITLE
fix: [CO-3029] update @zextras/carbonio-ui-text-composer to version 1.0.1-devel.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@zextras/carbonio-ui-commons": "2.0.1-devel.4",
 				"@zextras/carbonio-ui-preview": "4.0.1-devel.1",
 				"@zextras/carbonio-ui-soap-lib": "1.0.4",
-				"@zextras/carbonio-ui-text-composer": "1.0.1-devel.1",
+				"@zextras/carbonio-ui-text-composer": "1.0.1-devel.2",
 				"core-js": "^3.39.0",
 				"darkreader": "^4.9.79",
 				"date-arithmetic": "^4.1.0",
@@ -7232,9 +7232,9 @@
 			}
 		},
 		"node_modules/@zextras/carbonio-ui-text-composer": {
-			"version": "1.0.1-devel.1",
-			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-text-composer/-/carbonio-ui-text-composer-1.0.1-devel.1.tgz",
-			"integrity": "sha512-3mH6PGsA8ODIFxToRjsg+9Jvp3xMxFguKtYQ2EnSvFVAuI++B73lNUYf3tEYE13idheNWWfT4vxjv80tcp00Zg==",
+			"version": "1.0.1-devel.2",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-text-composer/-/carbonio-ui-text-composer-1.0.1-devel.2.tgz",
+			"integrity": "sha512-Cb9DnDlj6cK0lGXzXmxq0ltPeWawYUq9o08ilryCosMxFFKBw0cXBc4nyshD7Qe6p8ZsaZXDByKvTt0UB9KHyQ==",
 			"license": "AGPL-3.0-only",
 			"dependencies": {
 				"@tinymce/tinymce-react": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 		"@zextras/carbonio-ui-commons": "2.0.1-devel.4",
 		"@zextras/carbonio-ui-preview": "4.0.1-devel.1",
 		"@zextras/carbonio-ui-soap-lib": "1.0.4",
-		"@zextras/carbonio-ui-text-composer": "1.0.1-devel.1",
+		"@zextras/carbonio-ui-text-composer": "1.0.1-devel.2",
 		"core-js": "^3.39.0",
 		"darkreader": "^4.9.79",
 		"date-arithmetic": "^4.1.0",


### PR DESCRIPTION
This PR is to use latest composer lib in Calendars module. 

Even if the module is not directly impacted ATM. It adds benefits from latest changes that were made on the lib.