### PR TITLE
feat(CO-3170): Improve UX of Monthly repeat in Custom Recurrence dialog

### DIFF
--- a/src/view/editor/parts/recurrence/components/weekday-checkboxes.tsx
+++ b/src/view/editor/parts/recurrence/components/weekday-checkboxes.tsx
@@ -44,7 +44,7 @@ export const WeekdayCheckboxes = ({
 	);
 
 	return isHidden ? null : (
-		<Row width="fill" mainAlignment="space-between" wrap="nowrap">
+		<Row width="fill" mainAlignment="space-between" wrap="nowrap" gap={'0.5rem'}>
 			{map(weekDays, (opt) => {
 				const isChecked = !!find(value, ({ day }) => day === opt.value);
 				return (
@@ -56,7 +56,7 @@ export const WeekdayCheckboxes = ({
 						disabled={disabled}
 						labelColor={isChecked ? 'white' : 'primary'}
 						size="medium"
-						width="fit"
+						width="fill"
 					/>
 				);
 			})}

--- a/src/view/editor/parts/recurrence/views/custom-recurrence-modal.test.tsx
+++ b/src/view/editor/parts/recurrence/views/custom-recurrence-modal.test.tsx
@@ -250,33 +250,6 @@ describe('CustomRecurrenceModal', () => {
 			});
 		});
 
-		it('should save monthly frequency with day and interval when customized and confirmed', async () => {
-			const { store, editor } = createStoreWithEditor();
-
-			const { user } = setupTest(<CustomRecurrenceModal editorId={editor.id} onClose={vi.fn()} />, {
-				store
-			});
-
-			await selectFrequency(user, 'month');
-			await clickCustomizeButton(user);
-
-			const updatedEditor = getUpdatedEditor(store);
-
-			expect(updatedEditor.recur).toStrictEqual({
-				add: {
-					rule: {
-						bymonthday: {
-							modaylist: 1
-						},
-						freq: 'MON',
-						interval: {
-							ival: 1
-						}
-					}
-				}
-			});
-		});
-
 		it('should save yearly frequency with month and day when customized and confirmed', async () => {
 			const { store, editor } = createStoreWithEditor();
 

--- a/src/view/editor/parts/recurrence/views/custom-recurrence-modal.test.tsx
+++ b/src/view/editor/parts/recurrence/views/custom-recurrence-modal.test.tsx
@@ -116,25 +116,6 @@ describe('CustomRecurrenceModal', () => {
 	});
 
 	describe('Default States by Frequency', () => {
-		it('should show "day" + "months" options when "monthly" is selected', async () => {
-			const { store, editor } = createStoreWithEditor();
-
-			const { user } = setupTest(<CustomRecurrenceModal editorId={editor.id} onClose={vi.fn()} />, {
-				store
-			});
-
-			await selectFrequency(user, 'month');
-
-			const allRadios = screen.getAllByRole('radio');
-			const dayRadio = find(allRadios, ['value', RADIO_VALUES.DAY_OF_MONTH]);
-			const dayInputOption = within(screen.getByTestId('montly_day_input')).getByRole('textbox');
-			const everyMonthsInputOption = screen.getByRole('textbox', { name: 'label.months' });
-
-			expect(dayRadio).toBeChecked();
-			expect(dayInputOption).toHaveValue('1');
-			expect(everyMonthsInputOption).toHaveValue('1');
-		});
-
 		it('should show "day" + "month" options when "yearly" is selected', async () => {
 			const { store, editor } = createStoreWithEditor();
 

--- a/src/view/editor/parts/recurrence/views/custom-recurrence-modal.test.tsx
+++ b/src/view/editor/parts/recurrence/views/custom-recurrence-modal.test.tsx
@@ -195,7 +195,7 @@ describe('CustomRecurrenceModal', () => {
 				});
 			});
 
-			it.skip('should show plural "Months" for month frequency with interval 7', async () => {
+			it('should show plural "Months" for month frequency with interval 7', async () => {
 				const { store, editor } = createStoreWithEditor();
 
 				const { user } = setupTest(

--- a/src/view/editor/parts/recurrence/views/custom-recurrence-modal.tsx
+++ b/src/view/editor/parts/recurrence/views/custom-recurrence-modal.tsx
@@ -10,7 +10,7 @@ import { t } from '@zextras/carbonio-shell-ui';
 import { ModalFooter } from '@zextras/carbonio-ui-commons';
 import { isNil, omitBy } from 'lodash';
 
-import MonthlyOptions from './monthly-options';
+import { MonthlyOptions } from './monthly-options';
 import { RecurrenceEndOptions } from './recurrence-end-options';
 import { WeeklyOptions } from './weekly-options';
 import YearlyOptions from './yearly-options';
@@ -92,7 +92,7 @@ export const CustomRecurrenceModal = ({
 				<RepeatEveryRow />
 				<Padding vertical="small" width={'fill'}>
 					<WeeklyOptions editorId={editorId} />
-					<MonthlyOptions />
+					<MonthlyOptions editorId={editorId} />
 					<YearlyOptions />
 				</Padding>
 				<Padding vertical="medium">

--- a/src/view/editor/parts/recurrence/views/monthly-options.tsx
+++ b/src/view/editor/parts/recurrence/views/monthly-options.tsx
@@ -9,14 +9,14 @@ import { Container, Padding, Radio, RadioGroup, Row, Text } from '@zextras/carbo
 import { t } from '@zextras/carbonio-shell-ui';
 import { map } from 'lodash';
 
-import { RecurrenceContext } from '../../../../../commons/recurrence-context';
-import { useRecurrenceItems } from '../../../../../commons/use-recurrence-items';
-import { RADIO_VALUES, RECURRENCE_FREQUENCY } from '../../../../../constants/recurrence';
-import { RecurrenceStartValue } from '../../../../../types/editor';
 import { IntervalInput } from '../components/interval-input';
 import { MonthlyDayInput } from '../components/monthly-day-input';
 import { OrdinalNumberSelect } from '../components/ordinal-number-select';
 import WeekdaySelect from '../components/weekday-select';
+import { RecurrenceContext } from 'commons/recurrence-context';
+import { useRecurrenceItems } from 'commons/use-recurrence-items';
+import { RADIO_VALUES, RECURRENCE_FREQUENCY } from 'constants/recurrence';
+import { RecurrenceStartValue } from 'types/editor';
 
 const MonthlyOptions = (): ReactElement | null => {
 	const { frequency, setNewStartValue } = useContext(RecurrenceContext);

--- a/src/view/editor/parts/recurrence/views/monthly-options.tsx
+++ b/src/view/editor/parts/recurrence/views/monthly-options.tsx
@@ -29,15 +29,33 @@ const getOrdinalSuffix = (day: number): string => {
 	}
 };
 
-const getOrdinalNumber = (num: number): string => {
-	const ordinals = ['First', 'Second', 'Third', 'Fourth', 'Fifth'];
-	if (num >= 1 && num <= 5) {
-		return ordinals[num - 1];
-	}
-	if (num === -1) {
-		return 'Last';
-	}
+const getOrdinalNumber = (
+	num: number,
+	tFn: (key: string, defaultValue: string) => string
+): string => {
+	if (num === 1) return tFn('ordinal.first', 'First');
+	if (num === 2) return tFn('ordinal.second', 'Second');
+	if (num === 3) return tFn('ordinal.third', 'Third');
+	if (num === 4) return tFn('ordinal.fourth', 'Fourth');
+	if (num === 5) return tFn('ordinal.fifth', 'Fifth');
+	if (num === -1) return tFn('ordinal.last', 'Last');
 	return `${num}${getOrdinalSuffix(num)}`;
+};
+
+const getWeekdayName = (
+	dayCode: string,
+	tFn: (key: string, defaultValue: string) => string
+): string => {
+	const weekdayMap: Record<string, string> = {
+		SU: tFn('label.week_day.sunday', 'Sunday'),
+		MO: tFn('label.week_day.monday', 'Monday'),
+		TU: tFn('label.week_day.tuesday', 'Tuesday'),
+		WE: tFn('label.week_day.wednesday', 'Wednesday'),
+		TH: tFn('label.week_day.thursday', 'Thursday'),
+		FR: tFn('label.week_day.friday', 'Friday'),
+		SA: tFn('label.week_day.saturday', 'Saturday')
+	};
+	return weekdayMap[dayCode] || dayCode;
 };
 
 export const MonthlyOptions = ({ editorId }: { editorId: string }): ReactElement | null => {
@@ -53,13 +71,12 @@ export const MonthlyOptions = ({ editorId }: { editorId: string }): ReactElement
 	}, [start]);
 
 	// Calculate ordinal position and weekday from start date
-	const { ordinalPosition, weekdayName, weekdayCode } = useMemo(() => {
+	const { ordinalPosition, weekdayCode } = useMemo(() => {
 		if (!start) {
-			return { ordinalPosition: 1, weekdayName: 'Monday', weekdayCode: 'MO' };
+			return { ordinalPosition: 1, weekdayCode: 'MO' };
 		}
 		const date = moment(start);
 		const dayOfWeek = date.day(); // 0 = Sunday, 6 = Saturday
-		const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 		const dayCodes = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
 
 		// Calculate which occurrence of this weekday in the month (1st, 2nd, 3rd, etc.)
@@ -68,19 +85,25 @@ export const MonthlyOptions = ({ editorId }: { editorId: string }): ReactElement
 
 		return {
 			ordinalPosition: occurrence,
-			weekdayName: dayNames[dayOfWeek],
 			weekdayCode: dayCodes[dayOfWeek]
 		};
 	}, [start]);
 
 	const dayOfMonthLabel = useMemo(
-		() => `${dayOfMonth}${getOrdinalSuffix(dayOfMonth)} of the Month`,
+		() =>
+			t('label.day_of_month_recurrence', '{{day}} of the Month', {
+				day: `${dayOfMonth}${getOrdinalSuffix(dayOfMonth)}`
+			}),
 		[dayOfMonth]
 	);
 
 	const customDayLabel = useMemo(
-		() => `Every ${getOrdinalNumber(ordinalPosition).toLowerCase()} ${weekdayName} of the Month`,
-		[ordinalPosition, weekdayName]
+		() =>
+			t('label.ordinal_weekday_of_month', 'Every {{ordinal}} {{weekday}} of the Month', {
+				ordinal: getOrdinalNumber(ordinalPosition, t).toLowerCase(),
+				weekday: getWeekdayName(weekdayCode, t)
+			}),
+		[ordinalPosition, weekdayCode]
 	);
 
 	const [startValue, setStartValue] = useState<RecurrenceStartValue>({

--- a/src/view/editor/parts/recurrence/views/monthly-options.tsx
+++ b/src/view/editor/parts/recurrence/views/monthly-options.tsx
@@ -83,8 +83,13 @@ export const MonthlyOptions = ({ editorId }: { editorId: string }): ReactElement
 		const currentDayOfMonth = date.date();
 		const occurrence = Math.ceil(currentDayOfMonth / 7);
 
+		// Detect if this is the last occurrence of this weekday in the month.
+		// If adding 7 days changes the month, there is no next same weekday in this month.
+		const nextWeek = moment(date).add(7, 'days');
+		const isLastOccurrence = nextWeek.month() !== date.month();
+		const computedOrdinalPosition = isLastOccurrence ? -1 : occurrence;
 		return {
-			ordinalPosition: occurrence,
+			ordinalPosition: computedOrdinalPosition,
 			weekdayCode: dayCodes[dayOfWeek]
 		};
 	}, [start]);

--- a/src/view/editor/parts/recurrence/views/monthly-options.tsx
+++ b/src/view/editor/parts/recurrence/views/monthly-options.tsx
@@ -3,41 +3,91 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React, { ReactElement, useCallback, useContext, useEffect, useState } from 'react';
+import React, { ReactElement, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import { Container, Padding, Radio, RadioGroup, Row, Text } from '@zextras/carbonio-design-system';
 import { t } from '@zextras/carbonio-shell-ui';
-import { map } from 'lodash';
+import moment from 'moment';
 
-import { IntervalInput } from '../components/interval-input';
-import { MonthlyDayInput } from '../components/monthly-day-input';
-import { OrdinalNumberSelect } from '../components/ordinal-number-select';
-import WeekdaySelect from '../components/weekday-select';
 import { RecurrenceContext } from 'commons/recurrence-context';
-import { useRecurrenceItems } from 'commons/use-recurrence-items';
 import { RADIO_VALUES, RECURRENCE_FREQUENCY } from 'constants/recurrence';
+import { useAppSelector } from 'store/redux/hooks';
+import { selectEditorStart } from 'store/selectors/editor';
 import { RecurrenceStartValue } from 'types/editor';
 
-const MonthlyOptions = (): ReactElement | null => {
+const getOrdinalSuffix = (day: number): string => {
+	if (day > 3 && day < 21) return 'th';
+	switch (day % 10) {
+		case 1:
+			return 'st';
+		case 2:
+			return 'nd';
+		case 3:
+			return 'rd';
+		default:
+			return 'th';
+	}
+};
+
+const getOrdinalNumber = (num: number): string => {
+	const ordinals = ['First', 'Second', 'Third', 'Fourth', 'Fifth'];
+	if (num >= 1 && num <= 5) {
+		return ordinals[num - 1];
+	}
+	if (num === -1) {
+		return 'Last';
+	}
+	return `${num}${getOrdinalSuffix(num)}`;
+};
+
+export const MonthlyOptions = ({ editorId }: { editorId: string }): ReactElement | null => {
 	const { frequency, setNewStartValue } = useContext(RecurrenceContext);
+	const start = useAppSelector(selectEditorStart(editorId));
+
 	const [radioValue, setRadioValue] = useState(RADIO_VALUES.DAY_OF_MONTH);
-	const [moDayList, setMoDayList] = useState('1');
-	const [intervalFirstInput, setIntervalFirstInput] = useState('1');
-	const [intervalSecondInput, setIntervalSecondInput] = useState('1');
+
+	// Calculate day of month from start date
+	const dayOfMonth = useMemo(() => {
+		if (!start) return 1;
+		return moment(start).date();
+	}, [start]);
+
+	// Calculate ordinal position and weekday from start date
+	const { ordinalPosition, weekdayName, weekdayCode } = useMemo(() => {
+		if (!start) {
+			return { ordinalPosition: 1, weekdayName: 'Monday', weekdayCode: 'MO' };
+		}
+		const date = moment(start);
+		const dayOfWeek = date.day(); // 0 = Sunday, 6 = Saturday
+		const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+		const dayCodes = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
+
+		// Calculate which occurrence of this weekday in the month (1st, 2nd, 3rd, etc.)
+		const currentDayOfMonth = date.date();
+		const occurrence = Math.ceil(currentDayOfMonth / 7);
+
+		return {
+			ordinalPosition: occurrence,
+			weekdayName: dayNames[dayOfWeek],
+			weekdayCode: dayCodes[dayOfWeek]
+		};
+	}, [start]);
+
+	const dayOfMonthLabel = useMemo(
+		() => `${dayOfMonth}${getOrdinalSuffix(dayOfMonth)} of the Month`,
+		[dayOfMonth]
+	);
+
+	const customDayLabel = useMemo(
+		() => `Every ${getOrdinalNumber(ordinalPosition).toLowerCase()} ${weekdayName} of the Month`,
+		[ordinalPosition, weekdayName]
+	);
 
 	const [startValue, setStartValue] = useState<RecurrenceStartValue>({
 		bymonthday: {
-			modaylist: parseInt(moDayList, 10)
-		},
-		interval: {
-			ival: parseInt(intervalFirstInput, 10)
+			modaylist: dayOfMonth
 		}
 	});
-
-	const { weekOptions, ordinalNumbers } = useRecurrenceItems();
-
-	const [posListSelectValue, setPosListSelectValue] = useState(ordinalNumbers?.[0]);
-	const [byDaySelectValue, setByDaySelectValue] = useState(weekOptions?.[0]);
 
 	const onRadioChange = useCallback(
 		(ev?: string) => {
@@ -45,10 +95,7 @@ const MonthlyOptions = (): ReactElement | null => {
 				case RADIO_VALUES.DAY_OF_MONTH:
 					setStartValue({
 						bymonthday: {
-							modaylist: parseInt(moDayList, 10)
-						},
-						interval: {
-							ival: parseInt(intervalFirstInput, 10)
+							modaylist: dayOfMonth
 						}
 					});
 					setRadioValue(ev);
@@ -56,11 +103,8 @@ const MonthlyOptions = (): ReactElement | null => {
 				case RADIO_VALUES.MONTHLY_CUSTOMIZED:
 					setRadioValue(ev);
 					setStartValue({
-						bysetpos: { poslist: posListSelectValue?.value },
-						byday: { wkday: map(byDaySelectValue?.value?.split?.(','), (day) => ({ day })) },
-						interval: {
-							ival: parseInt(intervalSecondInput, 10)
-						}
+						bysetpos: { poslist: ordinalPosition.toString() },
+						byday: { wkday: [{ day: weekdayCode }] }
 					});
 					break;
 				default:
@@ -68,73 +112,7 @@ const MonthlyOptions = (): ReactElement | null => {
 					break;
 			}
 		},
-		[
-			byDaySelectValue?.value,
-			intervalFirstInput,
-			intervalSecondInput,
-			moDayList,
-			posListSelectValue?.value
-		]
-	);
-
-	const onMoDayListChange = useCallback(
-		(ev: number) => {
-			if (ev && radioValue === RADIO_VALUES.DAY_OF_MONTH) {
-				setStartValue((prevValue) => ({
-					...(prevValue ?? {}),
-					bymonthday: {
-						modaylist: ev
-					}
-				}));
-			}
-		},
-		[radioValue]
-	);
-
-	const onFirstIntervalChange = useCallback(
-		(ev: number) => {
-			if (radioValue === RADIO_VALUES.DAY_OF_MONTH) {
-				setStartValue((prevValue) => ({
-					...prevValue,
-					interval: {
-						ival: ev
-					}
-				}));
-			}
-		},
-		[setStartValue, radioValue]
-	);
-
-	const onSecondIntervalChange = useCallback(
-		(ev: number) => {
-			if (radioValue === RADIO_VALUES.MONTHLY_CUSTOMIZED) {
-				setStartValue((prevValue) => ({
-					...prevValue,
-					interval: {
-						ival: ev
-					}
-				}));
-			}
-		},
-		[setStartValue, radioValue]
-	);
-
-	const onBySetPosChange = useCallback(
-		(ev: string) => {
-			if (ev && radioValue === RADIO_VALUES.MONTHLY_CUSTOMIZED) {
-				setStartValue((prevValue) => ({ ...(prevValue ?? {}), bysetpos: { poslist: ev } }));
-			}
-		},
-		[radioValue]
-	);
-
-	const onByDayChange = useCallback(
-		(ev: Array<{ day: string }>) => {
-			if (ev && radioValue === RADIO_VALUES.MONTHLY_CUSTOMIZED) {
-				setStartValue((prevValue) => ({ ...(prevValue ?? {}), byday: { wkday: ev } }));
-			}
-		},
-		[radioValue]
+		[dayOfMonth, ordinalPosition, weekdayCode]
 	);
 
 	useEffect(() => {
@@ -144,95 +122,62 @@ const MonthlyOptions = (): ReactElement | null => {
 	}, [frequency, setNewStartValue, startValue]);
 
 	return frequency === RECURRENCE_FREQUENCY.MONTHLY ? (
-		<RadioGroup value={radioValue} onChange={onRadioChange}>
-			<Radio
-				size="small"
-				iconColor="primary"
-				label={
-					<Row width="fit" orientation="horizontal" mainAlignment="flex-start" wrap="nowrap">
-						<Padding horizontal="small">
-							<Text>{t('label.day', 'Day')}</Text>
-						</Padding>
-						<MonthlyDayInput
-							value={moDayList}
-							setValue={setMoDayList}
-							onChange={onMoDayListChange}
-							disabled={radioValue !== RADIO_VALUES.DAY_OF_MONTH}
-							testId={'montly_day_input'}
-						/>
-						<Padding horizontal="small">
-							<Text>{t('label.every', 'every')}</Text>
-						</Padding>
-						<IntervalInput
-							value={intervalFirstInput}
-							setValue={setIntervalFirstInput}
-							label={t('label.months', 'Months')}
-							onChange={onFirstIntervalChange}
-							disabled={radioValue !== RADIO_VALUES.DAY_OF_MONTH}
-						/>
-					</Row>
-				}
-				value={RADIO_VALUES.DAY_OF_MONTH}
-			/>
-			<Radio
-				size="small"
-				iconColor="primary"
-				label={
-					<Container
-						orientation="vertical"
-						mainAlignment="center"
-						crossAlignment="flex-start"
-						width="100%"
-					>
-						<Container
-							orientation="horizontal"
-							mainAlignment="flex-start"
-							crossAlignment="center"
-							width="fill"
-						>
-							<Padding horizontal="small">
-								<Text>{t('label.the', 'The')}</Text>
-							</Padding>
-							<OrdinalNumberSelect
-								value={posListSelectValue}
-								setValue={setPosListSelectValue}
-								onChange={onBySetPosChange}
-								disabled={radioValue !== RADIO_VALUES.MONTHLY_CUSTOMIZED}
-							/>
-							<Padding horizontal="small" />
-							<WeekdaySelect
-								setSelection={setByDaySelectValue}
-								onChange={onByDayChange}
-								selection={byDaySelectValue}
-								disabled={radioValue !== RADIO_VALUES.MONTHLY_CUSTOMIZED}
-							/>
-						</Container>
-						<Container
-							orientation="horizontal"
-							mainAlignment="flex-start"
-							crossAlignment="center"
-							padding={{ vertical: 'small' }}
-							width="80%"
-						>
-							<Padding horizontal="small">
-								<Text>{t('label.of_every_month', 'of the month, every')}</Text>
-							</Padding>
-							<MonthlyDayInput
-								value={intervalSecondInput}
-								setValue={setIntervalSecondInput}
-								onChange={onSecondIntervalChange}
-								disabled={radioValue !== RADIO_VALUES.MONTHLY_CUSTOMIZED}
-							/>
-							<Padding horizontal="small">
-								<Text>{t('label.months', 'Months')}</Text>
-							</Padding>
-						</Container>
-					</Container>
-				}
-				value={RADIO_VALUES.MONTHLY_CUSTOMIZED}
-			/>
-		</RadioGroup>
+		<Container
+			orientation="vertical"
+			mainAlignment={'flex-start'}
+			crossAlignment={'flex-start'}
+			width={'fill'}
+			gap={'1rem'}
+		>
+			<Container
+				orientation="vertical"
+				mainAlignment="flex-start"
+				crossAlignment="flex-start"
+				width="fill"
+			>
+				<Padding vertical="medium">
+					<Text weight="bold" size="large">
+						{t('label.on', 'On')}
+					</Text>
+				</Padding>
+				<RadioGroup value={radioValue} onChange={onRadioChange}>
+					<Radio
+						size={'small'}
+						key={'day_of_month'}
+						iconColor="primary"
+						label={
+							<Row
+								style={{ cursor: 'pointer' }}
+								width="fill"
+								orientation="horizontal"
+								mainAlignment="flex-start"
+								wrap="nowrap"
+							>
+								<Text>{dayOfMonthLabel}</Text>
+							</Row>
+						}
+						value={RADIO_VALUES.DAY_OF_MONTH}
+					/>
+					<Padding key={'padding-1'} top="medium" />
+					<Radio
+						size={'small'}
+						key={'custom'}
+						iconColor="primary"
+						label={
+							<Row
+								style={{ cursor: 'pointer' }}
+								width="fill"
+								orientation="horizontal"
+								mainAlignment="flex-start"
+								wrap="nowrap"
+							>
+								<Text>{customDayLabel}</Text>
+							</Row>
+						}
+						value={RADIO_VALUES.MONTHLY_CUSTOMIZED}
+					/>
+				</RadioGroup>
+			</Container>
+		</Container>
 	) : null;
 };
-
-export default MonthlyOptions;

--- a/src/view/editor/parts/recurrence/views/recurrence-end-options.tsx
+++ b/src/view/editor/parts/recurrence/views/recurrence-end-options.tsx
@@ -167,17 +167,17 @@ export const RecurrenceEndOptions = ({ editorId }: { editorId: string }): ReactE
 				orientation="horizontal"
 				mainAlignment="flex-start"
 				wrap="nowrap"
+				gap="0.5rem"
 			>
-				<Row
+				<Container
 					width="fit"
-					orientation="horizontal"
+					minWidth="5rem"
 					mainAlignment="flex-start"
-					wrap="nowrap"
-					padding={{ right: 'small' }}
+					crossAlignment={'flex-start'}
 				>
-					<Text>{t('label.end_after', 'End after')}</Text>
-				</Row>
-				<Row width="fill" orientation="horizontal" mainAlignment="flex-start" wrap="nowrap">
+					<Text textAlign={'start'}>{t('label.end_after', 'End after')}</Text>
+				</Container>
+				<Container width="fill" mainAlignment="flex-start">
 					<Input
 						background={'gray5'}
 						width="fill"
@@ -187,7 +187,7 @@ export const RecurrenceEndOptions = ({ editorId }: { editorId: string }): ReactE
 						onChange={onInputValueChange}
 						hasError={!isNil(num) && (num > 99 || num < 1 || !isNumber(num))}
 					/>
-				</Row>
+				</Container>
 			</Row>
 		),
 		[inputValue, radioValue, onInputValueChange, num, t]
@@ -201,29 +201,27 @@ export const RecurrenceEndOptions = ({ editorId }: { editorId: string }): ReactE
 				orientation="horizontal"
 				mainAlignment="flex-start"
 				wrap="nowrap"
+				gap="0.5rem"
 			>
-				<Row
+				<Container
 					width="fit"
-					orientation="horizontal"
+					minWidth="5rem"
 					mainAlignment="flex-start"
-					wrap="nowrap"
-					padding={{ right: 'small' }}
+					crossAlignment={'flex-start'}
 				>
 					<Text>{t('label.end_on', 'End on')}</Text>
-				</Row>
-				<Row width="fill" orientation="horizontal" mainAlignment="flex-start" wrap="nowrap">
-					<Container crossAlignment="flex-start" width={'fill'}>
-						<DateTimePicker
-							width={'fill'}
-							label={t('label.end_after_date', 'Date')}
-							showTimeSelect={false}
-							defaultValue={initialPickerValue}
-							onChange={onDateChange}
-							disabled={isDatePickerDisabled}
-							dateFormat="dd/MM/yyyy"
-						/>
-					</Container>
-				</Row>
+				</Container>
+				<Container width="fill" mainAlignment="flex-start">
+					<DateTimePicker
+						width={'fill'}
+						label={t('label.end_after_date', 'Date')}
+						showTimeSelect={false}
+						defaultValue={initialPickerValue}
+						onChange={onDateChange}
+						disabled={isDatePickerDisabled}
+						dateFormat="dd/MM/yyyy"
+					/>
+				</Container>
 			</Row>
 		),
 		[initialPickerValue, onDateChange, isDatePickerDisabled, t]


### PR DESCRIPTION
Improves the Monthly recurrence UX in the Custom Recurrence dialog by simplifying the monthly option selection UI and adjusting layout spacing/alignment for recurrence-related controls.

**Changes:**
- Refactors Monthly recurrence options to derive labels and defaults from the editor start date (via Redux selector).
- Updates layout/spacing in recurrence end options and weekday checkbox row for better alignment.
- Re-enables a previously skipped test for monthly interval pluralization.
