### PR TITLE
feat: add close confirmation modal when editor has unsaved changes

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -37,6 +37,7 @@ import { getCalendarGroupsRequest } from './soap/get-calendar-groups-request';
 import { StoreProvider } from './store/redux';
 import { useAppDispatch } from './store/redux/hooks';
 import { updateCalendarGroupsStore } from './store/zustand/calendar-group-store';
+import { EditorCloseConfirmationModal } from './view/modals/editor-close-confirmation-modal';
 import Notifications from './view/notifications';
 import { AppointmentReminder } from './view/reminder/appointment-reminder';
 import { InitializeTags } from './view/tags/initialize-tags';
@@ -227,6 +228,7 @@ export default function App(): React.JSX.Element {
 				<InitializeTags />
 				<SyncDataHandler />
 				<Notifications />
+				<EditorCloseConfirmationModal />
 			</StoreProvider>
 		</AuthGuard>
 	);

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -37,7 +37,7 @@ import { getCalendarGroupsRequest } from './soap/get-calendar-groups-request';
 import { StoreProvider } from './store/redux';
 import { useAppDispatch } from './store/redux/hooks';
 import { updateCalendarGroupsStore } from './store/zustand/calendar-group-store';
-import { EditorCloseConfirmationModal } from './view/modals/editor-close-confirmation-modal';
+import { GlobalModalManager } from './view/global-modal-manager';
 import Notifications from './view/notifications';
 import { AppointmentReminder } from './view/reminder/appointment-reminder';
 import { InitializeTags } from './view/tags/initialize-tags';
@@ -221,14 +221,13 @@ export default function App(): React.JSX.Element {
 	return (
 		<AuthGuard>
 			<StoreProvider>
-				<ModalManager>
+				<GlobalModalManager>
 					<AppRegistrations />
-				</ModalManager>
+				</GlobalModalManager>
 				<AppointmentReminder />
 				<InitializeTags />
 				<SyncDataHandler />
 				<Notifications />
-				<EditorCloseConfirmationModal />
 			</StoreProvider>
 		</AuthGuard>
 	);

--- a/src/commons/editor-generator.ts
+++ b/src/commons/editor-generator.ts
@@ -127,7 +127,8 @@ export const createEmptyEditor = (id: string, folders: Folders): Editor => {
 		plainText: '',
 		disabled: disabledFields,
 		id,
-		compNum: 0
+		compNum: 0,
+		isDirty: false
 	};
 };
 

--- a/src/commons/modal-footer.tsx
+++ b/src/commons/modal-footer.tsx
@@ -11,6 +11,7 @@ import { ModalFooterProps } from '@zextras/carbonio-ui-commons';
 
 type ExtendedModalFooterProps = ModalFooterProps & {
 	leftSideContent?: ReactNode;
+	loading?: boolean;
 };
 
 const ModalFooter: FC<ExtendedModalFooterProps> = ({
@@ -34,7 +35,8 @@ const ModalFooter: FC<ExtendedModalFooterProps> = ({
 	additionalBtnType = 'outlined',
 	additionalColor = 'secondary',
 	additionalLabel = t('label.cancel', 'cancel'),
-	leftSideContent
+	leftSideContent,
+	loading
 }): ReactElement => {
 	const secondaryButtonTypeAndColor = useMemo(() => {
 		if (secondaryBtnType === 'ghost') {
@@ -122,7 +124,8 @@ const ModalFooter: FC<ExtendedModalFooterProps> = ({
 								width="fit"
 								onClick={onConfirm}
 								label={label}
-								disabled={disabled}
+								disabled={disabled || loading}
+								loading={loading}
 								{...primaryButtonTypeAndColor}
 							/>
 						</Tooltip>
@@ -131,7 +134,8 @@ const ModalFooter: FC<ExtendedModalFooterProps> = ({
 							width="fit"
 							onClick={onConfirm}
 							label={label}
-							disabled={disabled}
+							disabled={disabled || loading}
+							loading={loading}
 							{...primaryButtonTypeAndColor}
 						/>
 					)}

--- a/src/normalizations/tests/normalize-editor.test.ts
+++ b/src/normalizations/tests/normalize-editor.test.ts
@@ -102,7 +102,8 @@ describe('normalizeEditor', () => {
 			start: event.start.valueOf(),
 			timezone: emptyEditor.timezone,
 			title: event.title,
-			uid: ''
+			uid: '',
+			isDirty: false
 		};
 
 		expect(result).toStrictEqual(expectedResult);

--- a/src/store/reducers/editor-reducers.ts
+++ b/src/store/reducers/editor-reducers.ts
@@ -8,7 +8,7 @@ import { isEqual, isNil, omit, union } from 'lodash';
 
 import { CalendarEditor, Resource, Editor, Room, CalendarSender } from '../../types/editor';
 import { EditorChipAttendees, InviteClass, InviteFreeBusy } from '../../types/store/invite';
-import type { EditorSlice, PendingCloseConfirmation } from '../../types/store/store';
+import type { EditorSlice } from '../../types/store/store';
 
 const METADATA_FIELDS: ReadonlyArray<keyof Editor> = [
 	'id',
@@ -377,15 +377,3 @@ export const updateEditorReducer = (
 	}
 };
 
-export const setPendingCloseConfirmationReducer = (
-	state: EditorSlice,
-	{ payload }: PayloadAction<PendingCloseConfirmation>
-): void => {
-	// eslint-disable-next-line no-param-reassign
-	state.pendingCloseConfirmation = payload;
-};
-
-export const clearPendingCloseConfirmationReducer = (state: EditorSlice): void => {
-	// eslint-disable-next-line no-param-reassign
-	state.pendingCloseConfirmation = null;
-};

--- a/src/store/reducers/editor-reducers.ts
+++ b/src/store/reducers/editor-reducers.ts
@@ -34,7 +34,7 @@ const METADATA_FIELDS: ReadonlyArray<keyof Editor> = [
 const ATTENDEE_FIELDS: ReadonlyArray<keyof Editor> = ['attendees', 'optionalAttendees'];
 
 const getAttendeeEmails = (attendees: Editor['attendees']): string[] =>
-	(attendees ?? []).map((a) => a.email.toLowerCase()).sort();
+	(attendees ?? []).map((a) => a.email.toLowerCase()).sort((a, b) => a.localeCompare(b));
 
 const recomputeIsDirty = (
 	editors: EditorSlice['editors'],

--- a/src/store/reducers/editor-reducers.ts
+++ b/src/store/reducers/editor-reducers.ts
@@ -4,11 +4,49 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import type { PayloadAction } from '@reduxjs/toolkit';
-import { isNil, union } from 'lodash';
+import { isEqual, isNil, omit, union } from 'lodash';
 
 import { CalendarEditor, Resource, Editor, Room, CalendarSender } from '../../types/editor';
 import { EditorChipAttendees, InviteClass, InviteFreeBusy } from '../../types/store/invite';
-import type { EditorSlice } from '../../types/store/store';
+import type { EditorSlice, PendingCloseConfirmation } from '../../types/store/store';
+
+const METADATA_FIELDS: ReadonlyArray<keyof Editor> = [
+	'id',
+	'isDirty',
+	'disabled',
+	'panel',
+	'isNew',
+	'originalStart',
+	'originalEnd',
+	'compNum',
+	'inviteId',
+	'uid',
+	'ridZ',
+	'exceptId',
+	'isSeries',
+	'isInstance',
+	'isException',
+	'searchPanel',
+	'isProposeNewTime',
+	'draft'
+];
+
+const recomputeIsDirty = (
+	editors: EditorSlice['editors'],
+	originalEditors: EditorSlice['originalEditors'],
+	id: string
+): void => {
+	const original = originalEditors[id];
+	if (!original) {
+		editors[id].isDirty = true;
+		return;
+	}
+	// eslint-disable-next-line no-param-reassign
+	editors[id].isDirty = !isEqual(
+		omit(editors[id], METADATA_FIELDS),
+		omit(original, METADATA_FIELDS)
+	);
+};
 
 type SenderPayload = {
 	id: string | undefined;
@@ -82,22 +120,25 @@ type AttachmentFilesPayload = {
 
 export const newEditorReducer = (state: EditorSlice, action: PayloadAction<Editor>): void => {
 	if (action.payload) {
-		state.editors[action.payload.id] = action.payload;
+		const editor = { ...action.payload, isDirty: false };
+		state.editors[action.payload.id] = editor;
+		state.originalEditors[action.payload.id] = editor;
 	}
 };
 
 export const editIsRichTextReducer = (
-	{ editors }: EditorSlice,
+	{ editors, originalEditors }: EditorSlice,
 	{ payload }: PayloadAction<IsRichTextPayload>
 ): void => {
 	if (payload?.id && !isNil(editors?.[payload?.id]?.isRichText)) {
 		// eslint-disable-next-line no-param-reassign
 		editors[payload.id].isRichText = payload.isRichText;
+		recomputeIsDirty(editors, originalEditors, payload.id);
 	}
 };
 
 export const editEditorAttachmentsReducer = (
-	{ editors }: EditorSlice,
+	{ editors, originalEditors }: EditorSlice,
 	{ payload }: PayloadAction<AttachmentFilesPayload>
 ): void => {
 	if (!payload?.id || !editors?.[payload.id]) return;
@@ -108,60 +149,65 @@ export const editEditorAttachmentsReducer = (
 		aid: (payload.attachmentFiles ?? []).filter((f) => f.aid).map((f) => f.aid) as string[],
 		mp: payload.attach?.mp ?? editor.attach?.mp ?? []
 	};
+	recomputeIsDirty(editors, originalEditors, payload.id);
 };
 
 export const editSenderReducer = (
-	{ editors }: EditorSlice,
+	{ editors, originalEditors }: EditorSlice,
 	{ payload }: PayloadAction<SenderPayload>
 ): void => {
 	if (payload?.id && editors?.[payload?.id]?.sender && payload?.sender) {
-		const editor = editors[payload.id];
-		editor.sender = payload.sender;
+		editors[payload.id].sender = payload.sender;
+		recomputeIsDirty(editors, originalEditors, payload.id);
 	}
 };
 
 export const editTitleReducer = (
-	{ editors }: EditorSlice,
+	{ editors, originalEditors }: EditorSlice,
 	{ payload }: PayloadAction<TitlePayload>
 ): void => {
 	if (payload?.id && !isNil(editors?.[payload?.id]?.title) && !isNil(payload?.title)) {
 		// eslint-disable-next-line no-param-reassign
 		editors[payload.id].title = payload.title;
+		recomputeIsDirty(editors, originalEditors, payload.id);
 	}
 };
 
 export const editLocationReducer = (
-	{ editors }: EditorSlice,
+	{ editors, originalEditors }: EditorSlice,
 	{ payload }: PayloadAction<LocationPayload>
 ): void => {
 	if (payload?.id && !isNil(editors?.[payload?.id]?.location) && !isNil(payload?.location)) {
 		// eslint-disable-next-line no-param-reassign
 		editors[payload.id].location = payload.location;
+		recomputeIsDirty(editors, originalEditors, payload.id);
 	}
 };
 
 export const editEditorMeetingRoomReducer = (
-	{ editors }: EditorSlice,
+	{ editors, originalEditors }: EditorSlice,
 	{ payload }: PayloadAction<{ id: string; meetingRoom: Array<Resource> }>
 ): void => {
 	if (payload?.id && !isNil(editors?.[payload?.id])) {
 		// eslint-disable-next-line no-param-reassign
 		editors[payload.id].meetingRoom = payload.meetingRoom;
+		recomputeIsDirty(editors, originalEditors, payload.id);
 	}
 };
 
 export const editEditorEquipmentReducer = (
-	{ editors }: EditorSlice,
+	{ editors, originalEditors }: EditorSlice,
 	{ payload }: PayloadAction<{ id: string; equipment: Array<Resource> }>
 ): void => {
 	if (payload?.id && !isNil(editors?.[payload?.id])) {
 		// eslint-disable-next-line no-param-reassign
 		editors[payload.id].equipment = payload.equipment;
+		recomputeIsDirty(editors, originalEditors, payload.id);
 	}
 };
 
 export const editEditorRoomReducer = (
-	{ editors }: EditorSlice,
+	{ editors, originalEditors }: EditorSlice,
 	{ payload }: PayloadAction<RoomPayload>
 ): void => {
 	const { label, link, attendees } = payload.room;
@@ -177,57 +223,63 @@ export const editEditorRoomReducer = (
 			// eslint-disable-next-line no-param-reassign
 			editors[payload.id].attendees = union(editors[payload.id].attendees, attendees);
 		}
+		recomputeIsDirty(editors, originalEditors, payload.id);
 	}
 };
 
 export const editEditorAttendeesReducer = (
-	{ editors }: EditorSlice,
+	{ editors, originalEditors }: EditorSlice,
 	{ payload }: PayloadAction<AttendeePayload>
 ): void => {
 	// eslint-disable-next-line no-param-reassign
 	editors[payload.id].attendees = payload.attendees;
+	recomputeIsDirty(editors, originalEditors, payload.id);
 };
 
 export const editEditorOptionalAttendeesReducer = (
-	{ editors }: EditorSlice,
+	{ editors, originalEditors }: EditorSlice,
 	{ payload }: PayloadAction<OptionalAttendeePayload>
 ): void => {
 	// eslint-disable-next-line no-param-reassign
 	editors[payload.id].optionalAttendees = payload.optionalAttendees;
+	recomputeIsDirty(editors, originalEditors, payload.id);
 };
 
 export const editEditorDisplayStatusReducer = (
-	{ editors }: EditorSlice,
+	{ editors, originalEditors }: EditorSlice,
 	{ payload }: PayloadAction<FreeBusyPayload>
 ): void => {
 	if (editors?.[payload?.id]) {
 		// eslint-disable-next-line no-param-reassign
 		editors[payload.id].freeBusy = payload.freeBusy;
+		recomputeIsDirty(editors, originalEditors, payload.id);
 	}
 };
 
 export const editEditorCalendarReducer = (
-	{ editors }: EditorSlice,
+	{ editors, originalEditors }: EditorSlice,
 	{ payload }: PayloadAction<CalendarPayload>
 ): void => {
 	if (payload?.id && editors?.[payload?.id]) {
 		// eslint-disable-next-line no-param-reassign
 		editors[payload.id].calendar = payload.calendar;
+		recomputeIsDirty(editors, originalEditors, payload.id);
 	}
 };
 
 export const editEditorClassReducer = (
-	{ editors }: EditorSlice,
+	{ editors, originalEditors }: EditorSlice,
 	{ payload }: PayloadAction<ClassPayload>
 ): void => {
 	if (payload?.id && editors?.[payload?.id]) {
 		// eslint-disable-next-line no-param-reassign
 		editors[payload.id].class = payload.class;
+		recomputeIsDirty(editors, originalEditors, payload.id);
 	}
 };
 
 export const editEditorDateReducer = (
-	{ editors }: EditorSlice,
+	{ editors, originalEditors }: EditorSlice,
 	{ payload }: PayloadAction<DateReducer>
 ): void => {
 	if (payload?.id && editors?.[payload?.id]) {
@@ -235,11 +287,12 @@ export const editEditorDateReducer = (
 		editors[payload.id].start = payload.start;
 		// eslint-disable-next-line no-param-reassign
 		editors[payload.id].end = payload.end;
+		recomputeIsDirty(editors, originalEditors, payload.id);
 	}
 };
 
 export const editEditorTextReducer = (
-	{ editors }: EditorSlice,
+	{ editors, originalEditors }: EditorSlice,
 	{ payload }: PayloadAction<TextPayload>
 ): void => {
 	if (payload?.id && editors?.[payload?.id]) {
@@ -247,55 +300,76 @@ export const editEditorTextReducer = (
 		editors[payload.id].richText = payload.richText;
 		// eslint-disable-next-line no-param-reassign
 		editors[payload.id].plainText = payload.plainText;
+		recomputeIsDirty(editors, originalEditors, payload.id);
 	}
 };
 
 export const editEditorAllDayReducer = (
-	{ editors }: EditorSlice,
+	{ editors, originalEditors }: EditorSlice,
 	{ payload }: PayloadAction<AllDayPayload>
 ): void => {
 	if (payload?.id && editors?.[payload?.id]) {
 		// eslint-disable-next-line no-param-reassign
 		editors[payload.id].allDay = payload.allDay;
+		recomputeIsDirty(editors, originalEditors, payload.id);
 	}
 };
 
 export const editEditorTimezoneReducer = (
-	{ editors }: EditorSlice,
+	{ editors, originalEditors }: EditorSlice,
 	{ payload }: PayloadAction<any>
 ): void => {
 	if (payload?.id && editors?.[payload?.id]) {
 		// eslint-disable-next-line no-param-reassign
 		editors[payload.id].timezone = payload.timezone;
+		recomputeIsDirty(editors, originalEditors, payload.id);
 	}
 };
 
 export const editEditorReminderReducer = (
-	{ editors }: EditorSlice,
+	{ editors, originalEditors }: EditorSlice,
 	{ payload }: PayloadAction<any>
 ): void => {
 	if (payload?.id && editors?.[payload?.id]) {
 		// eslint-disable-next-line no-param-reassign
 		editors[payload.id].reminder = payload.reminder;
+		recomputeIsDirty(editors, originalEditors, payload.id);
 	}
 };
 
 export const editEditorRecurrenceReducer = (
-	{ editors }: EditorSlice,
+	{ editors, originalEditors }: EditorSlice,
 	{ payload }: PayloadAction<any>
 ): void => {
 	if (payload?.id && editors?.[payload?.id]) {
 		// eslint-disable-next-line no-param-reassign
 		editors[payload.id].recur = payload.recur;
+		recomputeIsDirty(editors, originalEditors, payload.id);
 	}
 };
 
 export const updateEditorReducer = (
-	editor: EditorSlice,
+	state: EditorSlice,
 	{ payload }: PayloadAction<{ id: string; editor: Editor }>
 ): void => {
-	if (payload?.id && editor?.editors?.[payload?.id]) {
+	if (payload?.id && state?.editors?.[payload?.id]) {
+		const saved = { ...state.editors[payload.id], ...payload.editor, isDirty: false };
 		// eslint-disable-next-line no-param-reassign
-		editor.editors[payload.id] = { ...editor.editors[payload.id], ...payload.editor };
+		state.editors[payload.id] = saved;
+		// eslint-disable-next-line no-param-reassign
+		state.originalEditors[payload.id] = saved;
 	}
+};
+
+export const setPendingCloseConfirmationReducer = (
+	state: EditorSlice,
+	{ payload }: PayloadAction<PendingCloseConfirmation>
+): void => {
+	// eslint-disable-next-line no-param-reassign
+	state.pendingCloseConfirmation = payload;
+};
+
+export const clearPendingCloseConfirmationReducer = (state: EditorSlice): void => {
+	// eslint-disable-next-line no-param-reassign
+	state.pendingCloseConfirmation = null;
 };

--- a/src/store/reducers/editor-reducers.ts
+++ b/src/store/reducers/editor-reducers.ts
@@ -173,6 +173,7 @@ export const editSenderReducer = (
 	{ payload }: PayloadAction<SenderPayload>
 ): void => {
 	if (payload?.id && editors?.[payload?.id]?.sender && payload?.sender) {
+		// eslint-disable-next-line no-param-reassign
 		editors[payload.id].sender = payload.sender;
 		recomputeIsDirty(editors, originalEditors, payload.id);
 	}
@@ -376,4 +377,3 @@ export const updateEditorReducer = (
 		state.originalEditors[payload.id] = saved;
 	}
 };
-

--- a/src/store/reducers/editor-reducers.ts
+++ b/src/store/reducers/editor-reducers.ts
@@ -31,6 +31,11 @@ const METADATA_FIELDS: ReadonlyArray<keyof Editor> = [
 	'draft'
 ];
 
+const ATTENDEE_FIELDS: ReadonlyArray<keyof Editor> = ['attendees', 'optionalAttendees'];
+
+const getAttendeeEmails = (attendees: Editor['attendees']): string[] =>
+	(attendees ?? []).map((a) => a.email.toLowerCase()).sort();
+
 const recomputeIsDirty = (
 	editors: EditorSlice['editors'],
 	originalEditors: EditorSlice['originalEditors'],
@@ -38,14 +43,25 @@ const recomputeIsDirty = (
 ): void => {
 	const original = originalEditors[id];
 	if (!original) {
+		// eslint-disable-next-line no-param-reassign
 		editors[id].isDirty = true;
 		return;
 	}
-	// eslint-disable-next-line no-param-reassign
-	editors[id].isDirty = !isEqual(
-		omit(editors[id], METADATA_FIELDS),
-		omit(original, METADATA_FIELDS)
+	const excludedFields = [...METADATA_FIELDS, ...ATTENDEE_FIELDS];
+	const nonAttendeeChanged = !isEqual(
+		omit(editors[id], excludedFields),
+		omit(original, excludedFields)
 	);
+	const attendeesChanged = !isEqual(
+		getAttendeeEmails(editors[id].attendees),
+		getAttendeeEmails(original.attendees)
+	);
+	const optionalAttendeesChanged = !isEqual(
+		getAttendeeEmails(editors[id].optionalAttendees),
+		getAttendeeEmails(original.optionalAttendees)
+	);
+	// eslint-disable-next-line no-param-reassign
+	editors[id].isDirty = nonAttendeeChanged || attendeesChanged || optionalAttendeesChanged;
 };
 
 type SenderPayload = {

--- a/src/store/selectors/editor.ts
+++ b/src/store/selectors/editor.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { Editor } from '../../types/editor';
+import type { PendingCloseConfirmation } from '../../types/store/store';
 import type { RootState } from '../redux';
 
 export const selectEditor =
@@ -230,3 +231,11 @@ export const selectIsException =
 	(id: string) =>
 	(state: RootState): Editor['isException'] =>
 		state?.editor?.editors?.[id]?.isException;
+
+export const selectEditorIsDirty =
+	(id: string) =>
+	(state: RootState): boolean =>
+		state?.editor?.editors?.[id]?.isDirty ?? false;
+
+export const selectPendingCloseConfirmation = (state: RootState): PendingCloseConfirmation | null =>
+	state?.editor?.pendingCloseConfirmation ?? null;

--- a/src/store/selectors/editor.ts
+++ b/src/store/selectors/editor.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { Editor } from '../../types/editor';
-import type { PendingCloseConfirmation } from '../../types/store/store';
 import type { RootState } from '../redux';
 
 export const selectEditor =
@@ -236,6 +235,3 @@ export const selectEditorIsDirty =
 	(id: string) =>
 	(state: RootState): boolean =>
 		state?.editor?.editors?.[id]?.isDirty ?? false;
-
-export const selectPendingCloseConfirmation = (state: RootState): PendingCloseConfirmation | null =>
-	state?.editor?.pendingCloseConfirmation ?? null;

--- a/src/store/slices/editor-slice.ts
+++ b/src/store/slices/editor-slice.ts
@@ -27,16 +27,13 @@ import {
 	newEditorReducer,
 	editSenderReducer,
 	editEditorMeetingRoomReducer,
-	editEditorEquipmentReducer,
-	setPendingCloseConfirmationReducer,
-	clearPendingCloseConfirmationReducer
+	editEditorEquipmentReducer
 } from '../reducers/editor-reducers';
 
 const initialState: EditorSlice = {
 	status: 'idle',
 	editors: {},
-	originalEditors: {},
-	pendingCloseConfirmation: null
+	originalEditors: {}
 };
 
 export const editorSlice = createSlice({
@@ -63,9 +60,7 @@ export const editorSlice = createSlice({
 		editEditorTimezone: editEditorTimezoneReducer,
 		editEditorReminder: editEditorReminderReducer,
 		editEditorRecurrence: editEditorRecurrenceReducer,
-		updateEditor: updateEditorReducer,
-		setPendingCloseConfirmation: setPendingCloseConfirmationReducer,
-		clearPendingCloseConfirmation: clearPendingCloseConfirmationReducer
+		updateEditor: updateEditorReducer
 	}
 });
 
@@ -90,9 +85,7 @@ export const {
 	editEditorTimezone,
 	editEditorReminder,
 	editEditorRecurrence,
-	updateEditor,
-	setPendingCloseConfirmation,
-	clearPendingCloseConfirmation
+	updateEditor
 } = editorSlice.actions;
 
 export default editorSlice.reducer;

--- a/src/store/slices/editor-slice.ts
+++ b/src/store/slices/editor-slice.ts
@@ -27,12 +27,16 @@ import {
 	newEditorReducer,
 	editSenderReducer,
 	editEditorMeetingRoomReducer,
-	editEditorEquipmentReducer
+	editEditorEquipmentReducer,
+	setPendingCloseConfirmationReducer,
+	clearPendingCloseConfirmationReducer
 } from '../reducers/editor-reducers';
 
 const initialState: EditorSlice = {
 	status: 'idle',
-	editors: {}
+	editors: {},
+	originalEditors: {},
+	pendingCloseConfirmation: null
 };
 
 export const editorSlice = createSlice({
@@ -59,7 +63,9 @@ export const editorSlice = createSlice({
 		editEditorTimezone: editEditorTimezoneReducer,
 		editEditorReminder: editEditorReminderReducer,
 		editEditorRecurrence: editEditorRecurrenceReducer,
-		updateEditor: updateEditorReducer
+		updateEditor: updateEditorReducer,
+		setPendingCloseConfirmation: setPendingCloseConfirmationReducer,
+		clearPendingCloseConfirmation: clearPendingCloseConfirmationReducer
 	}
 });
 
@@ -84,7 +90,9 @@ export const {
 	editEditorTimezone,
 	editEditorReminder,
 	editEditorRecurrence,
-	updateEditor
+	updateEditor,
+	setPendingCloseConfirmation,
+	clearPendingCloseConfirmation
 } = editorSlice.actions;
 
 export default editorSlice.reducer;

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -145,4 +145,5 @@ export type Editor = {
 	attach?: any;
 	isProposeNewTime?: boolean;
 	compNum: number;
+	isDirty?: boolean;
 };

--- a/src/types/store/store.ts
+++ b/src/types/store/store.ts
@@ -44,14 +44,8 @@ export type InvitesSlice = {
 	invites: Record<string, Invite>;
 };
 
-export type PendingCloseConfirmation = {
-	editorId: string;
-	boardTitle: string;
-};
-
 export type EditorSlice = {
 	status: string;
 	editors: Record<string, Editor>;
 	originalEditors: Record<string, Editor>;
-	pendingCloseConfirmation: PendingCloseConfirmation | null;
 };

--- a/src/types/store/store.ts
+++ b/src/types/store/store.ts
@@ -44,7 +44,14 @@ export type InvitesSlice = {
 	invites: Record<string, Invite>;
 };
 
+export type PendingCloseConfirmation = {
+	editorId: string;
+	boardTitle: string;
+};
+
 export type EditorSlice = {
 	status: string;
 	editors: Record<string, Editor>;
+	originalEditors: Record<string, Editor>;
+	pendingCloseConfirmation: PendingCloseConfirmation | null;
 };

--- a/src/view/editor/editor-board-wrapper.tsx
+++ b/src/view/editor/editor-board-wrapper.tsx
@@ -20,11 +20,11 @@ const BoardEditPanel = (): ReactElement | null => {
 	const dispatch = useAppDispatch();
 	const isDirty = useAppSelector(selectEditorIsDirty(editorId ?? ''));
 	const isDirtyRef = useRef(isDirty);
-	// Update every render so the onClose closure always reads the latest value
 	isDirtyRef.current = isDirty;
+	const boardTitleRef = useRef(board?.title ?? '');
+	boardTitleRef.current = board?.title ?? '';
 
-	const boardHooks = useBoardHooks();
-	const { updateBoard } = boardHooks;
+	const { updateBoard } = useBoardHooks();
 
 	useEffect(() => {
 		updateBoard({
@@ -33,14 +33,13 @@ const BoardEditPanel = (): ReactElement | null => {
 					dispatch(
 						setPendingCloseConfirmation({
 							editorId,
-							boardTitle: board?.title ?? ''
+							boardTitle: boardTitleRef.current
 						})
 					);
 				}
 			}
 		});
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [updateBoard]);
+	}, [dispatch, editorId, updateBoard]);
 
 	if (!editorId) {
 		return null;

--- a/src/view/editor/editor-board-wrapper.tsx
+++ b/src/view/editor/editor-board-wrapper.tsx
@@ -8,16 +8,17 @@ import React, { ReactElement, useEffect, useRef } from 'react';
 import { useBoard, useBoardHooks } from '@zextras/carbonio-shell-ui';
 
 import { EditorPanel } from './editor-panel';
-import { useAppDispatch, useAppSelector } from '../../store/redux/hooks';
+import { StoreProvider } from '../../store/redux';
+import { useAppSelector } from '../../store/redux/hooks';
 import { selectEditorIsDirty } from '../../store/selectors/editor';
-import { setPendingCloseConfirmation } from '../../store/slices/editor-slice';
+import { useGlobalModal } from '../global-modal-manager';
+import { EditorCloseConfirmationModal } from '../modals/editor-close-confirmation-modal';
 
 const BoardEditPanel = (): ReactElement | null => {
 	const board = useBoard();
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore
 	const editorId: string | undefined = board?.editor?.id;
-	const dispatch = useAppDispatch();
 	const isDirty = useAppSelector(selectEditorIsDirty(editorId ?? ''));
 	const isDirtyRef = useRef(isDirty);
 	isDirtyRef.current = isDirty;
@@ -25,21 +26,33 @@ const BoardEditPanel = (): ReactElement | null => {
 	boardTitleRef.current = board?.title ?? '';
 
 	const { updateBoard } = useBoardHooks();
+	const { createModal, closeModal } = useGlobalModal();
 
 	useEffect(() => {
 		updateBoard({
 			onClose: () => {
 				if (isDirtyRef.current && editorId) {
-					dispatch(
-						setPendingCloseConfirmation({
-							editorId,
-							boardTitle: boardTitleRef.current
-						})
+					const modalId = 'editor-close-confirmation';
+					createModal(
+						{
+							id: modalId,
+							children: (
+								<StoreProvider>
+									<EditorCloseConfirmationModal
+										editorId={editorId}
+										boardTitle={boardTitleRef.current}
+										onClose={(): void => closeModal(modalId)}
+									/>
+								</StoreProvider>
+							),
+							onClose: () => closeModal(modalId)
+						},
+						true
 					);
 				}
 			}
 		});
-	}, [dispatch, editorId, updateBoard]);
+	}, [closeModal, createModal, editorId, updateBoard]);
 
 	if (!editorId) {
 		return null;

--- a/src/view/editor/editor-board-wrapper.tsx
+++ b/src/view/editor/editor-board-wrapper.tsx
@@ -3,21 +3,49 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useEffect, useRef } from 'react';
 
-import { useBoard } from '@zextras/carbonio-shell-ui';
+import { useBoard, useBoardHooks } from '@zextras/carbonio-shell-ui';
 
 import { EditorPanel } from './editor-panel';
+import { useAppDispatch, useAppSelector } from '../../store/redux/hooks';
+import { selectEditorIsDirty } from '../../store/selectors/editor';
+import { setPendingCloseConfirmation } from '../../store/slices/editor-slice';
 
 const BoardEditPanel = (): ReactElement | null => {
 	const board = useBoard();
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore
-	if (!board?.editor?.id) {
+	const editorId: string | undefined = board?.editor?.id;
+	const dispatch = useAppDispatch();
+	const isDirty = useAppSelector(selectEditorIsDirty(editorId ?? ''));
+	const isDirtyRef = useRef(isDirty);
+	// Update every render so the onClose closure always reads the latest value
+	isDirtyRef.current = isDirty;
+
+	const boardHooks = useBoardHooks();
+	const { updateBoard } = boardHooks;
+
+	useEffect(() => {
+		updateBoard({
+			onClose: () => {
+				if (isDirtyRef.current && editorId) {
+					dispatch(
+						setPendingCloseConfirmation({
+							editorId,
+							boardTitle: board?.title ?? ''
+						})
+					);
+				}
+			}
+		});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [updateBoard]);
+
+	if (!editorId) {
 		return null;
 	}
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore
-	return <EditorPanel editorId={board?.editor?.id} />;
+
+	return <EditorPanel editorId={editorId} />;
 };
 export default BoardEditPanel;

--- a/src/view/editor/parts/attendees-contact-input.tsx
+++ b/src/view/editor/parts/attendees-contact-input.tsx
@@ -6,9 +6,8 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 
-import { isEqual } from 'lodash';
-
 import { CONTACT_TYPES, useContactInput, ContactInputItem } from '@zextras/carbonio-ui-commons';
+import { isEqual } from 'lodash';
 
 import { EditorChipAttendees } from '../../../types/store/invite';
 

--- a/src/view/editor/parts/attendees-contact-input.tsx
+++ b/src/view/editor/parts/attendees-contact-input.tsx
@@ -6,6 +6,8 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 
+import { isEqual } from 'lodash';
+
 import { CONTACT_TYPES, useContactInput, ContactInputItem } from '@zextras/carbonio-ui-commons';
 
 import { EditorChipAttendees } from '../../../types/store/invite';
@@ -53,11 +55,15 @@ export const AttendeesContactInput = ({
 			setInputState(newInputState);
 			const updatedAttendees = valuesFromInput.map((contact) => {
 				const currentAttendee = attendees.find(
-					(attendee) => attendee.email === contact.value.email
+					(attendee) => attendee.email.toLowerCase() === contact.value.email.toLowerCase()
 				);
 				return currentAttendee || createEditorAttendeeFromContactInput(contact);
 			});
-			onChange(updatedAttendees);
+			const currentEmails = attendees.map((a) => a.email.toLowerCase()).sort();
+			const newEmails = updatedAttendees.map((a) => a.email.toLowerCase()).sort();
+			if (!isEqual(currentEmails, newEmails)) {
+				onChange(updatedAttendees);
+			}
 		},
 		[attendees, onChange]
 	);

--- a/src/view/editor/parts/attendees-contact-input.tsx
+++ b/src/view/editor/parts/attendees-contact-input.tsx
@@ -58,8 +58,12 @@ export const AttendeesContactInput = ({
 				);
 				return currentAttendee || createEditorAttendeeFromContactInput(contact);
 			});
-			const currentEmails = attendees.map((a) => a.email.toLowerCase()).sort();
-			const newEmails = updatedAttendees.map((a) => a.email.toLowerCase()).sort();
+			const currentEmails = attendees
+				.map((a) => a.email.toLowerCase())
+				.sort((a, b) => a.localeCompare(b));
+			const newEmails = updatedAttendees
+				.map((a) => a.email.toLowerCase())
+				.sort((a, b) => a.localeCompare(b));
 			if (!isEqual(currentEmails, newEmails)) {
 				onChange(updatedAttendees);
 			}

--- a/src/view/editor/parts/editor-composer.tsx
+++ b/src/view/editor/parts/editor-composer.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React, { ReactElement, useCallback, useMemo, useState } from 'react';
+import React, { ReactElement, useCallback, useMemo, useRef, useState } from 'react';
 
 import styled from '@emotion/styled';
 import { t, useUserSettings } from '@zextras/carbonio-shell-ui';
@@ -126,6 +126,7 @@ const HtmlComposer = ({ editorId }: { editorId: string }): React.JSX.Element => 
 	const dispatch = useAppDispatch();
 
 	const [richTextValue, setRichTextValue] = useState(richText ?? '');
+	const hasTinyMCEFiredInit = useRef(false);
 
 	const debounceInput = useMemo(
 		() =>
@@ -144,6 +145,11 @@ const HtmlComposer = ({ editorId }: { editorId: string }): React.JSX.Element => 
 
 	const onRichTextChange = useCallback(
 		(e: Array<string>) => {
+			// TinyMCE fires onEditorChange once on init before loading content — skip it
+			if (!hasTinyMCEFiredInit.current) {
+				hasTinyMCEFiredInit.current = true;
+				return;
+			}
 			setRichTextValue(e[1]);
 			debounceInput(e);
 		},

--- a/src/view/editor/tests/editor-board-wrapper.test.tsx
+++ b/src/view/editor/tests/editor-board-wrapper.test.tsx
@@ -19,6 +19,13 @@ import { Editor } from '../../../types/editor';
 import BoardEditPanel from '../editor-board-wrapper';
 import { setupTest } from '@test-setup';
 
+const mockCreateModal = vi.fn();
+const mockCloseModal = vi.fn();
+
+vi.mock('../../global-modal-manager', () => ({
+	useGlobalModal: vi.fn(() => ({ createModal: mockCreateModal, closeModal: mockCloseModal }))
+}));
+
 const initBoard = ({
 	editorId,
 	isNew
@@ -79,7 +86,7 @@ describe('Editor board wrapper', () => {
 			);
 		});
 
-		it('dispatches setPendingCloseConfirmation when onClose fires with dirty editor', () => {
+		it('opens close confirmation modal when onClose fires with dirty editor', () => {
 			const store = configureStore({ reducer: combineReducers(reducers) });
 			const mockBoardHooks = shell.useBoardHooks();
 
@@ -99,13 +106,13 @@ describe('Editor board wrapper', () => {
 			const { onClose } = lastCall[0];
 			onClose();
 
-			expect(store.getState().editor.pendingCloseConfirmation).toEqual({
-				editorId: defaultEditor.id,
-				boardTitle: 'Nuovo appuntamento'
-			});
+			expect(mockCreateModal).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 'editor-close-confirmation' }),
+				true
+			);
 		});
 
-		it('does not dispatch setPendingCloseConfirmation when onClose fires with clean editor', () => {
+		it('does not open close confirmation modal when onClose fires with clean editor', () => {
 			const store = configureStore({ reducer: combineReducers(reducers) });
 			const mockBoardHooks = shell.useBoardHooks();
 
@@ -122,10 +129,10 @@ describe('Editor board wrapper', () => {
 			const { onClose } = lastCall[0];
 			onClose();
 
-			expect(store.getState().editor.pendingCloseConfirmation).toBeNull();
+			expect(mockCreateModal).not.toHaveBeenCalled();
 		});
 
-		it('does not dispatch setPendingCloseConfirmation when onClose fires after a successful save', () => {
+		it('does not open close confirmation modal when onClose fires after a successful save', () => {
 			const store = configureStore({ reducer: combineReducers(reducers) });
 			const mockBoardHooks = shell.useBoardHooks();
 
@@ -147,7 +154,7 @@ describe('Editor board wrapper', () => {
 			const { onClose } = lastCall[0];
 			onClose();
 
-			expect(store.getState().editor.pendingCloseConfirmation).toBeNull();
+			expect(mockCreateModal).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/view/editor/tests/editor-board-wrapper.test.tsx
+++ b/src/view/editor/tests/editor-board-wrapper.test.tsx
@@ -14,6 +14,7 @@ import * as shell from '../../../../__mocks__/@zextras/carbonio-shell-ui';
 import { generateEditor } from '../../../commons/editor-generator';
 import { CALENDAR_BOARD_ID } from '../../../constants';
 import { reducers } from '../../../store/redux';
+import { editEditorTitle } from '../../../store/slices/editor-slice';
 import { Editor } from '../../../types/editor';
 import BoardEditPanel from '../editor-board-wrapper';
 import { setupTest } from '@test-setup';
@@ -58,6 +59,70 @@ describe('Editor board wrapper', () => {
 			setupTest(<BoardEditPanel />, { store });
 
 			expect(await screen.findByTestId('EditorPanel')).toBeInTheDocument();
+		});
+	});
+
+	describe('close confirmation', () => {
+		it('calls updateBoard with an onClose handler when mounted', () => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			const mockBoardHooks = shell.useBoardHooks();
+
+			shell.useBoard.mockImplementation(() => initBoard({ editorId: '1', isNew: true }));
+			generateEditor({
+				context: { folders: {}, dispatch: store.dispatch, ...defaultEditor }
+			});
+
+			setupTest(<BoardEditPanel />, { store });
+
+			expect(mockBoardHooks.updateBoard).toHaveBeenCalledWith(
+				expect.objectContaining({ onClose: expect.any(Function) })
+			);
+		});
+
+		it('dispatches setPendingCloseConfirmation when onClose fires with dirty editor', () => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			const mockBoardHooks = shell.useBoardHooks();
+
+			shell.useBoard.mockImplementation(() => initBoard({ editorId: '1', isNew: true }));
+			generateEditor({
+				context: { folders: {}, dispatch: store.dispatch, ...defaultEditor }
+			});
+
+			// Mark the editor as dirty
+			store.dispatch(editEditorTitle({ id: defaultEditor.id, title: 'Changed title' }));
+
+			setupTest(<BoardEditPanel />, { store });
+
+			// Simulate the board X button click by calling onClose
+			const updateBoardCalls = mockBoardHooks.updateBoard.mock.calls;
+			const lastCall = updateBoardCalls[updateBoardCalls.length - 1];
+			const { onClose } = lastCall[0];
+			onClose();
+
+			expect(store.getState().editor.pendingCloseConfirmation).toEqual({
+				editorId: defaultEditor.id,
+				boardTitle: 'Nuovo appuntamento'
+			});
+		});
+
+		it('does not dispatch setPendingCloseConfirmation when onClose fires with clean editor', () => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			const mockBoardHooks = shell.useBoardHooks();
+
+			shell.useBoard.mockImplementation(() => initBoard({ editorId: '1', isNew: true }));
+			generateEditor({
+				context: { folders: {}, dispatch: store.dispatch, ...defaultEditor }
+			});
+
+			setupTest(<BoardEditPanel />, { store });
+
+			// Simulate the board X button click without editing
+			const updateBoardCalls = mockBoardHooks.updateBoard.mock.calls;
+			const lastCall = updateBoardCalls[updateBoardCalls.length - 1];
+			const { onClose } = lastCall[0];
+			onClose();
+
+			expect(store.getState().editor.pendingCloseConfirmation).toBeNull();
 		});
 	});
 });

--- a/src/view/editor/tests/editor-board-wrapper.test.tsx
+++ b/src/view/editor/tests/editor-board-wrapper.test.tsx
@@ -14,7 +14,7 @@ import * as shell from '../../../../__mocks__/@zextras/carbonio-shell-ui';
 import { generateEditor } from '../../../commons/editor-generator';
 import { CALENDAR_BOARD_ID } from '../../../constants';
 import { reducers } from '../../../store/redux';
-import { editEditorTitle } from '../../../store/slices/editor-slice';
+import { editEditorTitle, updateEditor } from '../../../store/slices/editor-slice';
 import { Editor } from '../../../types/editor';
 import BoardEditPanel from '../editor-board-wrapper';
 import { setupTest } from '@test-setup';
@@ -117,6 +117,31 @@ describe('Editor board wrapper', () => {
 			setupTest(<BoardEditPanel />, { store });
 
 			// Simulate the board X button click without editing
+			const updateBoardCalls = mockBoardHooks.updateBoard.mock.calls;
+			const lastCall = updateBoardCalls[updateBoardCalls.length - 1];
+			const { onClose } = lastCall[0];
+			onClose();
+
+			expect(store.getState().editor.pendingCloseConfirmation).toBeNull();
+		});
+
+		it('does not dispatch setPendingCloseConfirmation when onClose fires after a successful save', () => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			const mockBoardHooks = shell.useBoardHooks();
+
+			shell.useBoard.mockImplementation(() => initBoard({ editorId: '1', isNew: true }));
+			const editor = generateEditor({
+				context: { folders: {}, dispatch: store.dispatch, ...defaultEditor }
+			});
+
+			// Make dirty, then simulate a successful save (isDirty resets to false)
+			store.dispatch(editEditorTitle({ id: defaultEditor.id, title: 'Changed title' }));
+			store.dispatch(
+				updateEditor({ id: defaultEditor.id, editor: { ...editor, title: 'Changed title' } })
+			);
+
+			setupTest(<BoardEditPanel />, { store });
+
 			const updateBoardCalls = mockBoardHooks.updateBoard.mock.calls;
 			const lastCall = updateBoardCalls[updateBoardCalls.length - 1];
 			const { onClose } = lastCall[0];

--- a/src/view/editor/tests/editor-board-wrapper.test.tsx
+++ b/src/view/editor/tests/editor-board-wrapper.test.tsx
@@ -112,6 +112,28 @@ describe('Editor board wrapper', () => {
 			);
 		});
 
+		it('calls closeModal when the modal outer onClose is triggered', () => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			const mockBoardHooks = shell.useBoardHooks();
+
+			shell.useBoard.mockImplementation(() => initBoard({ editorId: '1', isNew: true }));
+			generateEditor({
+				context: { folders: {}, dispatch: store.dispatch, ...defaultEditor }
+			});
+			store.dispatch(editEditorTitle({ id: defaultEditor.id, title: 'Changed title' }));
+
+			setupTest(<BoardEditPanel />, { store });
+
+			const updateBoardCalls = mockBoardHooks.updateBoard.mock.calls;
+			const { onClose } = updateBoardCalls[updateBoardCalls.length - 1][0];
+			onClose();
+
+			const modalArgs = mockCreateModal.mock.calls[0][0];
+			modalArgs.onClose();
+
+			expect(mockCloseModal).toHaveBeenCalledWith('editor-close-confirmation');
+		});
+
 		it('does not open close confirmation modal when onClose fires with clean editor', () => {
 			const store = configureStore({ reducer: combineReducers(reducers) });
 			const mockBoardHooks = shell.useBoardHooks();

--- a/src/view/global-modal-manager.tsx
+++ b/src/view/global-modal-manager.tsx
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React, { useEffect } from 'react';
+
+import {
+	CloseModalFn,
+	CreateModalFn,
+	ModalManager,
+	useModal
+} from '@zextras/carbonio-design-system';
+
+const globalModalObj: { createModal: CreateModalFn; closeModal: CloseModalFn } = {
+	createModal: () => {
+		throw new Error('global modal manager not initialized');
+	},
+	closeModal: () => {
+		throw new Error('global modal manager not initialized');
+	}
+};
+
+const GlobalModalManagerProvider = (): null => {
+	const { createModal, closeModal } = useModal();
+	useEffect(() => {
+		globalModalObj.createModal = createModal;
+		globalModalObj.closeModal = closeModal;
+	}, [createModal, closeModal]);
+	return null;
+};
+
+export const GlobalModalManager = ({
+	children
+}: React.PropsWithChildren<Record<string, unknown>>): React.JSX.Element => (
+	<ModalManager>
+		<GlobalModalManagerProvider />
+		{children}
+	</ModalManager>
+);
+
+export const useGlobalModal = (): { createModal: CreateModalFn; closeModal: CloseModalFn } =>
+	globalModalObj;

--- a/src/view/modals/editor-close-confirmation-modal.tsx
+++ b/src/view/modals/editor-close-confirmation-modal.tsx
@@ -3,11 +3,12 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
-import { Container, CustomModal, Text } from '@zextras/carbonio-design-system';
+import { Container, CustomModal, Text, useSnackbar } from '@zextras/carbonio-design-system';
 import { addBoard, t } from '@zextras/carbonio-shell-ui';
 
+import { onSave } from '../../commons/editor-save-send-fns';
 import ModalFooter from '../../commons/modal-footer';
 import { ModalHeader } from '../../commons/modal-header';
 import { CALENDAR_BOARD_ID } from '../../constants';
@@ -19,26 +20,28 @@ export const EditorCloseConfirmationModal = (): React.JSX.Element => {
 	const pendingConfirmation = useAppSelector(selectPendingCloseConfirmation);
 	const editor = useAppSelector(selectEditor(pendingConfirmation?.editorId ?? ''));
 	const dispatch = useAppDispatch();
+	const createSnackbar = useSnackbar();
+	const [isSaving, setIsSaving] = useState(false);
 
-	const title = useMemo(() => t('label.close_appointment_editor', 'Close appointment editor'), []);
+	const title = useMemo(() => t('label.close_appointment_editor', 'Unsaved changes'), []);
 
 	const message = useMemo(
 		() =>
 			t(
 				'message.close_appointment_editor_confirmation',
-				'Are you sure you want to close the appointment editor? If you close it without saving, you will lose the unsaved data.'
+				'Your appointment has unsaved changes. Closing the editor now will discard them.'
 			),
 		[]
 	);
 
-	const confirmLabel = useMemo(() => t('label.yes_close', 'Yes, close'), []);
-	const cancelLabel = useMemo(() => t('label.cancel', 'Cancel'), []);
+	const saveAndCloseLabel = useMemo(() => t('label.save_and_close', 'Save and close'), []);
+	const keepEditingLabel = useMemo(() => t('label.keep_editing', 'Keep editing'), []);
 
-	const onConfirmClose = useCallback(() => {
+	const onDismiss = useCallback(() => {
 		dispatch(clearPendingCloseConfirmation());
 	}, [dispatch]);
 
-	const onCancelClose = useCallback(() => {
+	const onKeepEditing = useCallback(() => {
 		if (pendingConfirmation && editor) {
 			addBoard({
 				boardViewId: CALENDAR_BOARD_ID,
@@ -51,26 +54,54 @@ export const EditorCloseConfirmationModal = (): React.JSX.Element => {
 		dispatch(clearPendingCloseConfirmation());
 	}, [dispatch, editor, pendingConfirmation]);
 
+	const onSaveAndClose = useCallback(() => {
+		if (!editor) return;
+		setIsSaving(true);
+		onSave({
+			draft: false,
+			isNew: editor.isNew,
+			editor,
+			dispatch
+		}).then(({ response }: { response: unknown }) => {
+			createSnackbar({
+				key: 'editor-close-save',
+				replace: true,
+				severity: response ? 'info' : 'warning',
+				hideButton: true,
+				label: response
+					? t('message.snackbar.calendar_edits_saved', 'Edits saved correctly')
+					: t('label.error_try_again', 'Something went wrong, please try again'),
+				autoHideTimeout: 3000
+			});
+			setIsSaving(false);
+			if (response) {
+				dispatch(clearPendingCloseConfirmation());
+			}
+		});
+	}, [createSnackbar, dispatch, editor]);
+
 	return (
-		<CustomModal open={!!pendingConfirmation} size="small" onClose={onCancelClose}>
+		<CustomModal open={!!pendingConfirmation} size="small" onClose={onDismiss}>
 			<Container
 				padding={{ all: 'large' }}
 				mainAlignment="center"
 				crossAlignment="flex-start"
 				height="fit"
 			>
-				<ModalHeader title={title} onClose={onCancelClose} />
+				<ModalHeader title={title} onClose={onDismiss} />
 				<Container padding={{ top: 'large', bottom: 'large' }} crossAlignment="flex-start">
 					<Text overflow="break-word">{message}</Text>
 				</Container>
 				<ModalFooter
-					onConfirm={onConfirmClose}
-					label={confirmLabel}
-					secondaryAction={onCancelClose}
-					secondaryLabel={cancelLabel}
+					onConfirm={onSaveAndClose}
+					label={saveAndCloseLabel}
+					secondaryAction={onKeepEditing}
+					secondaryLabel={keepEditingLabel}
 					secondaryBtnType="outlined"
 					secondaryColor="primary"
 					color="primary"
+					loading={isSaving}
+					disabled={isSaving}
 				/>
 			</Container>
 		</CustomModal>

--- a/src/view/modals/editor-close-confirmation-modal.tsx
+++ b/src/view/modals/editor-close-confirmation-modal.tsx
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React, { useCallback, useMemo } from 'react';
+
+import { Container, CustomModal, Text } from '@zextras/carbonio-design-system';
+import { addBoard, t } from '@zextras/carbonio-shell-ui';
+
+import ModalFooter from '../../commons/modal-footer';
+import { ModalHeader } from '../../commons/modal-header';
+import { CALENDAR_BOARD_ID } from '../../constants';
+import { useAppDispatch, useAppSelector } from '../../store/redux/hooks';
+import { selectEditor, selectPendingCloseConfirmation } from '../../store/selectors/editor';
+import { clearPendingCloseConfirmation } from '../../store/slices/editor-slice';
+
+export const EditorCloseConfirmationModal = (): React.JSX.Element => {
+	const pendingConfirmation = useAppSelector(selectPendingCloseConfirmation);
+	const editor = useAppSelector(selectEditor(pendingConfirmation?.editorId ?? ''));
+	const dispatch = useAppDispatch();
+
+	const title = useMemo(() => t('label.close_appointment_editor', 'Close appointment editor'), []);
+
+	const message = useMemo(
+		() =>
+			t(
+				'message.close_appointment_editor_confirmation',
+				'Are you sure you want to close the appointment editor? If you close it without saving, you will lose the unsaved data.'
+			),
+		[]
+	);
+
+	const confirmLabel = useMemo(() => t('label.yes_close', 'Yes, close'), []);
+	const cancelLabel = useMemo(() => t('label.cancel', 'Cancel'), []);
+
+	const onConfirmClose = useCallback(() => {
+		dispatch(clearPendingCloseConfirmation());
+	}, [dispatch]);
+
+	const onCancelClose = useCallback(() => {
+		if (pendingConfirmation && editor) {
+			addBoard({
+				boardViewId: CALENDAR_BOARD_ID,
+				title: pendingConfirmation.boardTitle || editor.title || '',
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore
+				editor
+			});
+		}
+		dispatch(clearPendingCloseConfirmation());
+	}, [dispatch, editor, pendingConfirmation]);
+
+	return (
+		<CustomModal open={!!pendingConfirmation} size="small" onClose={onCancelClose}>
+			<Container
+				padding={{ all: 'large' }}
+				mainAlignment="center"
+				crossAlignment="flex-start"
+				height="fit"
+			>
+				<ModalHeader title={title} onClose={onCancelClose} />
+				<Container padding={{ top: 'large', bottom: 'large' }} crossAlignment="flex-start">
+					<Text overflow="break-word">{message}</Text>
+				</Container>
+				<ModalFooter
+					onConfirm={onConfirmClose}
+					label={confirmLabel}
+					secondaryAction={onCancelClose}
+					secondaryLabel={cancelLabel}
+					secondaryBtnType="outlined"
+					secondaryColor="primary"
+					color="primary"
+				/>
+			</Container>
+		</CustomModal>
+	);
+};

--- a/src/view/modals/editor-close-confirmation-modal.tsx
+++ b/src/view/modals/editor-close-confirmation-modal.tsx
@@ -5,7 +5,7 @@
  */
 import React, { useCallback, useMemo, useState } from 'react';
 
-import { Container, CustomModal, Text, useSnackbar } from '@zextras/carbonio-design-system';
+import { Container, Text, useSnackbar } from '@zextras/carbonio-design-system';
 import { addBoard, t } from '@zextras/carbonio-shell-ui';
 
 import { onSave } from '../../commons/editor-save-send-fns';
@@ -13,12 +13,20 @@ import ModalFooter from '../../commons/modal-footer';
 import { ModalHeader } from '../../commons/modal-header';
 import { CALENDAR_BOARD_ID } from '../../constants';
 import { useAppDispatch, useAppSelector } from '../../store/redux/hooks';
-import { selectEditor, selectPendingCloseConfirmation } from '../../store/selectors/editor';
-import { clearPendingCloseConfirmation } from '../../store/slices/editor-slice';
+import { selectEditor } from '../../store/selectors/editor';
 
-export const EditorCloseConfirmationModal = (): React.JSX.Element => {
-	const pendingConfirmation = useAppSelector(selectPendingCloseConfirmation);
-	const editor = useAppSelector(selectEditor(pendingConfirmation?.editorId ?? ''));
+type EditorCloseConfirmationModalProps = {
+	editorId: string;
+	boardTitle: string;
+	onClose: () => void;
+};
+
+export const EditorCloseConfirmationModal = ({
+	editorId,
+	boardTitle,
+	onClose
+}: EditorCloseConfirmationModalProps): React.JSX.Element => {
+	const editor = useAppSelector(selectEditor(editorId));
 	const dispatch = useAppDispatch();
 	const createSnackbar = useSnackbar();
 	const [isSaving, setIsSaving] = useState(false);
@@ -37,22 +45,18 @@ export const EditorCloseConfirmationModal = (): React.JSX.Element => {
 	const saveAndCloseLabel = useMemo(() => t('label.save_and_close', 'Save and close'), []);
 	const keepEditingLabel = useMemo(() => t('label.keep_editing', 'Keep editing'), []);
 
-	const onDismiss = useCallback(() => {
-		dispatch(clearPendingCloseConfirmation());
-	}, [dispatch]);
-
 	const onKeepEditing = useCallback(() => {
-		if (pendingConfirmation && editor) {
+		if (editor) {
 			addBoard({
 				boardViewId: CALENDAR_BOARD_ID,
-				title: pendingConfirmation.boardTitle || editor.title || '',
+				title: boardTitle || editor.title || '',
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore
 				editor
 			});
 		}
-		dispatch(clearPendingCloseConfirmation());
-	}, [dispatch, editor, pendingConfirmation]);
+		onClose();
+	}, [boardTitle, editor, onClose]);
 
 	const onSaveAndClose = useCallback(() => {
 		if (!editor) return;
@@ -75,35 +79,33 @@ export const EditorCloseConfirmationModal = (): React.JSX.Element => {
 			});
 			setIsSaving(false);
 			if (response) {
-				dispatch(clearPendingCloseConfirmation());
+				onClose();
 			}
 		});
-	}, [createSnackbar, dispatch, editor]);
+	}, [createSnackbar, dispatch, editor, onClose]);
 
 	return (
-		<CustomModal open={!!pendingConfirmation} size="small" onClose={onDismiss}>
-			<Container
-				padding={{ all: 'large' }}
-				mainAlignment="center"
-				crossAlignment="flex-start"
-				height="fit"
-			>
-				<ModalHeader title={title} onClose={onDismiss} />
-				<Container padding={{ top: 'large', bottom: 'large' }} crossAlignment="flex-start">
-					<Text overflow="break-word">{message}</Text>
-				</Container>
-				<ModalFooter
-					onConfirm={onSaveAndClose}
-					label={saveAndCloseLabel}
-					secondaryAction={onKeepEditing}
-					secondaryLabel={keepEditingLabel}
-					secondaryBtnType="outlined"
-					secondaryColor="primary"
-					color="primary"
-					loading={isSaving}
-					disabled={isSaving}
-				/>
+		<Container
+			padding={{ all: 'large' }}
+			mainAlignment="center"
+			crossAlignment="flex-start"
+			height="fit"
+		>
+			<ModalHeader title={title} onClose={onClose} />
+			<Container padding={{ top: 'large', bottom: 'large' }} crossAlignment="flex-start">
+				<Text overflow="break-word">{message}</Text>
 			</Container>
-		</CustomModal>
+			<ModalFooter
+				onConfirm={onSaveAndClose}
+				label={saveAndCloseLabel}
+				secondaryAction={onKeepEditing}
+				secondaryLabel={keepEditingLabel}
+				secondaryBtnType="outlined"
+				secondaryColor="primary"
+				color="primary"
+				loading={isSaving}
+				disabled={isSaving}
+			/>
+		</Container>
 	);
 };

--- a/src/view/modals/tests/editor-close-confirmation-modal.test.tsx
+++ b/src/view/modals/tests/editor-close-confirmation-modal.test.tsx
@@ -16,9 +16,17 @@ import { onSave } from '../../../commons/editor-save-send-fns';
 import { CALENDAR_BOARD_ID } from '../../../constants';
 import { reducers, type RootState } from '../../../store/redux';
 import {
+	editEditorAllDay,
 	editEditorAttendees,
+	editEditorCalendar,
+	editEditorClass,
+	editEditorDisplayStatus,
 	editEditorLocation,
+	editEditorReminder,
+	editEditorText,
+	editEditorTimezone,
 	editEditorTitle,
+	editSender,
 	updateEditor
 } from '../../../store/slices/editor-slice';
 import { defaultEditor } from '../../editor/tests/common';
@@ -144,6 +152,22 @@ describe('EditorCloseConfirmationModal', () => {
 			expect(shell.addBoard).not.toHaveBeenCalled();
 		});
 
+		it('does nothing when editor is not found in store', async () => {
+			const emptyStore = createTestStore();
+			const mockOnClose = vi.fn();
+			const { user } = setupTest(
+				<EditorCloseConfirmationModal
+					editorId="non-existent"
+					boardTitle="Test"
+					onClose={mockOnClose}
+				/>,
+				{ store: emptyStore }
+			);
+			await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
+			expect(onSave).not.toHaveBeenCalled();
+			expect(mockOnClose).not.toHaveBeenCalled();
+		});
+
 		describe('on save success', () => {
 			beforeEach(() => {
 				(onSave as Mock).mockResolvedValue({ response: true });
@@ -170,7 +194,7 @@ describe('EditorCloseConfirmationModal', () => {
 				const { user } = renderModal(store);
 				await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
 				await waitFor(() => {
-					expect(screen.getByRole('button', { name: SAVE_CLOSE_BTN })).not.toBeDisabled();
+					expect(screen.getByRole('button', { name: SAVE_CLOSE_BTN })).toBeEnabled();
 				});
 			});
 		});
@@ -219,6 +243,47 @@ describe('EditorCloseConfirmationModal', () => {
 			expect(shell.addBoard).toHaveBeenCalledWith(
 				expect.objectContaining({ boardViewId: CALENDAR_BOARD_ID })
 			);
+		});
+
+		it('falls back to editor title when boardTitle is empty', async () => {
+			const { user } = renderModal(store, vi.fn(), '');
+			await user.click(screen.getByRole('button', { name: KEEP_EDITING_BTN }));
+			expect(shell.addBoard).toHaveBeenCalledWith(
+				expect.objectContaining({ title: defaultEditor.title })
+			);
+		});
+
+		it('falls back to empty string when boardTitle and editor title are both empty', async () => {
+			const emptyTitleStore = createTestStore();
+			generateEditor({
+				context: { folders: {}, dispatch: emptyTitleStore.dispatch, ...defaultEditor, title: '' }
+			});
+			const { user } = setupTest(
+				<EditorCloseConfirmationModal
+					editorId={defaultEditor.id}
+					boardTitle=""
+					onClose={vi.fn()}
+				/>,
+				{ store: emptyTitleStore }
+			);
+			await user.click(screen.getByRole('button', { name: KEEP_EDITING_BTN }));
+			expect(shell.addBoard).toHaveBeenCalledWith(expect.objectContaining({ title: '' }));
+		});
+
+		it('calls onClose but not addBoard when editor is not found in store', async () => {
+			const emptyStore = createTestStore();
+			const mockOnClose = vi.fn();
+			const { user } = setupTest(
+				<EditorCloseConfirmationModal
+					editorId="non-existent"
+					boardTitle="Test"
+					onClose={mockOnClose}
+				/>,
+				{ store: emptyStore }
+			);
+			await user.click(screen.getByRole('button', { name: KEEP_EDITING_BTN }));
+			expect(shell.addBoard).not.toHaveBeenCalled();
+			expect(mockOnClose).toHaveBeenCalled();
 		});
 	});
 
@@ -315,7 +380,12 @@ describe('EditorCloseConfirmationModal', () => {
 					}
 				];
 				generateEditor({
-					context: { folders: {}, dispatch: store.dispatch, ...defaultEditor, attendees: fullAttendees }
+					context: {
+						folders: {},
+						dispatch: store.dispatch,
+						...defaultEditor,
+						attendees: fullAttendees
+					}
 				});
 
 				// Simulate ContactInput's onChange returning stripped-down attendee objects
@@ -397,6 +467,68 @@ describe('EditorCloseConfirmationModal', () => {
 
 				expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(true);
 			});
+		});
+
+		it('becomes true when allDay is toggled', () => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			generateEditor({ context: { folders: {}, dispatch: store.dispatch, ...defaultEditor } });
+			store.dispatch(editEditorAllDay({ id: defaultEditor.id, allDay: !defaultEditor.allDay }));
+			expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(true);
+		});
+
+		it('becomes true when timezone is changed', () => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			generateEditor({ context: { folders: {}, dispatch: store.dispatch, ...defaultEditor } });
+			store.dispatch(editEditorTimezone({ id: defaultEditor.id, timezone: 'America/New_York' }));
+			expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(true);
+		});
+
+		it('becomes true when reminder is changed', () => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			generateEditor({ context: { folders: {}, dispatch: store.dispatch, ...defaultEditor } });
+			store.dispatch(editEditorReminder({ id: defaultEditor.id, reminder: '10' }));
+			expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(true);
+		});
+
+		it('becomes true when freeBusy status is changed', () => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			generateEditor({ context: { folders: {}, dispatch: store.dispatch, ...defaultEditor } });
+			store.dispatch(editEditorDisplayStatus({ id: defaultEditor.id, freeBusy: 'F' }));
+			expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(true);
+		});
+
+		it('becomes true when calendar is changed', () => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			generateEditor({ context: { folders: {}, dispatch: store.dispatch, ...defaultEditor } });
+			store.dispatch(
+				editEditorCalendar({ id: defaultEditor.id, calendar: { id: '99', name: 'Other' } })
+			);
+			expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(true);
+		});
+
+		it('becomes true when class is changed', () => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			generateEditor({ context: { folders: {}, dispatch: store.dispatch, ...defaultEditor } });
+			store.dispatch(editEditorClass({ id: defaultEditor.id, class: 'PRI' }));
+			expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(true);
+		});
+
+		it('becomes true when rich text is changed', () => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			generateEditor({ context: { folders: {}, dispatch: store.dispatch, ...defaultEditor } });
+			store.dispatch(
+				editEditorText({ id: defaultEditor.id, richText: '<p>new</p>', plainText: 'new' })
+			);
+			expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(true);
+		});
+
+		it('becomes true when sender is changed', () => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			generateEditor({ context: { folders: {}, dispatch: store.dispatch, ...defaultEditor } });
+			store.dispatch(
+				editSender({ id: defaultEditor.id, sender: { email: 'new@test.com', fullName: 'New' } })
+			);
+			expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(true);
 		});
 
 		it('uses the saved state as the new baseline after updateEditor', () => {

--- a/src/view/modals/tests/editor-close-confirmation-modal.test.tsx
+++ b/src/view/modals/tests/editor-close-confirmation-modal.test.tsx
@@ -1,0 +1,234 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { combineReducers, configureStore, type EnhancedStore } from '@reduxjs/toolkit';
+import { screen } from '@testing-library/react';
+import { useTheme } from '@zextras/carbonio-design-system';
+
+import * as shell from '../../../../__mocks__/@zextras/carbonio-shell-ui';
+import { generateEditor } from '../../../commons/editor-generator';
+import { CALENDAR_BOARD_ID } from '../../../constants';
+import { reducers, type RootState } from '../../../store/redux';
+import {
+	editEditorLocation,
+	editEditorTitle,
+	setPendingCloseConfirmation,
+	updateEditor
+} from '../../../store/slices/editor-slice';
+import { defaultEditor } from '../../editor/tests/common';
+import { EditorCloseConfirmationModal } from '../editor-close-confirmation-modal';
+import { setupHook, setupTest } from '@test-setup';
+
+const YES_CLOSE_BTN = 'label.yes_close';
+const CANCEL_BTN = 'label.cancel';
+const CLOSE_ICON = 'icon: CloseOutline';
+const CLEARS_PENDING = 'clears the pending close confirmation from state';
+
+describe('EditorCloseConfirmationModal', () => {
+	describe('when there is no pending close confirmation', () => {
+		it('does not render any modal content', () => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			setupTest(<EditorCloseConfirmationModal />, { store });
+			expect(screen.queryByText('label.close_appointment_editor')).not.toBeInTheDocument();
+		});
+	});
+
+	const createTestStore = (): EnhancedStore<RootState> =>
+		configureStore({ reducer: combineReducers(reducers) });
+
+	describe('when there is a pending close confirmation', () => {
+		let store: EnhancedStore<RootState>;
+
+		beforeEach(() => {
+			store = createTestStore();
+			generateEditor({
+				context: { folders: {}, dispatch: store.dispatch, ...defaultEditor }
+			});
+			store.dispatch(
+				setPendingCloseConfirmation({ editorId: defaultEditor.id, boardTitle: 'Test appointment' })
+			);
+		});
+
+		it('renders the modal title', () => {
+			setupTest(<EditorCloseConfirmationModal />, { store });
+			expect(screen.getByText('label.close_appointment_editor')).toBeInTheDocument();
+		});
+
+		it('renders the confirmation message', () => {
+			setupTest(<EditorCloseConfirmationModal />, { store });
+			expect(screen.getByText('message.close_appointment_editor_confirmation')).toBeInTheDocument();
+		});
+
+		it('renders the "Yes, close" button', () => {
+			setupTest(<EditorCloseConfirmationModal />, { store });
+			expect(screen.getByRole('button', { name: YES_CLOSE_BTN })).toBeInTheDocument();
+		});
+
+		it('renders the "Cancel" button', () => {
+			setupTest(<EditorCloseConfirmationModal />, { store });
+			expect(screen.getByRole('button', { name: CANCEL_BTN })).toBeInTheDocument();
+		});
+
+		it('renders the close icon button in the header', () => {
+			setupTest(<EditorCloseConfirmationModal />, { store });
+			expect(screen.getByTestId(CLOSE_ICON)).toBeInTheDocument();
+		});
+
+		describe('"Yes, close" button styling', () => {
+			it('has primary background color', () => {
+				setupTest(<EditorCloseConfirmationModal />, { store });
+				const { result } = setupHook(useTheme);
+				expect(screen.getByRole('button', { name: YES_CLOSE_BTN })).toHaveStyle(
+					`background-color: ${result.current.palette.primary.regular}`
+				);
+			});
+
+			it('has white (gray6) label color', () => {
+				setupTest(<EditorCloseConfirmationModal />, { store });
+				const { result } = setupHook(useTheme);
+				expect(screen.getByRole('button', { name: YES_CLOSE_BTN })).toHaveStyle(
+					`color: ${result.current.palette.gray6.regular}`
+				);
+			});
+		});
+
+		describe('"Cancel" button styling', () => {
+			it('has primary label color', () => {
+				setupTest(<EditorCloseConfirmationModal />, { store });
+				const { result } = setupHook(useTheme);
+				expect(screen.getByRole('button', { name: CANCEL_BTN })).toHaveStyle(
+					`color: ${result.current.palette.primary.regular}`
+				);
+			});
+		});
+
+		describe('clicking "Yes, close"', () => {
+			it(CLEARS_PENDING, async () => {
+				const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
+				await user.click(screen.getByRole('button', { name: YES_CLOSE_BTN }));
+				expect(store.getState().editor.pendingCloseConfirmation).toBeNull();
+			});
+
+			it('does not call addBoard', async () => {
+				const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
+				await user.click(screen.getByRole('button', { name: YES_CLOSE_BTN }));
+				expect(shell.addBoard).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('clicking "Cancel"', () => {
+			it(CLEARS_PENDING, async () => {
+				const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
+				await user.click(screen.getByRole('button', { name: CANCEL_BTN }));
+				expect(store.getState().editor.pendingCloseConfirmation).toBeNull();
+			});
+
+			it('calls addBoard to reopen the board', async () => {
+				const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
+				await user.click(screen.getByRole('button', { name: CANCEL_BTN }));
+				expect(shell.addBoard).toHaveBeenCalledWith(
+					expect.objectContaining({ boardViewId: CALENDAR_BOARD_ID })
+				);
+			});
+		});
+
+		describe('clicking the close icon (X) in header', () => {
+			it(CLEARS_PENDING, async () => {
+				const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
+				await user.click(screen.getByTestId(CLOSE_ICON));
+				expect(store.getState().editor.pendingCloseConfirmation).toBeNull();
+			});
+
+			it('calls addBoard to reopen the board', async () => {
+				const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
+				await user.click(screen.getByTestId(CLOSE_ICON));
+				expect(shell.addBoard).toHaveBeenCalledWith(
+					expect.objectContaining({ boardViewId: CALENDAR_BOARD_ID })
+				);
+			});
+		});
+	});
+
+	describe('isDirty tracking', () => {
+		it('starts as false when editor is created', () => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			generateEditor({
+				context: { folders: {}, dispatch: store.dispatch, ...defaultEditor }
+			});
+			expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(false);
+		});
+
+		it('becomes true when a field is edited', () => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			generateEditor({
+				context: { folders: {}, dispatch: store.dispatch, ...defaultEditor }
+			});
+			store.dispatch(editEditorTitle({ id: defaultEditor.id, title: 'New title' }));
+			expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(true);
+		});
+
+		it('resets to false when the only changed field is reverted to its original value', () => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			generateEditor({
+				context: { folders: {}, dispatch: store.dispatch, ...defaultEditor }
+			});
+			store.dispatch(editEditorTitle({ id: defaultEditor.id, title: 'New title' }));
+			expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(true);
+
+			store.dispatch(editEditorTitle({ id: defaultEditor.id, title: defaultEditor.title ?? '' }));
+			expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(false);
+		});
+
+		it('stays true when one field is reverted but another still differs', () => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			generateEditor({
+				context: { folders: {}, dispatch: store.dispatch, ...defaultEditor }
+			});
+			store.dispatch(editEditorTitle({ id: defaultEditor.id, title: 'New title' }));
+			store.dispatch(editEditorLocation({ id: defaultEditor.id, location: 'Rome' }));
+
+			store.dispatch(editEditorTitle({ id: defaultEditor.id, title: defaultEditor.title ?? '' }));
+			expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(true);
+		});
+
+		it('resets to false only when all changed fields are reverted', () => {
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			generateEditor({
+				context: { folders: {}, dispatch: store.dispatch, ...defaultEditor }
+			});
+			store.dispatch(editEditorTitle({ id: defaultEditor.id, title: 'New title' }));
+			store.dispatch(editEditorLocation({ id: defaultEditor.id, location: 'Rome' }));
+
+			store.dispatch(editEditorTitle({ id: defaultEditor.id, title: defaultEditor.title ?? '' }));
+			store.dispatch(
+				editEditorLocation({ id: defaultEditor.id, location: defaultEditor.location })
+			);
+			expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(false);
+		});
+
+		it('uses the saved state as the new baseline after updateEditor', () => {
+			const savedTitle = 'Saved title';
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			const editor = generateEditor({
+				context: { folders: {}, dispatch: store.dispatch, ...defaultEditor }
+			});
+			store.dispatch(editEditorTitle({ id: defaultEditor.id, title: savedTitle }));
+			store.dispatch(
+				updateEditor({ id: defaultEditor.id, editor: { ...editor, title: savedTitle } })
+			);
+			expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(false);
+
+			// Reverting to the pre-save title should now be treated as a change
+			store.dispatch(editEditorTitle({ id: defaultEditor.id, title: defaultEditor.title ?? '' }));
+			expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(true);
+
+			// Going back to the saved title clears isDirty
+			store.dispatch(editEditorTitle({ id: defaultEditor.id, title: savedTitle }));
+			expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(false);
+		});
+	});
+});

--- a/src/view/modals/tests/editor-close-confirmation-modal.test.tsx
+++ b/src/view/modals/tests/editor-close-confirmation-modal.test.tsx
@@ -6,14 +6,17 @@
 import React from 'react';
 
 import { combineReducers, configureStore, type EnhancedStore } from '@reduxjs/toolkit';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { useTheme } from '@zextras/carbonio-design-system';
+import type { Mock } from 'vitest';
 
 import * as shell from '../../../../__mocks__/@zextras/carbonio-shell-ui';
 import { generateEditor } from '../../../commons/editor-generator';
+import { onSave } from '../../../commons/editor-save-send-fns';
 import { CALENDAR_BOARD_ID } from '../../../constants';
 import { reducers, type RootState } from '../../../store/redux';
 import {
+	editEditorAttendees,
 	editEditorLocation,
 	editEditorTitle,
 	setPendingCloseConfirmation,
@@ -23,8 +26,10 @@ import { defaultEditor } from '../../editor/tests/common';
 import { EditorCloseConfirmationModal } from '../editor-close-confirmation-modal';
 import { setupHook, setupTest } from '@test-setup';
 
-const YES_CLOSE_BTN = 'label.yes_close';
-const CANCEL_BTN = 'label.cancel';
+vi.mock('../../../commons/editor-save-send-fns', () => ({ onSave: vi.fn() }));
+
+const SAVE_CLOSE_BTN = 'label.save_and_close';
+const KEEP_EDITING_BTN = 'label.keep_editing';
 const CLOSE_ICON = 'icon: CloseOutline';
 const CLEARS_PENDING = 'clears the pending close confirmation from state';
 
@@ -51,6 +56,7 @@ describe('EditorCloseConfirmationModal', () => {
 			store.dispatch(
 				setPendingCloseConfirmation({ editorId: defaultEditor.id, boardTitle: 'Test appointment' })
 			);
+			(onSave as Mock).mockResolvedValue({ response: true });
 		});
 
 		it('renders the modal title', () => {
@@ -63,14 +69,14 @@ describe('EditorCloseConfirmationModal', () => {
 			expect(screen.getByText('message.close_appointment_editor_confirmation')).toBeInTheDocument();
 		});
 
-		it('renders the "Yes, close" button', () => {
+		it('renders the "Save & close" button', () => {
 			setupTest(<EditorCloseConfirmationModal />, { store });
-			expect(screen.getByRole('button', { name: YES_CLOSE_BTN })).toBeInTheDocument();
+			expect(screen.getByRole('button', { name: SAVE_CLOSE_BTN })).toBeInTheDocument();
 		});
 
-		it('renders the "Cancel" button', () => {
+		it('renders the "Keep editing" button', () => {
 			setupTest(<EditorCloseConfirmationModal />, { store });
-			expect(screen.getByRole('button', { name: CANCEL_BTN })).toBeInTheDocument();
+			expect(screen.getByRole('button', { name: KEEP_EDITING_BTN })).toBeInTheDocument();
 		});
 
 		it('renders the close icon button in the header', () => {
@@ -78,11 +84,11 @@ describe('EditorCloseConfirmationModal', () => {
 			expect(screen.getByTestId(CLOSE_ICON)).toBeInTheDocument();
 		});
 
-		describe('"Yes, close" button styling', () => {
+		describe('"Save & close" button styling', () => {
 			it('has primary background color', () => {
 				setupTest(<EditorCloseConfirmationModal />, { store });
 				const { result } = setupHook(useTheme);
-				expect(screen.getByRole('button', { name: YES_CLOSE_BTN })).toHaveStyle(
+				expect(screen.getByRole('button', { name: SAVE_CLOSE_BTN })).toHaveStyle(
 					`background-color: ${result.current.palette.primary.regular}`
 				);
 			});
@@ -90,46 +96,110 @@ describe('EditorCloseConfirmationModal', () => {
 			it('has white (gray6) label color', () => {
 				setupTest(<EditorCloseConfirmationModal />, { store });
 				const { result } = setupHook(useTheme);
-				expect(screen.getByRole('button', { name: YES_CLOSE_BTN })).toHaveStyle(
+				expect(screen.getByRole('button', { name: SAVE_CLOSE_BTN })).toHaveStyle(
 					`color: ${result.current.palette.gray6.regular}`
 				);
 			});
 		});
 
-		describe('"Cancel" button styling', () => {
+		describe('"Keep editing" button styling', () => {
 			it('has primary label color', () => {
 				setupTest(<EditorCloseConfirmationModal />, { store });
 				const { result } = setupHook(useTheme);
-				expect(screen.getByRole('button', { name: CANCEL_BTN })).toHaveStyle(
+				expect(screen.getByRole('button', { name: KEEP_EDITING_BTN })).toHaveStyle(
 					`color: ${result.current.palette.primary.regular}`
 				);
 			});
 		});
 
-		describe('clicking "Yes, close"', () => {
-			it(CLEARS_PENDING, async () => {
+		describe('clicking "Save & close"', () => {
+			it('calls onSave with the editor', async () => {
 				const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
-				await user.click(screen.getByRole('button', { name: YES_CLOSE_BTN }));
-				expect(store.getState().editor.pendingCloseConfirmation).toBeNull();
+				await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
+				await waitFor(() => {
+					expect(onSave).toHaveBeenCalledWith(
+						expect.objectContaining({
+							editor: expect.objectContaining({ id: defaultEditor.id })
+						})
+					);
+				});
 			});
 
 			it('does not call addBoard', async () => {
 				const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
-				await user.click(screen.getByRole('button', { name: YES_CLOSE_BTN }));
+				await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
+				await waitFor(() => expect(onSave).toHaveBeenCalled());
 				expect(shell.addBoard).not.toHaveBeenCalled();
+			});
+
+			describe('on save success', () => {
+				beforeEach(() => {
+					(onSave as Mock).mockResolvedValue({ response: true });
+				});
+
+				it(CLEARS_PENDING, async () => {
+					const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
+					await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
+					await waitFor(() => {
+						expect(store.getState().editor.pendingCloseConfirmation).toBeNull();
+					});
+				});
+
+				it('shows success snackbar', async () => {
+					const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
+					await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
+					expect(
+						await screen.findByText('message.snackbar.calendar_edits_saved')
+					).toBeInTheDocument();
+				});
+
+				it('button is not in loading state when modal reopens after a successful save', async () => {
+					const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
+					await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
+					await waitFor(() => {
+						expect(store.getState().editor.pendingCloseConfirmation).toBeNull();
+					});
+
+					// Simulate the modal being triggered again
+					store.dispatch(
+						setPendingCloseConfirmation({ editorId: defaultEditor.id, boardTitle: 'Test appointment' })
+					);
+					await waitFor(() => {
+						expect(screen.getByRole('button', { name: SAVE_CLOSE_BTN })).not.toBeDisabled();
+					});
+				});
+			});
+
+			describe('on save failure', () => {
+				beforeEach(() => {
+					(onSave as Mock).mockResolvedValue({ response: null });
+				});
+
+				it('keeps the modal open', async () => {
+					const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
+					await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
+					await waitFor(() => expect(onSave).toHaveBeenCalled());
+					expect(store.getState().editor.pendingCloseConfirmation).not.toBeNull();
+				});
+
+				it('shows error snackbar', async () => {
+					const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
+					await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
+					expect(await screen.findByText('label.error_try_again')).toBeInTheDocument();
+				});
 			});
 		});
 
-		describe('clicking "Cancel"', () => {
+		describe('clicking "Keep editing"', () => {
 			it(CLEARS_PENDING, async () => {
 				const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
-				await user.click(screen.getByRole('button', { name: CANCEL_BTN }));
+				await user.click(screen.getByRole('button', { name: KEEP_EDITING_BTN }));
 				expect(store.getState().editor.pendingCloseConfirmation).toBeNull();
 			});
 
 			it('calls addBoard to reopen the board', async () => {
 				const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
-				await user.click(screen.getByRole('button', { name: CANCEL_BTN }));
+				await user.click(screen.getByRole('button', { name: KEEP_EDITING_BTN }));
 				expect(shell.addBoard).toHaveBeenCalledWith(
 					expect.objectContaining({ boardViewId: CALENDAR_BOARD_ID })
 				);
@@ -143,12 +213,10 @@ describe('EditorCloseConfirmationModal', () => {
 				expect(store.getState().editor.pendingCloseConfirmation).toBeNull();
 			});
 
-			it('calls addBoard to reopen the board', async () => {
+			it('does not call addBoard', async () => {
 				const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
 				await user.click(screen.getByTestId(CLOSE_ICON));
-				expect(shell.addBoard).toHaveBeenCalledWith(
-					expect.objectContaining({ boardViewId: CALENDAR_BOARD_ID })
-				);
+				expect(shell.addBoard).not.toHaveBeenCalled();
 			});
 		});
 	});
@@ -208,6 +276,102 @@ describe('EditorCloseConfirmationModal', () => {
 				editEditorLocation({ id: defaultEditor.id, location: defaultEditor.location ?? '' })
 			);
 			expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(false);
+		});
+
+		describe('attendees comparison', () => {
+			it('is not dirty when attendees are dispatched with same emails but different object shape', () => {
+				const store = configureStore({ reducer: combineReducers(reducers) });
+				const fullAttendees = [
+					{
+						email: 'alice@example.com',
+						fullName: 'Alice Smith',
+						label: 'Alice Smith',
+						ptst: 'AC' as const
+					}
+				];
+				generateEditor({
+					context: { folders: {}, dispatch: store.dispatch, ...defaultEditor, attendees: fullAttendees }
+				});
+
+				// Simulate ContactInput's onChange returning stripped-down attendee objects
+				store.dispatch(
+					editEditorAttendees({
+						id: defaultEditor.id,
+						attendees: [{ email: 'alice@example.com', label: 'Alice Smith' }]
+					})
+				);
+
+				expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(false);
+			});
+
+			it('is not dirty when attendees are dispatched with same emails but different casing', () => {
+				const store = configureStore({ reducer: combineReducers(reducers) });
+				generateEditor({
+					context: {
+						folders: {},
+						dispatch: store.dispatch,
+						...defaultEditor,
+						attendees: [{ email: 'Alice@Example.com', label: 'Alice Smith' }]
+					}
+				});
+
+				store.dispatch(
+					editEditorAttendees({
+						id: defaultEditor.id,
+						attendees: [{ email: 'alice@example.com', label: 'Alice Smith' }]
+					})
+				);
+
+				expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(false);
+			});
+
+			it('is dirty when an attendee is added', () => {
+				const store = configureStore({ reducer: combineReducers(reducers) });
+				generateEditor({
+					context: {
+						folders: {},
+						dispatch: store.dispatch,
+						...defaultEditor,
+						attendees: [{ email: 'alice@example.com', label: 'Alice' }]
+					}
+				});
+
+				store.dispatch(
+					editEditorAttendees({
+						id: defaultEditor.id,
+						attendees: [
+							{ email: 'alice@example.com', label: 'Alice' },
+							{ email: 'bob@example.com', label: 'Bob' }
+						]
+					})
+				);
+
+				expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(true);
+			});
+
+			it('is dirty when an attendee is removed', () => {
+				const store = configureStore({ reducer: combineReducers(reducers) });
+				generateEditor({
+					context: {
+						folders: {},
+						dispatch: store.dispatch,
+						...defaultEditor,
+						attendees: [
+							{ email: 'alice@example.com', label: 'Alice' },
+							{ email: 'bob@example.com', label: 'Bob' }
+						]
+					}
+				});
+
+				store.dispatch(
+					editEditorAttendees({
+						id: defaultEditor.id,
+						attendees: [{ email: 'alice@example.com', label: 'Alice' }]
+					})
+				);
+
+				expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(true);
+			});
 		});
 
 		it('uses the saved state as the new baseline after updateEditor', () => {

--- a/src/view/modals/tests/editor-close-confirmation-modal.test.tsx
+++ b/src/view/modals/tests/editor-close-confirmation-modal.test.tsx
@@ -205,7 +205,7 @@ describe('EditorCloseConfirmationModal', () => {
 
 			store.dispatch(editEditorTitle({ id: defaultEditor.id, title: defaultEditor.title ?? '' }));
 			store.dispatch(
-				editEditorLocation({ id: defaultEditor.id, location: defaultEditor.location })
+				editEditorLocation({ id: defaultEditor.id, location: defaultEditor.location ?? '' })
 			);
 			expect(store.getState().editor.editors[defaultEditor.id]?.isDirty).toBe(false);
 		});

--- a/src/view/modals/tests/editor-close-confirmation-modal.test.tsx
+++ b/src/view/modals/tests/editor-close-confirmation-modal.test.tsx
@@ -19,7 +19,6 @@ import {
 	editEditorAttendees,
 	editEditorLocation,
 	editEditorTitle,
-	setPendingCloseConfirmation,
 	updateEditor
 } from '../../../store/slices/editor-slice';
 import { defaultEditor } from '../../editor/tests/common';
@@ -31,21 +30,26 @@ vi.mock('../../../commons/editor-save-send-fns', () => ({ onSave: vi.fn() }));
 const SAVE_CLOSE_BTN = 'label.save_and_close';
 const KEEP_EDITING_BTN = 'label.keep_editing';
 const CLOSE_ICON = 'icon: CloseOutline';
-const CLEARS_PENDING = 'clears the pending close confirmation from state';
 
 describe('EditorCloseConfirmationModal', () => {
-	describe('when there is no pending close confirmation', () => {
-		it('does not render any modal content', () => {
-			const store = configureStore({ reducer: combineReducers(reducers) });
-			setupTest(<EditorCloseConfirmationModal />, { store });
-			expect(screen.queryByText('label.close_appointment_editor')).not.toBeInTheDocument();
-		});
-	});
-
 	const createTestStore = (): EnhancedStore<RootState> =>
 		configureStore({ reducer: combineReducers(reducers) });
 
-	describe('when there is a pending close confirmation', () => {
+	const renderModal = (
+		store: EnhancedStore<RootState>,
+		onClose = vi.fn(),
+		boardTitle = 'Test appointment'
+	): ReturnType<typeof setupTest> =>
+		setupTest(
+			<EditorCloseConfirmationModal
+				editorId={defaultEditor.id}
+				boardTitle={boardTitle}
+				onClose={onClose}
+			/>,
+			{ store }
+		);
+
+	describe('rendering', () => {
 		let store: EnhancedStore<RootState>;
 
 		beforeEach(() => {
@@ -53,40 +57,37 @@ describe('EditorCloseConfirmationModal', () => {
 			generateEditor({
 				context: { folders: {}, dispatch: store.dispatch, ...defaultEditor }
 			});
-			store.dispatch(
-				setPendingCloseConfirmation({ editorId: defaultEditor.id, boardTitle: 'Test appointment' })
-			);
 			(onSave as Mock).mockResolvedValue({ response: true });
 		});
 
 		it('renders the modal title', () => {
-			setupTest(<EditorCloseConfirmationModal />, { store });
+			renderModal(store);
 			expect(screen.getByText('label.close_appointment_editor')).toBeInTheDocument();
 		});
 
 		it('renders the confirmation message', () => {
-			setupTest(<EditorCloseConfirmationModal />, { store });
+			renderModal(store);
 			expect(screen.getByText('message.close_appointment_editor_confirmation')).toBeInTheDocument();
 		});
 
 		it('renders the "Save & close" button', () => {
-			setupTest(<EditorCloseConfirmationModal />, { store });
+			renderModal(store);
 			expect(screen.getByRole('button', { name: SAVE_CLOSE_BTN })).toBeInTheDocument();
 		});
 
 		it('renders the "Keep editing" button', () => {
-			setupTest(<EditorCloseConfirmationModal />, { store });
+			renderModal(store);
 			expect(screen.getByRole('button', { name: KEEP_EDITING_BTN })).toBeInTheDocument();
 		});
 
 		it('renders the close icon button in the header', () => {
-			setupTest(<EditorCloseConfirmationModal />, { store });
+			renderModal(store);
 			expect(screen.getByTestId(CLOSE_ICON)).toBeInTheDocument();
 		});
 
 		describe('"Save & close" button styling', () => {
 			it('has primary background color', () => {
-				setupTest(<EditorCloseConfirmationModal />, { store });
+				renderModal(store);
 				const { result } = setupHook(useTheme);
 				expect(screen.getByRole('button', { name: SAVE_CLOSE_BTN })).toHaveStyle(
 					`background-color: ${result.current.palette.primary.regular}`
@@ -94,7 +95,7 @@ describe('EditorCloseConfirmationModal', () => {
 			});
 
 			it('has white (gray6) label color', () => {
-				setupTest(<EditorCloseConfirmationModal />, { store });
+				renderModal(store);
 				const { result } = setupHook(useTheme);
 				expect(screen.getByRole('button', { name: SAVE_CLOSE_BTN })).toHaveStyle(
 					`color: ${result.current.palette.gray6.regular}`
@@ -104,120 +105,144 @@ describe('EditorCloseConfirmationModal', () => {
 
 		describe('"Keep editing" button styling', () => {
 			it('has primary label color', () => {
-				setupTest(<EditorCloseConfirmationModal />, { store });
+				renderModal(store);
 				const { result } = setupHook(useTheme);
 				expect(screen.getByRole('button', { name: KEEP_EDITING_BTN })).toHaveStyle(
 					`color: ${result.current.palette.primary.regular}`
 				);
 			});
 		});
+	});
 
-		describe('clicking "Save & close"', () => {
-			it('calls onSave with the editor', async () => {
-				const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
-				await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
-				await waitFor(() => {
-					expect(onSave).toHaveBeenCalledWith(
-						expect.objectContaining({
-							editor: expect.objectContaining({ id: defaultEditor.id })
-						})
-					);
-				});
+	describe('clicking "Save & close"', () => {
+		let store: EnhancedStore<RootState>;
+
+		beforeEach(() => {
+			store = createTestStore();
+			generateEditor({
+				context: { folders: {}, dispatch: store.dispatch, ...defaultEditor }
 			});
-
-			it('does not call addBoard', async () => {
-				const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
-				await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
-				await waitFor(() => expect(onSave).toHaveBeenCalled());
-				expect(shell.addBoard).not.toHaveBeenCalled();
-			});
-
-			describe('on save success', () => {
-				beforeEach(() => {
-					(onSave as Mock).mockResolvedValue({ response: true });
-				});
-
-				it(CLEARS_PENDING, async () => {
-					const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
-					await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
-					await waitFor(() => {
-						expect(store.getState().editor.pendingCloseConfirmation).toBeNull();
-					});
-				});
-
-				it('shows success snackbar', async () => {
-					const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
-					await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
-					expect(
-						await screen.findByText('message.snackbar.calendar_edits_saved')
-					).toBeInTheDocument();
-				});
-
-				it('button is not in loading state when modal reopens after a successful save', async () => {
-					const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
-					await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
-					await waitFor(() => {
-						expect(store.getState().editor.pendingCloseConfirmation).toBeNull();
-					});
-
-					// Simulate the modal being triggered again
-					store.dispatch(
-						setPendingCloseConfirmation({ editorId: defaultEditor.id, boardTitle: 'Test appointment' })
-					);
-					await waitFor(() => {
-						expect(screen.getByRole('button', { name: SAVE_CLOSE_BTN })).not.toBeDisabled();
-					});
-				});
-			});
-
-			describe('on save failure', () => {
-				beforeEach(() => {
-					(onSave as Mock).mockResolvedValue({ response: null });
-				});
-
-				it('keeps the modal open', async () => {
-					const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
-					await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
-					await waitFor(() => expect(onSave).toHaveBeenCalled());
-					expect(store.getState().editor.pendingCloseConfirmation).not.toBeNull();
-				});
-
-				it('shows error snackbar', async () => {
-					const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
-					await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
-					expect(await screen.findByText('label.error_try_again')).toBeInTheDocument();
-				});
-			});
+			(onSave as Mock).mockResolvedValue({ response: true });
 		});
 
-		describe('clicking "Keep editing"', () => {
-			it(CLEARS_PENDING, async () => {
-				const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
-				await user.click(screen.getByRole('button', { name: KEEP_EDITING_BTN }));
-				expect(store.getState().editor.pendingCloseConfirmation).toBeNull();
-			});
-
-			it('calls addBoard to reopen the board', async () => {
-				const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
-				await user.click(screen.getByRole('button', { name: KEEP_EDITING_BTN }));
-				expect(shell.addBoard).toHaveBeenCalledWith(
-					expect.objectContaining({ boardViewId: CALENDAR_BOARD_ID })
+		it('calls onSave with the editor', async () => {
+			const { user } = renderModal(store);
+			await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
+			await waitFor(() => {
+				expect(onSave).toHaveBeenCalledWith(
+					expect.objectContaining({
+						editor: expect.objectContaining({ id: defaultEditor.id })
+					})
 				);
 			});
 		});
 
-		describe('clicking the close icon (X) in header', () => {
-			it(CLEARS_PENDING, async () => {
-				const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
-				await user.click(screen.getByTestId(CLOSE_ICON));
-				expect(store.getState().editor.pendingCloseConfirmation).toBeNull();
+		it('does not call addBoard', async () => {
+			const { user } = renderModal(store);
+			await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
+			await waitFor(() => expect(onSave).toHaveBeenCalled());
+			expect(shell.addBoard).not.toHaveBeenCalled();
+		});
+
+		describe('on save success', () => {
+			beforeEach(() => {
+				(onSave as Mock).mockResolvedValue({ response: true });
 			});
 
-			it('does not call addBoard', async () => {
-				const { user } = setupTest(<EditorCloseConfirmationModal />, { store });
-				await user.click(screen.getByTestId(CLOSE_ICON));
-				expect(shell.addBoard).not.toHaveBeenCalled();
+			it('calls onClose', async () => {
+				const mockOnClose = vi.fn();
+				const { user } = renderModal(store, mockOnClose);
+				await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
+				await waitFor(() => {
+					expect(mockOnClose).toHaveBeenCalled();
+				});
 			});
+
+			it('shows success snackbar', async () => {
+				const { user } = renderModal(store);
+				await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
+				expect(
+					await screen.findByText('message.snackbar.calendar_edits_saved')
+				).toBeInTheDocument();
+			});
+
+			it('button is not in loading state after a successful save', async () => {
+				const { user } = renderModal(store);
+				await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
+				await waitFor(() => {
+					expect(screen.getByRole('button', { name: SAVE_CLOSE_BTN })).not.toBeDisabled();
+				});
+			});
+		});
+
+		describe('on save failure', () => {
+			beforeEach(() => {
+				(onSave as Mock).mockResolvedValue({ response: null });
+			});
+
+			it('does not call onClose', async () => {
+				const mockOnClose = vi.fn();
+				const { user } = renderModal(store, mockOnClose);
+				await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
+				await waitFor(() => expect(onSave).toHaveBeenCalled());
+				expect(mockOnClose).not.toHaveBeenCalled();
+			});
+
+			it('shows error snackbar', async () => {
+				const { user } = renderModal(store);
+				await user.click(screen.getByRole('button', { name: SAVE_CLOSE_BTN }));
+				expect(await screen.findByText('label.error_try_again')).toBeInTheDocument();
+			});
+		});
+	});
+
+	describe('clicking "Keep editing"', () => {
+		let store: EnhancedStore<RootState>;
+
+		beforeEach(() => {
+			store = createTestStore();
+			generateEditor({
+				context: { folders: {}, dispatch: store.dispatch, ...defaultEditor }
+			});
+		});
+
+		it('calls onClose', async () => {
+			const mockOnClose = vi.fn();
+			const { user } = renderModal(store, mockOnClose);
+			await user.click(screen.getByRole('button', { name: KEEP_EDITING_BTN }));
+			expect(mockOnClose).toHaveBeenCalled();
+		});
+
+		it('calls addBoard to reopen the board', async () => {
+			const { user } = renderModal(store);
+			await user.click(screen.getByRole('button', { name: KEEP_EDITING_BTN }));
+			expect(shell.addBoard).toHaveBeenCalledWith(
+				expect.objectContaining({ boardViewId: CALENDAR_BOARD_ID })
+			);
+		});
+	});
+
+	describe('clicking the close icon (X) in header', () => {
+		let store: EnhancedStore<RootState>;
+
+		beforeEach(() => {
+			store = createTestStore();
+			generateEditor({
+				context: { folders: {}, dispatch: store.dispatch, ...defaultEditor }
+			});
+		});
+
+		it('calls onClose', async () => {
+			const mockOnClose = vi.fn();
+			const { user } = renderModal(store, mockOnClose);
+			await user.click(screen.getByTestId(CLOSE_ICON));
+			expect(mockOnClose).toHaveBeenCalled();
+		});
+
+		it('does not call addBoard', async () => {
+			const { user } = renderModal(store);
+			await user.click(screen.getByTestId(CLOSE_ICON));
+			expect(shell.addBoard).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/view/tests/global-modal-manager-uninitialized.test.tsx
+++ b/src/view/tests/global-modal-manager-uninitialized.test.tsx
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { useGlobalModal } from '../global-modal-manager';
+
+// This file intentionally never renders GlobalModalManager, so globalModalObj
+// stays in its initial uninitialized state and the guard throws are exercised.
+describe('GlobalModalManager — before initialization', () => {
+	it('createModal throws when called before any GlobalModalManager is mounted', () => {
+		const { createModal } = useGlobalModal();
+		expect(() => createModal({ id: 'x', children: <span /> }, true)).toThrow(
+			'global modal manager not initialized'
+		);
+	});
+
+	it('closeModal throws when called before any GlobalModalManager is mounted', () => {
+		const { closeModal } = useGlobalModal();
+		expect(() => closeModal('x')).toThrow('global modal manager not initialized');
+	});
+});

--- a/src/view/tests/global-modal-manager.test.tsx
+++ b/src/view/tests/global-modal-manager.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { GlobalModalManager, useGlobalModal } from '../global-modal-manager';
+import { setupTest } from '@test-setup';
+
+describe('GlobalModalManager', () => {
+	it('renders children', () => {
+		setupTest(
+			<GlobalModalManager>
+				<span>child content</span>
+			</GlobalModalManager>
+		);
+		expect(screen.getByText('child content')).toBeInTheDocument();
+	});
+
+	it('populates createModal and closeModal after mounting', () => {
+		setupTest(
+			<GlobalModalManager>
+				<span />
+			</GlobalModalManager>
+		);
+		const { createModal, closeModal } = useGlobalModal();
+		expect(createModal).toBeInstanceOf(Function);
+		expect(closeModal).toBeInstanceOf(Function);
+	});
+
+	it('createModal does not throw after mounting', () => {
+		setupTest(
+			<GlobalModalManager>
+				<span />
+			</GlobalModalManager>
+		);
+		const { createModal } = useGlobalModal();
+		expect(() =>
+			createModal({ id: 'test-modal', children: <span>modal</span> }, true)
+		).not.toThrow();
+	});
+
+	it('closeModal does not throw after mounting', () => {
+		setupTest(
+			<GlobalModalManager>
+				<span />
+			</GlobalModalManager>
+		);
+		const { closeModal } = useGlobalModal();
+		expect(() => closeModal('test-modal')).not.toThrow();
+	});
+});


### PR DESCRIPTION
Show a confirmation dialog when the user tries to close the appointment editor board with unsaved modifications. Tracks isDirty per-editor and resets it automatically when all changes are reverted to the original values; the baseline is also refreshed after a successful save.