### PR TITLE
feat: add input focus management and required field indicators in modals

### DIFF
--- a/src/actions/calendar-actions-fn.tsx
+++ b/src/actions/calendar-actions-fn.tsx
@@ -89,6 +89,7 @@ export const createGroup =
 			{
 				id: modalId,
 				maxHeight: '90vh',
+				focusModalContent: false,
 				children: (
 					<StoreProvider>
 						<CreateGroupModal onClose={(): void => closeModal(modalId)} />
@@ -191,6 +192,7 @@ export const addIcsFromUrl =
 		createModal(
 			{
 				id: modalId,
+				focusModalContent: false,
 				children: (
 					<StoreProvider>
 						<AddExternalCalendarModal onClose={(): void => closeModal(modalId)} />
@@ -244,6 +246,7 @@ export const editCalendar =
 				children: <StoreProvider>{modalContent}</StoreProvider>,
 				maxHeight: '90vh',
 				size: 'medium',
+				focusModalContent: false,
 				onClose: () => {
 					closeModal(modalId);
 				}
@@ -535,6 +538,7 @@ export const shareCalendar =
 					</StoreProvider>
 				),
 				maxHeight: '70vh',
+				focusModalContent: false,
 				onClose: () => {
 					closeModal(modalId);
 				}

--- a/src/actions/calendar-actions-fn.tsx
+++ b/src/actions/calendar-actions-fn.tsx
@@ -59,6 +59,7 @@ export const newCalendar =
 		createModal(
 			{
 				id: modalId,
+				focusModalContent: false,
 				children: (
 					<StoreProvider>
 						<NewModal onClose={(): void => closeModal(modalId)} folderId={item.id} />
@@ -566,6 +567,7 @@ export const findShares =
 				createModal(
 					{
 						id: modalId,
+						focusModalContent: false,
 						children: (
 							<StoreProvider>
 								<SharesModal calendars={resCalendars} onClose={(): void => closeModal(modalId)} />

--- a/src/actions/modals/add-external-calendar-modal-ics-flow.tsx
+++ b/src/actions/modals/add-external-calendar-modal-ics-flow.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React from 'react';
+import React, { RefObject } from 'react';
 
 import { Input, Padding, Select } from '@zextras/carbonio-design-system';
 import { useTranslation } from 'react-i18next';
@@ -23,6 +23,7 @@ type AddExternalCalendarModalIcsFlowProps = {
 	onCalendarUrlChange: (value: string) => void;
 	onCalendarNameChange: (value: string) => void;
 	onSelectedColorChange: (value: string) => void;
+	calendarUrlInputRef?: RefObject<HTMLInputElement>;
 };
 
 export const AddExternalCalendarModalIcsFlow = ({
@@ -37,7 +38,8 @@ export const AddExternalCalendarModalIcsFlow = ({
 	colorItems,
 	onCalendarUrlChange,
 	onCalendarNameChange,
-	onSelectedColorChange
+	onSelectedColorChange,
+	calendarUrlInputRef
 }: AddExternalCalendarModalIcsFlowProps): JSX.Element => {
 	const [t] = useTranslation();
 
@@ -57,6 +59,7 @@ export const AddExternalCalendarModalIcsFlow = ({
 				value={calendarUrl}
 				disabled={isSubmitting}
 				onChange={(event): void => onCalendarUrlChange(event.target.value)}
+				inputRef={calendarUrlInputRef}
 			/>
 			<Padding top="medium" />
 			<Input

--- a/src/actions/modals/add-external-calendar-modal.tsx
+++ b/src/actions/modals/add-external-calendar-modal.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import {
 	Container,
@@ -20,8 +20,8 @@ import { useTranslation } from 'react-i18next';
 import { AddExternalCalendarModalCaldavFlow } from './add-external-calendar-modal-caldav-flow';
 import { AddExternalCalendarModalIcsFlow } from './add-external-calendar-modal-ics-flow';
 import ModalFooter from '../../commons/modal-footer';
-import { buildCalendarColorItems } from 'commons/calendar-color-picker';
 import { triggerCaldavSync } from 'commons/caldav-sync';
+import { buildCalendarColorItems } from 'commons/calendar-color-picker';
 import { ModalHeader } from 'commons/modal-header';
 import { FOLDER_OPERATIONS } from 'constants/api';
 import { CALENDARS_STANDARD_COLORS } from 'constants/calendar';
@@ -130,6 +130,11 @@ export const AddExternalCalendarModal = ({ onClose }: { onClose: () => void }): 
 
 	const [calendarType, setCalendarType] = useState<CalendarType>(CALENDAR_TYPE_ICS);
 	const [isSubmitting, setIsSubmitting] = useState(false);
+
+	const calendarUrlInputRef = useRef<HTMLInputElement>(null);
+	useEffect(() => {
+		calendarUrlInputRef.current?.focus();
+	}, []);
 
 	// ── ICS state ──────────────────────────────────────────────────────────────
 	const [calendarUrl, setCalendarUrl] = useState('');
@@ -436,7 +441,7 @@ export const AddExternalCalendarModal = ({ onClose }: { onClose: () => void }): 
 			/>
 			<Padding top="medium" />
 			<Select
-				label={`${t('label.type', 'Type')}*`}
+				label={t('label.type', 'Type')}
 				items={calendarTypeItems}
 				defaultSelection={calendarTypeItems[0]}
 				disabled={isSubmitting}
@@ -464,6 +469,7 @@ export const AddExternalCalendarModal = ({ onClose }: { onClose: () => void }): 
 					onCalendarUrlChange={setCalendarUrl}
 					onCalendarNameChange={setCalendarName}
 					onSelectedColorChange={setSelectedColor}
+					calendarUrlInputRef={calendarUrlInputRef}
 				/>
 			) : (
 				<AddExternalCalendarModalCaldavFlow

--- a/src/actions/modals/create-group-modal.tsx
+++ b/src/actions/modals/create-group-modal.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React, { ReactElement, useCallback, useMemo, useState } from 'react';
+import React, { ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
 	Container,
@@ -53,6 +53,11 @@ export const CreateGroupModal = ({ onClose }: CreateGroupModalProps): ReactEleme
 		() => `${t('label.type_group_name_here', 'Group Name')}*`,
 		[t]
 	);
+
+	const groupNameInputRef = useRef<HTMLInputElement>(null);
+	useEffect(() => {
+		groupNameInputRef.current?.focus();
+	}, []);
 
 	const groupNameDescription = useMemo(() => {
 		if (isDirty) {
@@ -150,6 +155,7 @@ export const CreateGroupModal = ({ onClose }: CreateGroupModalProps): ReactEleme
 						if (!isDirty) setIsDirty(true);
 						setGroupName(e.target.value);
 					}}
+					inputRef={groupNameInputRef}
 				/>
 				<Padding vertical="small" />
 				<Divider />

--- a/src/actions/modals/edit-group-modal.tsx
+++ b/src/actions/modals/edit-group-modal.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React, { useCallback, useMemo, useState, FC, useEffect } from 'react';
+import React, { useCallback, useMemo, useRef, useState, FC, useEffect } from 'react';
 
 import {
 	Container,
@@ -78,6 +78,11 @@ export const EditGroupModal: FC<EditGroupModalProps> = ({
 		() => `${t('label.type_group_name_here', 'Group Name')}*`,
 		[t]
 	);
+
+	const groupNameInputRef = useRef<HTMLInputElement>(null);
+	useEffect(() => {
+		groupNameInputRef.current?.focus();
+	}, []);
 
 	const groupNameDescription = useMemo(() => {
 		if (isDirty) {
@@ -190,6 +195,7 @@ export const EditGroupModal: FC<EditGroupModalProps> = ({
 					}}
 					hasError={!isGroupNameValid}
 					description={groupNameDescription}
+					inputRef={groupNameInputRef}
 				/>
 				<Padding vertical="small" />
 				<Divider />

--- a/src/actions/modals/edit-modal/parts/main-edit-modal.tsx
+++ b/src/actions/modals/edit-modal/parts/main-edit-modal.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React, { FC, useCallback, useMemo, useState } from 'react';
+import React, { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import styled from '@emotion/styled';
 import {
@@ -42,9 +42,9 @@ import { GranteeChip } from './grantee-chip';
 import { ShareCalendarUrls } from './share-calendar-urls';
 import { useEditModalContext } from 'commons/edit-modal-context';
 import { isCaldavChild } from 'commons/utilities';
-import { SHARE_USER_TYPE } from 'constants/index';
 import { FOLDER_OPERATIONS } from 'constants/api';
 import { CALENDARS_STANDARD_COLORS } from 'constants/calendar';
+import { SHARE_USER_TYPE } from 'constants/index';
 import { folderAction } from 'store/actions/calendar-actions';
 import { sendShareCalendarNotification } from 'store/actions/send-share-calendar-notification';
 import { useAppDispatch } from 'store/redux/hooks';
@@ -337,13 +337,21 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 
 	const title = useMemo(() => t('action.edit_and_share_calendar', 'Edit and share calendar'), [t]);
 
-	const placeholder = useMemo(() => t('label.type_name_here', 'Calendar name'), [t]);
+	const placeholder = useMemo(() => `${t('label.type_name_here', 'Calendar name')}*`, [t]);
 
 	const isCaldavChildReadOnly = useMemo(() => {
 		const caldavChild = isCaldavChild(folder);
 		const isReadOnly = folder.perm && !/w/.test(folder.perm);
 		return caldavChild && isReadOnly;
 	}, [folder]);
+
+	const calendarNameInputRef = useRef<HTMLInputElement>(null);
+	const isCalendarNameEditable = !isCaldavChildReadOnly && !hasId(folder, FOLDERS.CALENDAR);
+	useEffect(() => {
+		if (isCalendarNameEditable) {
+			calendarNameInputRef.current?.focus();
+		}
+	}, [isCalendarNameEditable]);
 
 	let calendarNameInput: React.JSX.Element;
 	if (isCaldavChildReadOnly) {
@@ -373,7 +381,7 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 			>
 				<Input
 					label={placeholder}
-					backgroundColor="gray5"
+					background="gray5"
 					defaultValue={folderName}
 					onChange={(e): void => {
 						setFolderName(e.target.value);
@@ -397,6 +405,7 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 				onChange={(e): void => {
 					setFolderName(e.target.value);
 				}}
+				inputRef={calendarNameInputRef}
 			/>
 		);
 	}

--- a/src/actions/modals/share-calendar-modal.tsx
+++ b/src/actions/modals/share-calendar-modal.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React, { FC, ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { FC, ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
 	Checkbox,
@@ -112,6 +112,10 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 	const createSnackbar = useSnackbar();
 
 	const ContactInput = useContactInput();
+	const recipientsInputRef = useRef<HTMLInputElement>(null);
+	useEffect(() => {
+		recipientsInputRef.current?.focus();
+	}, []);
 
 	const [shareWithUserRole, setShareWithUserRole] = useState<string | null>('r');
 	const [sendNotification, setSendNotification] = useState(true);
@@ -414,7 +418,7 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 				height="fit"
 			>
 				<ContactInput
-					placeholder={t('share.placeholder.recipients_address', 'Recipients e-mail addresses')}
+					placeholder={`${t('share.placeholder.recipients_address', 'Recipients e-mail addresses')}*`}
 					onChange={onContactInputChange}
 					background={'gray5'}
 					defaultValue={contacts}
@@ -427,6 +431,7 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 							: undefined
 					}
 					hasError={contactInputHasError}
+					inputRef={recipientsInputRef}
 				/>
 				<Padding top="extrasmall" />
 				<Text size="extrasmall" color="secondary">

--- a/src/actions/modals/shares-modal.tsx
+++ b/src/actions/modals/shares-modal.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React, { FC, ReactElement, useCallback, useMemo, useState } from 'react';
+import React, { FC, ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import styled from '@emotion/styled';
 import {
@@ -89,6 +89,7 @@ export const SharesModal: FC<{ calendars: ResFolder[]; onClose: () => void }> = 
 	calendars,
 	onClose
 }) => {
+	const nameInputRef = useRef<HTMLInputElement>(null);
 	const [links, setLinks] = useState([]);
 	const [data, setData] = useState<any>();
 	const dispatch = useAppDispatch();
@@ -203,6 +204,10 @@ export const SharesModal: FC<{ calendars: ResFolder[]; onClose: () => void }> = 
 		[filteredFolders]
 	);
 
+	useEffect(() => {
+		nameInputRef.current?.focus();
+	}, []);
+
 	return isEmpty(nestedData) ? (
 		<>No shared folders to show at the moment</>
 	) : (
@@ -215,12 +220,13 @@ export const SharesModal: FC<{ calendars: ResFolder[]; onClose: () => void }> = 
 			</Row>
 			<Row padding={{ top: 'small', bottom: 'large' }} width="fill">
 				<Input
-					label={t('label.filter_sharer_user', 'Foder owner')}
-					backgroundColor="gray5"
+					label={t('label.filter_sharer_user', 'Folder owner')}
+					background="gray5"
 					CustomIcon={({ hasFocus }): ReactElement => (
 						<Icon icon="FunnelOutline" size="large" color={hasFocus ? 'primary' : 'text'} />
 					)}
 					onChange={filterResults}
+					inputRef={nameInputRef}
 				/>
 			</Row>
 			<ContainerEl orientation="vertical" mainAlignment="flex-start" maxHeight="40vh">

--- a/src/hooks/use-calendar-group-actions.tsx
+++ b/src/hooks/use-calendar-group-actions.tsx
@@ -55,6 +55,7 @@ const useCalendarGroupEditActionFn = (calendarGroupId: string): (() => void) => 
 				{
 					id: GROUP_ACTIONS.EDIT,
 					maxHeight: '90vh',
+					focusModalContent: false,
 					children: (
 						<EditGroupModal
 							onClose={(): void => closeModal(GROUP_ACTIONS.EDIT)}

--- a/src/view/editor/parts/editor-title.tsx
+++ b/src/view/editor/parts/editor-title.tsx
@@ -56,11 +56,11 @@ export const EditorTitle = ({ editorId }: { editorId: string }): ReactElement | 
 
 	return !isNil(title) ? (
 		<Input
-			label={t('label.event_title', 'Event title')}
+			label={`${t('label.event_title', 'Event title')}*`}
 			value={value}
 			onChange={onChange}
 			disabled={disabled?.title}
-			backgroundColor="gray5"
+			background="gray5"
 			data-testid="editor-title"
 			// eslint-disable-next-line jsx-a11y/no-autofocus
 			autoFocus

--- a/src/view/move/new-calendar-modal.tsx
+++ b/src/view/move/new-calendar-modal.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React, { ReactElement, useCallback, useMemo, useState } from 'react';
+import React, { ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
 	Container,
@@ -54,6 +54,7 @@ export const NewModal = ({
 	const [selectedColor, setSelectedColor] = useState(0);
 	const createSnackbar = useSnackbar();
 	const root = useRoot(folderId);
+	const nameInputRef = useRef<HTMLInputElement>(null);
 
 	const folders = useFoldersMapByRoot(root?.id ?? '1');
 	const folderArray = useMemo(() => map(folders, (f) => f.name), [folders]);
@@ -123,7 +124,11 @@ export const NewModal = ({
 		onClose();
 	}, [onClose]);
 
-	const placeholder = useMemo(() => t('label.type_name_here', 'Calendar name'), [t]);
+	const placeholder = useMemo(() => `${t('label.type_name_here', 'Calendar name')}*`, [t]);
+
+	useEffect(() => {
+		nameInputRef.current?.focus();
+	}, []);
 
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	return (
@@ -144,6 +149,7 @@ export const NewModal = ({
 				onChange={(e: React.ChangeEvent<HTMLInputElement>): void => {
 					setInputValue(e.target.value);
 				}}
+				inputRef={nameInputRef}
 			/>
 			{showDupWarning && (
 				<Padding all="small">

--- a/src/view/tags/create-update-tag-modal.tsx
+++ b/src/view/tags/create-update-tag-modal.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React, { FC, ReactElement, useCallback, useMemo, useState } from 'react';
+import React, { FC, ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Input, Padding, Text, useSnackbar } from '@zextras/carbonio-design-system';
 import { t } from '@zextras/carbonio-shell-ui';
@@ -35,6 +35,10 @@ const CreateUpdateTagModal: FC<ComponentProps> = ({
 	event
 }): ReactElement => {
 	const createSnackbar = useSnackbar();
+	const nameInputRef = useRef<HTMLInputElement>(null);
+	useEffect(() => {
+		nameInputRef.current?.focus();
+	}, []);
 	const [name, setName] = useState(tag?.name || '');
 
 	// TODO: remove any cast when tag.color is properly typed
@@ -46,7 +50,7 @@ const CreateUpdateTagModal: FC<ComponentProps> = ({
 				: t('label.create_tag', 'Create a new Tag'),
 		[editMode, tag?.name]
 	);
-	const label = useMemo(() => t('label.tag_name', 'Tag name'), []);
+	const label = useMemo(() => `${t('label.tag_name', 'Tag name')}*`, []);
 	const handleColorChange = useCallback((c: string | null) => setColor(c), []);
 	const handleNameChange = useCallback(
 		(ev: React.ChangeEvent<HTMLInputElement>) => setName(ev.target.value),
@@ -165,9 +169,10 @@ const CreateUpdateTagModal: FC<ComponentProps> = ({
 				label={label}
 				value={name}
 				onChange={handleNameChange}
-				backgroundColor="gray5"
+				background="gray5"
 				textColor={showWarning ? 'error' : 'text'}
 				hasError={showWarning}
+				inputRef={nameInputRef}
 			/>
 
 			{showWarning && (

--- a/src/view/tags/tag-actions.tsx
+++ b/src/view/tags/tag-actions.tsx
@@ -73,6 +73,7 @@ export const createTag = ({ createModal, closeModal }: ActionParams): ActionDesc
 		createModal?.(
 			{
 				id: modalId,
+				focusModalContent: false,
 				children: (
 					<StoreProvider>
 						<CreateUpdateTagModal onClose={(): void => closeModal?.(modalId)} />
@@ -106,6 +107,7 @@ export const createAndApplyTag = ({
 		context.createModal(
 			{
 				id: modalId,
+				focusModalContent: false,
 				children: (
 					<StoreProvider>
 						<CreateUpdateTagModal onClose={(): void => context.closeModal(modalId)} event={event} />
@@ -131,6 +133,7 @@ export const editTag = ({ createModal, closeModal, tag }: ActionParams): ActionD
 		createModal?.(
 			{
 				id: modalId,
+				focusModalContent: false,
 				children: (
 					<StoreProvider>
 						<CreateUpdateTagModal onClose={(): void => closeModal?.(modalId)} tag={tag} editMode />


### PR DESCRIPTION
This pull request focuses on improving accessibility and user experience in modal dialogs by ensuring that the primary input field is automatically focused when a modal opens. It also clarifies required fields by adding asterisks to labels and makes minor property adjustments for consistency. The most important changes are grouped below.

**Accessibility and Focus Improvements:**

* Added logic to automatically focus the main input field (e.g., name, URL, or recipient address) when opening modals such as `CreateGroupModal`, `EditGroupModal`, `AddExternalCalendarModal`, `MainEditModal`, `ShareCalendarModal`, and `CreateUpdateTagModal`. This is achieved by using `useRef` and `useEffect` to call `.focus()` on the relevant input elements. [[1]](diffhunk://#diff-fb5fe851e68f00e2d62004fe383ca413bb0171b112b7b9f4b57963a15612c5acR57-R61) [[2]](diffhunk://#diff-fb5fe851e68f00e2d62004fe383ca413bb0171b112b7b9f4b57963a15612c5acR158) [[3]](diffhunk://#diff-ba64b398225f938f4244d72955da7dc58fff2d9c5d4c0232ac09d27ab61b1bccR82-R86) [[4]](diffhunk://#diff-ba64b398225f938f4244d72955da7dc58fff2d9c5d4c0232ac09d27ab61b1bccR198) [[5]](diffhunk://#diff-1cd83aad893fa60229fd766389b8bea65aaaff17c1ddce5bd1711f51d6c0ff92L6-R6) [[6]](diffhunk://#diff-1cd83aad893fa60229fd766389b8bea65aaaff17c1ddce5bd1711f51d6c0ff92R26) [[7]](diffhunk://#diff-1cd83aad893fa60229fd766389b8bea65aaaff17c1ddce5bd1711f51d6c0ff92L40-R42) [[8]](diffhunk://#diff-1cd83aad893fa60229fd766389b8bea65aaaff17c1ddce5bd1711f51d6c0ff92R62) [[9]](diffhunk://#diff-0d4b6eb1ae183e1d20a02a91975016964a06e607b1cd88c1cd6d298bbbdd0e69L6-R6) [[10]](diffhunk://#diff-0d4b6eb1ae183e1d20a02a91975016964a06e607b1cd88c1cd6d298bbbdd0e69R134-R138) [[11]](diffhunk://#diff-0d4b6eb1ae183e1d20a02a91975016964a06e607b1cd88c1cd6d298bbbdd0e69R472) [[12]](diffhunk://#diff-d471327a6f8765579b1d69ffa7676c061ade4dc17a7c8d6e5047be1778b20ebaL6-R6) [[13]](diffhunk://#diff-d471327a6f8765579b1d69ffa7676c061ade4dc17a7c8d6e5047be1778b20ebaL340-R355) [[14]](diffhunk://#diff-d471327a6f8765579b1d69ffa7676c061ade4dc17a7c8d6e5047be1778b20ebaR408) [[15]](diffhunk://#diff-099f95b3b8c94fb53a3949c40fbbf8d6faeac62503cc1929a4967fc039550a98L7-R7) [[16]](diffhunk://#diff-099f95b3b8c94fb53a3949c40fbbf8d6faeac62503cc1929a4967fc039550a98R115-R118) [[17]](diffhunk://#diff-099f95b3b8c94fb53a3949c40fbbf8d6faeac62503cc1929a4967fc039550a98R434) [[18]](diffhunk://#diff-88b3755111c97bc83a0be9123b2d482db3a181f8da07fee53c4221a91d2ef5f8L7-R7) [[19]](diffhunk://#diff-88b3755111c97bc83a0be9123b2d482db3a181f8da07fee53c4221a91d2ef5f8R38-R41) [[20]](diffhunk://#diff-88b3755111c97bc83a0be9123b2d482db3a181f8da07fee53c4221a91d2ef5f8L168-R175)

**Required Field Labeling and UI Consistency:**

* Updated labels for required fields to include an asterisk (e.g., "Event title*", "Tag name*") in various components and modals for better clarity to users. [[1]](diffhunk://#diff-3ad592324edf016d1c4449ad4f1633c61e60a80fd190b657a99e44f6a9e012b5L59-R63) [[2]](diffhunk://#diff-0d4b6eb1ae183e1d20a02a91975016964a06e607b1cd88c1cd6d298bbbdd0e69L439-R444) [[3]](diffhunk://#diff-d471327a6f8765579b1d69ffa7676c061ade4dc17a7c8d6e5047be1778b20ebaL340-R355) [[4]](diffhunk://#diff-099f95b3b8c94fb53a3949c40fbbf8d6faeac62503cc1929a4967fc039550a98L417-R421) [[5]](diffhunk://#diff-88b3755111c97bc83a0be9123b2d482db3a181f8da07fee53c4221a91d2ef5f8L49-R53)
* Changed the `backgroundColor` prop to `background` in several `Input` components for consistency with the design system. [[1]](diffhunk://#diff-d471327a6f8765579b1d69ffa7676c061ade4dc17a7c8d6e5047be1778b20ebaL376-R384) [[2]](diffhunk://#diff-3ad592324edf016d1c4449ad4f1633c61e60a80fd190b657a99e44f6a9e012b5L59-R63) [[3]](diffhunk://#diff-88b3755111c97bc83a0be9123b2d482db3a181f8da07fee53c4221a91d2ef5f8L168-R175)

**Modal Behavior Adjustments:**

* Set `focusModalContent: false` in modal creation calls to prevent the modal wrapper from stealing focus, allowing the custom input focus logic to work as intended. This change affects group, calendar, and tag modals. [[1]](diffhunk://#diff-edd8eb573f643c339f6ef0a1f46d89d487de2a8d57b87c27687de19087cdc8b4R92) [[2]](diffhunk://#diff-edd8eb573f643c339f6ef0a1f46d89d487de2a8d57b87c27687de19087cdc8b4R195) [[3]](diffhunk://#diff-edd8eb573f643c339f6ef0a1f46d89d487de2a8d57b87c27687de19087cdc8b4R249) [[4]](diffhunk://#diff-edd8eb573f643c339f6ef0a1f46d89d487de2a8d57b87c27687de19087cdc8b4R541) [[5]](diffhunk://#diff-62f1bbd4b993c83064779fefe41a65b968b1c3cd5f8f050836e02ee2aa0a97b1R58) [[6]](diffhunk://#diff-af3ef495e3819f45cbf60104b1ec0f440a819dda6e950f24d6a9646b89006725R76)

These changes collectively enhance the usability of modal dialogs by streamlining user input and clarifying required actions.