### PR TITLE
feat(CO-3168): Improve UX of Weekly repeat in Custom Recurrence dialog

### DIFF
--- a/src/view/editor/parts/recurrence/components/weekday-checkboxes.tsx
+++ b/src/view/editor/parts/recurrence/components/weekday-checkboxes.tsx
@@ -34,7 +34,7 @@ export const WeekdayCheckboxes = ({
 				const newValue = [...value, { day: opt.value }];
 				setValue(newValue);
 				onClick(newValue);
-			} else {
+			} else if (value.length > 1) {
 				const newValue = reject(value, { day: opt.value });
 				setValue(newValue);
 				onClick(newValue);

--- a/src/view/editor/parts/recurrence/components/weekday-checkboxes.tsx
+++ b/src/view/editor/parts/recurrence/components/weekday-checkboxes.tsx
@@ -5,10 +5,10 @@
  */
 import React, { ReactElement, useCallback } from 'react';
 
-import { Checkbox, Container } from '@zextras/carbonio-design-system';
+import { Button, Row } from '@zextras/carbonio-design-system';
 import { find, map, reject } from 'lodash';
 
-import { useRecurrenceItems } from '../../../../../commons/use-recurrence-items';
+import { useRecurrenceItems } from 'commons/use-recurrence-items';
 
 type WeekdayCheckboxesProps = {
 	value: { day: string }[];
@@ -44,28 +44,22 @@ export const WeekdayCheckboxes = ({
 	);
 
 	return isHidden ? null : (
-		<>
+		<Row width="fill" mainAlignment="space-between" wrap="nowrap">
 			{map(weekDays, (opt) => {
 				const isChecked = !!find(value, ({ day }) => day === opt.value);
 				return (
-					<Container
+					<Button
 						key={`week_day_${opt.value}`}
-						orientation="horizontal"
+						type={isChecked ? 'default' : 'outlined'}
+						label={opt.label.slice(0, 3).toUpperCase()}
+						onClick={(): void => onCheckboxClick(opt)}
+						disabled={disabled}
+						labelColor={isChecked ? 'white' : 'primary'}
+						size="medium"
 						width="fit"
-						mainAlignment="flex-start"
-						padding={{ horizontal: 'small' }}
-					>
-						<Checkbox
-							size="small"
-							key={opt.label}
-							onClick={(): void => onCheckboxClick(opt)}
-							label={opt.label.slice(0, 3)}
-							value={isChecked}
-							disabled={disabled}
-						/>
-					</Container>
+					/>
 				);
 			})}
-		</>
+		</Row>
 	);
 };

--- a/src/view/editor/parts/recurrence/views/custom-recurrence-modal.test.tsx
+++ b/src/view/editor/parts/recurrence/views/custom-recurrence-modal.test.tsx
@@ -116,26 +116,6 @@ describe('CustomRecurrenceModal', () => {
 	});
 
 	describe('Default States by Frequency', () => {
-		it('should show "every" + "day" options when "week" is selected', async () => {
-			const { store, editor } = createStoreWithEditor();
-
-			const { user } = setupTest(<CustomRecurrenceModal editorId={editor.id} onClose={vi.fn()} />, {
-				store
-			});
-
-			await selectFrequency(user, 'week');
-
-			const allRadios = screen.getAllByRole('radio');
-			const everyDayRadio = find(allRadios, ['value', RADIO_VALUES.QUICK_OPTIONS]);
-			const daySelectOption = screen.getByText('Day');
-
-			await user.click(screen.getByText('Day'));
-			await user.click(screen.getByText('Weekend day'));
-
-			expect(everyDayRadio).toBeChecked();
-			expect(daySelectOption).toBeVisible();
-		});
-
 		it('should show "day" + "months" options when "monthly" is selected', async () => {
 			const { store, editor } = createStoreWithEditor();
 

--- a/src/view/editor/parts/recurrence/views/custom-recurrence-modal.test.tsx
+++ b/src/view/editor/parts/recurrence/views/custom-recurrence-modal.test.tsx
@@ -196,7 +196,7 @@ describe('CustomRecurrenceModal', () => {
 				});
 			});
 
-			it.skip('should show plural "Weeks" for week frequency with interval 3', async () => {
+			it('should show plural "Weeks" for week frequency with interval 3', async () => {
 				const { store, editor } = createStoreWithEditor();
 
 				const { user } = setupTest(

--- a/src/view/editor/parts/recurrence/views/custom-recurrence-modal.tsx
+++ b/src/view/editor/parts/recurrence/views/custom-recurrence-modal.tsx
@@ -12,7 +12,7 @@ import { isNil, omitBy } from 'lodash';
 
 import MonthlyOptions from './monthly-options';
 import { RecurrenceEndOptions } from './recurrence-end-options';
-import WeeklyOptions from './weekly-options';
+import { WeeklyOptions } from './weekly-options';
 import YearlyOptions from './yearly-options';
 import { RecurrenceContext } from 'commons/recurrence-context';
 import { useAppDispatch, useAppSelector } from 'store/redux/hooks';
@@ -90,7 +90,7 @@ export const CustomRecurrenceModal = ({
 			<Divider />
 			<ModalBody>
 				<RepeatEveryRow />
-				<Padding vertical="small">
+				<Padding vertical="small" width={'fill'}>
 					<WeeklyOptions editorId={editorId} />
 					<MonthlyOptions />
 					<YearlyOptions />

--- a/src/view/editor/parts/recurrence/views/weekly-options.tsx
+++ b/src/view/editor/parts/recurrence/views/weekly-options.tsx
@@ -3,196 +3,88 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React, { ReactElement, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { ReactElement, useCallback, useContext, useEffect, useState } from 'react';
 
 import { Container, Padding, Row, Text } from '@zextras/carbonio-design-system';
 import { t } from '@zextras/carbonio-shell-ui';
-import { usePrefs } from '@zextras/carbonio-ui-commons';
-import { find, differenceWith, map, isEqual, filter, omitBy, isNil } from 'lodash';
+import moment from 'moment';
 
 import { WeekdayCheckboxes } from '../components/weekday-checkboxes';
 import { RecurrenceContext } from 'commons/recurrence-context';
-import { useRecurrenceItems } from 'commons/use-recurrence-items';
-import { WEEK_SCHEDULE } from 'constants/calendar';
-import { RADIO_VALUES, RECURRENCE_FREQUENCY } from 'constants/recurrence';
+import { RECURRENCE_FREQUENCY } from 'constants/recurrence';
 import { useAppSelector } from 'store/redux/hooks';
 import {
 	selectEditorRecurrenceByDay,
 	selectEditorRecurrenceFrequency,
-	selectEditorRecurrenceInterval
+	selectEditorRecurrenceInterval,
+	selectEditorStart
 } from 'store/selectors/editor';
 import { Byday, Interval, RecurrenceStartValue } from 'types/editor';
-import { workWeek, WorkWeekDay } from 'utils/work-week';
 
 const defaultState = {
-	freq: RECURRENCE_FREQUENCY.WEEKLY,
 	interval: {
 		ival: 1
 	},
 	byday: {
 		wkday: [{ day: 'MO' }]
-	},
-	radioValue: RADIO_VALUES.QUICK_OPTIONS
+	}
 };
 
-const radioInitialState = (
-	freq: string | undefined,
-	interval: Interval | undefined,
+// Helper function to convert JavaScript day (0-6, Sunday=0) to recurrence format (MO, TU, etc.)
+const getDayCodeFromDate = (date: number): string => {
+	const dayOfWeek = moment(date).day(); // 0 = Sunday, 1 = Monday, ..., 6 = Saturday
+	const dayMap = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
+	return dayMap[dayOfWeek];
+};
+
+const checkboxesInitialValue = (
 	byday: Byday | undefined,
-	workingSchedule: WorkWeekDay[]
-): string => {
-	if (
-		(freq === RECURRENCE_FREQUENCY.DAILY || freq === RECURRENCE_FREQUENCY.WEEKLY) &&
-		byday?.wkday
-	) {
-		// building an array with the same structure of wkday to check if they have the same values
-		// to determine if we are receiving the value of the working day option
-		const workingDays = map(filter(workingSchedule, ['working', true]), (workingDay) => {
-			const day = find(WEEK_SCHEDULE, ['value', workingDay.day])?.label?.slice(0, 2);
-			return { day };
-		});
-		const diff = differenceWith(workingDays, byday?.wkday, isEqual);
-		if (diff?.length === 0 && interval?.ival === 1) {
-			return RADIO_VALUES.QUICK_OPTIONS;
-		}
-		return RADIO_VALUES.CUSTOM_OPTIONS;
+	eventStartDate: number | undefined
+): { day: string }[] => {
+	// If we have existing byday value, use it
+	if (byday?.wkday && byday.wkday.length > 0) {
+		return byday.wkday;
 	}
-	if (freq === RECURRENCE_FREQUENCY.WEEKLY) {
-		if (interval?.ival === 1) {
-			return RADIO_VALUES.QUICK_OPTIONS;
-		}
-		return RADIO_VALUES.CUSTOM_OPTIONS;
+	// Otherwise, use the day of the week from the event's start date
+	if (eventStartDate) {
+		const dayCode = getDayCodeFromDate(eventStartDate);
+		return [{ day: dayCode }];
 	}
-	return defaultState.radioValue;
+	// Fallback to Monday
+	return defaultState.byday.wkday;
 };
 
 const startValueInitialState = (
 	freq: string | undefined,
 	interval: Interval | undefined,
-	byday: Byday | undefined,
-	weeklyOptions: { label: string; value: string }[]
+	byday: Byday | undefined
 ): RecurrenceStartValue | undefined => {
 	if (freq === RECURRENCE_FREQUENCY.WEEKLY) {
-		return omitBy({ interval, byday }, isNil);
-	}
-	if (freq === RECURRENCE_FREQUENCY.DAILY && byday?.wkday && interval?.ival === 1) {
-		const option = find(
-			weeklyOptions,
-			(item) =>
-				differenceWith(
-					map(item?.value?.split?.(','), (day) => ({ day })),
-					byday?.wkday ?? {},
-					isEqual
-				).length === 0
-		);
-		if (option) {
-			return { interval, byday };
-		}
-		return { interval: defaultState.interval, byday: defaultState.byday };
+		return { interval, byday };
 	}
 	return undefined;
 };
-
-const selectInitialValue = (
-	weeklyOptions: { label: string; value: string }[],
-	byday: Byday | undefined
-): { label: string; value: string } =>
-	find(
-		weeklyOptions,
-		(item) =>
-			differenceWith(
-				map(item?.value?.split?.(','), (day) => ({ day })),
-				byday?.wkday ?? [],
-				isEqual
-			).length === 0
-	) ?? weeklyOptions[0];
 
 export const WeeklyOptions = ({ editorId }: { editorId: string }): ReactElement | null => {
 	const { frequency, setNewStartValue } = useContext(RecurrenceContext);
 	const freq = useAppSelector(selectEditorRecurrenceFrequency(editorId));
 	const interval = useAppSelector(selectEditorRecurrenceInterval(editorId));
-	const byday = useAppSelector(selectEditorRecurrenceByDay(editorId));
+	const byDay = useAppSelector(selectEditorRecurrenceByDay(editorId));
+	const start = useAppSelector(selectEditorStart(editorId));
 
-	const prefs = usePrefs();
-
-	const workingSchedule = useMemo(
-		() => workWeek(prefs.zimbraPrefCalendarWorkingHours),
-		[prefs?.zimbraPrefCalendarWorkingHours]
+	const [checkboxesValue, setCheckboxesValue] = useState(() =>
+		checkboxesInitialValue(byDay, start)
 	);
+	const [startValue, setStartValue] = useState(() => startValueInitialState(freq, interval, byDay));
 
-	const { weekOptions } = useRecurrenceItems();
-
-	const [radioValue, setRadioValue] = useState(() =>
-		radioInitialState(freq, interval, byday, workingSchedule)
-	);
-	const [inputValue, setInputValue] = useState<string>(`${interval?.ival ?? 1}`);
-	const [selectValue, setSelectValue] = useState(() => selectInitialValue(weekOptions, byday));
-	const [checkboxesValue, setCheckboxesValue] = useState(byday?.wkday ?? []);
-	const [startValue, setStartValue] = useState(() =>
-		startValueInitialState(freq, interval, byday, weekOptions)
-	);
-
-	const onByDayChange = useCallback(
-		(ev: Array<{ day: string }>) => {
-			if (ev && radioValue === RADIO_VALUES.QUICK_OPTIONS) {
-				setStartValue((prevValue) => ({ ...(prevValue ?? {}), byday: { wkday: ev } }));
-			}
-		},
-		[radioValue]
-	);
-
-	const onChange = useCallback(
-		(ev?: string) => {
-			switch (ev) {
-				case RADIO_VALUES.QUICK_OPTIONS:
-					setStartValue({
-						byday: { wkday: map(selectValue?.value?.split?.(','), (day) => ({ day })) }
-					});
-					setRadioValue(ev);
-					break;
-				case RADIO_VALUES.CUSTOM_OPTIONS:
-					setStartValue({
-						byday: { wkday: checkboxesValue },
-						interval: { ival: parseInt(inputValue, 10) }
-					});
-					setRadioValue(ev);
-					break;
-				default:
-					setStartValue({
-						byday: { wkday: map(selectValue?.value?.split?.(','), (day) => ({ day })) }
-					});
-					setRadioValue(RADIO_VALUES.QUICK_OPTIONS);
-					break;
-			}
-		},
-		[checkboxesValue, inputValue, selectValue?.value, setStartValue]
-	);
-
-	const onInputChange = useCallback(
-		(ev: number) => {
-			if (radioValue === RADIO_VALUES.CUSTOM_OPTIONS) {
-				setStartValue((prevValue) => ({
-					...prevValue,
-					interval: {
-						ival: ev
-					}
-				}));
-			}
-		},
-		[setStartValue, radioValue]
-	);
-
-	const onCheckboxClick = useCallback(
-		(ev: Array<{ day: string }>) => {
-			if (ev && radioValue === RADIO_VALUES.CUSTOM_OPTIONS) {
-				setStartValue((prevValue) => ({
-					...prevValue,
-					byday: { wkday: ev }
-				}));
-			}
-		},
-		[radioValue]
-	);
+	const onCheckboxClick = useCallback((ev: Array<{ day: string }>) => {
+		if (ev) {
+			setStartValue((prevValue) => ({
+				...prevValue,
+				byday: { wkday: ev }
+			}));
+		}
+	}, []);
 
 	useEffect(() => {
 		if (startValue && frequency === RECURRENCE_FREQUENCY.WEEKLY) {

--- a/src/view/editor/parts/recurrence/views/weekly-options.tsx
+++ b/src/view/editor/parts/recurrence/views/weekly-options.tsx
@@ -30,52 +30,56 @@ const defaultState = {
 	}
 };
 
-// Helper function to convert JavaScript day (0-6, Sunday=0) to recurrence format (MO, TU, etc.)
 const getDayCodeFromDate = (date: number): string => {
-	const dayOfWeek = moment(date).day(); // 0 = Sunday, 1 = Monday, ..., 6 = Saturday
+	const dayOfWeek = moment(date).day();
 	const dayMap = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
 	return dayMap[dayOfWeek];
 };
 
 const checkboxesInitialValue = (
-	byday: Byday | undefined,
+	byDay: Byday | undefined,
 	eventStartDate: number | undefined
 ): { day: string }[] => {
-	// If we have existing byday value, use it
-	if (byday?.wkday && byday.wkday.length > 0) {
-		return byday.wkday;
+	if (byDay?.wkday?.length) {
+		return byDay.wkday;
 	}
-	// Otherwise, use the day of the week from the event's start date
-	if (eventStartDate) {
-		const dayCode = getDayCodeFromDate(eventStartDate);
-		return [{ day: dayCode }];
-	}
-	// Fallback to Monday
-	return defaultState.byday.wkday;
-};
 
-const startValueInitialState = (
-	freq: string | undefined,
-	interval: Interval | undefined,
-	byday: Byday | undefined
-): RecurrenceStartValue | undefined => {
-	if (freq === RECURRENCE_FREQUENCY.WEEKLY) {
-		return { interval, byday };
+	if (!eventStartDate) {
+		return defaultState.byday.wkday;
 	}
-	return undefined;
+
+	return [{ day: getDayCodeFromDate(eventStartDate) }];
 };
 
 export const WeeklyOptions = ({ editorId }: { editorId: string }): ReactElement | null => {
 	const { frequency, setNewStartValue } = useContext(RecurrenceContext);
-	const freq = useAppSelector(selectEditorRecurrenceFrequency(editorId));
-	const interval = useAppSelector(selectEditorRecurrenceInterval(editorId));
-	const byDay = useAppSelector(selectEditorRecurrenceByDay(editorId));
-	const start = useAppSelector(selectEditorStart(editorId));
+	const editorRecurrenceFrequency = useAppSelector(selectEditorRecurrenceFrequency(editorId));
+	const editorRecurrenceInterval = useAppSelector(selectEditorRecurrenceInterval(editorId));
+	const editorRecurrenceByDay = useAppSelector(selectEditorRecurrenceByDay(editorId));
+	const editorStart = useAppSelector(selectEditorStart(editorId));
 
 	const [checkboxesValue, setCheckboxesValue] = useState(() =>
-		checkboxesInitialValue(byDay, start)
+		checkboxesInitialValue(editorRecurrenceByDay, editorStart)
 	);
-	const [startValue, setStartValue] = useState(() => startValueInitialState(freq, interval, byDay));
+
+	const startValueInitialState = (
+		freq: string | undefined,
+		interval: Interval | undefined,
+		byDay: Byday | undefined
+	): RecurrenceStartValue | undefined => {
+		if (freq === RECURRENCE_FREQUENCY.WEEKLY) {
+			return { interval, byday: byDay };
+		}
+		return undefined;
+	};
+
+	const [startValue, setStartValue] = useState(() =>
+		startValueInitialState(
+			editorRecurrenceFrequency,
+			editorRecurrenceInterval,
+			editorRecurrenceByDay
+		)
+	);
 
 	const onCheckboxClick = useCallback((ev: Array<{ day: string }>) => {
 		if (ev) {

--- a/src/view/editor/parts/recurrence/views/weekly-options.tsx
+++ b/src/view/editor/parts/recurrence/views/weekly-options.tsx
@@ -5,26 +5,24 @@
  */
 import React, { ReactElement, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
-import { Container, Radio, RadioGroup, Row, Text, Padding } from '@zextras/carbonio-design-system';
+import { Container, Padding, Row, Text } from '@zextras/carbonio-design-system';
 import { t } from '@zextras/carbonio-shell-ui';
 import { usePrefs } from '@zextras/carbonio-ui-commons';
 import { find, differenceWith, map, isEqual, filter, omitBy, isNil } from 'lodash';
 
-import { RecurrenceContext } from '../../../../../commons/recurrence-context';
-import { useRecurrenceItems } from '../../../../../commons/use-recurrence-items';
-import { WEEK_SCHEDULE } from '../../../../../constants/calendar';
-import { RADIO_VALUES, RECURRENCE_FREQUENCY } from '../../../../../constants/recurrence';
-import { useAppSelector } from '../../../../../store/redux/hooks';
+import { WeekdayCheckboxes } from '../components/weekday-checkboxes';
+import { RecurrenceContext } from 'commons/recurrence-context';
+import { useRecurrenceItems } from 'commons/use-recurrence-items';
+import { WEEK_SCHEDULE } from 'constants/calendar';
+import { RADIO_VALUES, RECURRENCE_FREQUENCY } from 'constants/recurrence';
+import { useAppSelector } from 'store/redux/hooks';
 import {
 	selectEditorRecurrenceByDay,
 	selectEditorRecurrenceFrequency,
 	selectEditorRecurrenceInterval
-} from '../../../../../store/selectors/editor';
-import { Byday, Interval, RecurrenceStartValue } from '../../../../../types/editor';
-import { workWeek, WorkWeekDay } from '../../../../../utils/work-week';
-import { IntervalInput } from '../components/interval-input';
-import { WeekdayCheckboxes } from '../components/weekday-checkboxes';
-import WeekdaySelect from '../components/weekday-select';
+} from 'store/selectors/editor';
+import { Byday, Interval, RecurrenceStartValue } from 'types/editor';
+import { workWeek, WorkWeekDay } from 'utils/work-week';
 
 const defaultState = {
 	freq: RECURRENCE_FREQUENCY.WEEKLY,
@@ -109,7 +107,7 @@ const selectInitialValue = (
 			).length === 0
 	) ?? weeklyOptions[0];
 
-const WeeklyOptions = ({ editorId }: { editorId: string }): ReactElement | null => {
+export const WeeklyOptions = ({ editorId }: { editorId: string }): ReactElement | null => {
 	const { frequency, setNewStartValue } = useContext(RecurrenceContext);
 	const freq = useAppSelector(selectEditorRecurrenceFrequency(editorId));
 	const interval = useAppSelector(selectEditorRecurrenceInterval(editorId));
@@ -203,69 +201,32 @@ const WeeklyOptions = ({ editorId }: { editorId: string }): ReactElement | null 
 	}, [frequency, setNewStartValue, startValue]);
 
 	return frequency === RECURRENCE_FREQUENCY.WEEKLY ? (
-		<RadioGroup value={radioValue} onChange={onChange}>
-			<Radio
-				size="small"
-				iconColor="primary"
-				label={
-					<Row width="fit" orientation="horizontal" mainAlignment="flex-start" wrap="nowrap">
-						<Text overflow="break-word">{t('label.every', 'Every')}</Text>
-						<Padding horizontal="small">
-							<WeekdaySelect
-								setSelection={setSelectValue}
-								onChange={onByDayChange}
-								selection={selectValue}
-								disabled={radioValue !== RADIO_VALUES.QUICK_OPTIONS}
-							/>
-						</Padding>
-					</Row>
-				}
-				value={RADIO_VALUES.QUICK_OPTIONS}
-				name={RADIO_VALUES.QUICK_OPTIONS}
-			/>
-			<Radio
-				size="small"
-				iconColor="primary"
-				label={
-					<Container
-						orientation="vertical"
-						width="fit"
-						mainAlignment="flex-start"
-						crossAlignment="flex-start"
-					>
-						<Row width="fit" orientation="horizontal" mainAlignment="flex-start" wrap="nowrap">
-							<Text overflow="break-word">{t('label.every', 'Every')}</Text>
-							<Padding horizontal="small">
-								<IntervalInput
-									label={t('label.weeks_on', 'Week(s) on')}
-									onChange={onInputChange}
-									setValue={setInputValue}
-									value={inputValue}
-									disabled={radioValue !== RADIO_VALUES.CUSTOM_OPTIONS}
-								/>
-							</Padding>
-						</Row>
-					</Container>
-				}
-				value={RADIO_VALUES.CUSTOM_OPTIONS}
-			/>
+		<Container
+			orientation="vertical"
+			mainAlignment={'flex-start'}
+			crossAlignment={'flex-start'}
+			width={'fill'}
+		>
+			<Padding vertical="medium">
+				<Text weight="bold" size="large">
+					{t('label.on', 'On')}
+				</Text>
+			</Padding>
 			<Row
-				width="fit"
+				width="fill"
 				orientation="horizontal"
 				mainAlignment="flex-start"
 				crossAlignment="flex-start"
 				wrap="nowrap"
 			>
 				<WeekdayCheckboxes
-					isHidden={radioValue !== RADIO_VALUES.CUSTOM_OPTIONS}
+					isHidden={false}
 					value={checkboxesValue}
 					setValue={setCheckboxesValue}
 					onClick={onCheckboxClick}
-					disabled={radioValue !== RADIO_VALUES.CUSTOM_OPTIONS}
+					disabled={false}
 				/>
 			</Row>
-		</RadioGroup>
+		</Container>
 	) : null;
 };
-
-export default WeeklyOptions;


### PR DESCRIPTION
Improves the Weekly repeat UX in the Custom Recurrence dialog by replacing the “quick/custom” weekly controls with a simplified weekday button selector and aligning modal layout accordingly.

**Changes:**
- Refactored weekly recurrence UI to always show weekday selection (removed radio/select/interval UI for weekly view).
- Updated weekday selector component from checkboxes to button-style toggles and prevented deselecting the last remaining day.
- Adjusted modal layout and updated tests (removed an outdated weekly UI test; re-enabled an interval pluralization test).