### PR TITLE
[co-3273] fix: closing summary view on component when switching module

### DIFF
--- a/src/view/calendar/calendar-component.jsx
+++ b/src/view/calendar/calendar-component.jsx
@@ -297,10 +297,6 @@ export default function CalendarComponent() {
 		return undefined;
 	}, [calendarView, calendars, isSplitLayoutEnabled]);
 
-	const handleClose = useCallback(() => {
-		useAppStatusStore.setState({ summaryViewId: undefined });
-	}, []);
-
 	return (
 		<>
 			{!isEmpty(calendars) && <CalendarSyncWithRange />}
@@ -319,9 +315,9 @@ export default function CalendarComponent() {
 					open={summaryViewOpen}
 					styleAsModal
 					placement="left"
-					onClose={handleClose}
+					onClose={() => useAppStatusStore.setState({ summaryViewId: undefined })}
 				>
-					<MemoEventSummaryView events={events} onClose={handleClose} />
+					<MemoEventSummaryView events={events} />
 				</Popover>
 			)}
 			<BigCalendar

--- a/src/view/calendar/calendar-component.jsx
+++ b/src/view/calendar/calendar-component.jsx
@@ -297,6 +297,10 @@ export default function CalendarComponent() {
 		return undefined;
 	}, [calendarView, calendars, isSplitLayoutEnabled]);
 
+	const handleClose = useCallback(() => {
+		useAppStatusStore.setState({ summaryViewId: undefined });
+	}, []);
+
 	return (
 		<>
 			{!isEmpty(calendars) && <CalendarSyncWithRange />}
@@ -315,16 +319,9 @@ export default function CalendarComponent() {
 					open={summaryViewOpen}
 					styleAsModal
 					placement="left"
-					onClose={() => {
-						useAppStatusStore.setState({ summaryViewId: undefined });
-					}}
+					onClose={handleClose}
 				>
-					<MemoEventSummaryView
-						events={events}
-						onClose={() => {
-							useAppStatusStore.setState({ summaryViewId: undefined });
-						}}
-					/>
+					<MemoEventSummaryView events={events} onClose={handleClose} />
 				</Popover>
 			)}
 			<BigCalendar

--- a/src/view/event-summary-view/event-summary-view.tsx
+++ b/src/view/event-summary-view/event-summary-view.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React, { ReactElement, useMemo } from 'react';
+import React, { ReactElement, useEffect, useMemo } from 'react';
 
 import { Container, Divider } from '@zextras/carbonio-design-system';
 import { isNil, omitBy, startsWith } from 'lodash';
@@ -60,6 +60,8 @@ export const EventSummaryView = ({ events, onClose }: EventSummaryProps): ReactE
 		[event?.resource?.class, event?.resource?.location, event?.resource?.locationUrl]
 	);
 	const neverSentWarningLabel = useNeverSentWarningLabel(invite?.attendees);
+
+	useEffect(() => onClose, [onClose]);
 
 	if (!event) {
 		return null;

--- a/src/view/event-summary-view/tests/event-summary-view.test.tsx
+++ b/src/view/event-summary-view/tests/event-summary-view.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { EventSummaryView } from '../event-summary-view';
+import { setupTest, screen } from '@test-setup';
+import mockedData from 'test/generators';
+
+const EVENT_ID = 'event-1';
+const event = mockedData.getEvent({ id: EVENT_ID });
+
+vi.mock('../../../hooks/use-invite', () => ({
+	useInvite: (): undefined => undefined
+}));
+
+vi.mock('../../../store/zustand/hooks', () => ({
+	useSummaryView: (): string => EVENT_ID
+}));
+
+vi.mock('../../../hooks/use-never-sent-warning-label', () => ({
+	useNeverSentWarningLabel: (): string => ''
+}));
+
+vi.mock('../actions-buttons-row', () => ({
+	ActionsButtonsRow: ({ onClose }: { onClose: () => void }): React.ReactElement => (
+		<button onClick={onClose} data-testid="close-action-btn">
+			Close
+		</button>
+	)
+}));
+
+describe('EventSummaryView - close behavior', () => {
+	it('calls onClose when the component unmounts', () => {
+		const onClose = vi.fn();
+		const { unmount } = setupTest(<EventSummaryView events={[event]} onClose={onClose} />);
+
+		expect(onClose).not.toHaveBeenCalled();
+
+		unmount();
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not call onClose on initial render', () => {
+		const onClose = vi.fn();
+
+		setupTest(<EventSummaryView events={[event]} onClose={onClose} />);
+
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('passes onClose down to ActionsButtonsRow', async () => {
+		const onClose = vi.fn();
+		const { user } = setupTest(<EventSummaryView events={[event]} onClose={onClose} />);
+
+		await user.click(screen.getByTestId('close-action-btn'));
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not render and does not call onClose when no matching event is found', () => {
+		const onClose = vi.fn();
+		const { container } = setupTest(<EventSummaryView events={[]} onClose={onClose} />);
+
+		expect(container).toBeEmptyDOMElement();
+		expect(onClose).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Stabilized onClose callback with useCallback to prevent unintended effect re-triggers
Added cleanup effect in EventSummaryView to reset the store on unmount