### PR TITLE
feat: redesign sharing sections in edit calendar modal

### DIFF
--- a/src/actions/calendar-actions-fn.tsx
+++ b/src/actions/calendar-actions-fn.tsx
@@ -527,7 +527,6 @@ export const shareCalendar =
 				children: (
 					<StoreProvider>
 						<ShareCalendarModal
-							folderName={item.name}
 							folderId={item.id}
 							closeFn={(): void => closeModal(modalId)}
 							grant={item?.acl?.grant ?? []}

--- a/src/actions/modals/add-external-calendar-modal.test.tsx
+++ b/src/actions/modals/add-external-calendar-modal.test.tsx
@@ -121,7 +121,10 @@ describe('AddExternalCalendarModal', () => {
 			// Individual tests that don't care about polling behavior mock it with a
 			// never-settling promise so the polling hangs silently without causing
 			// unhandled-rejection noise.
-			vi.spyOn(getImportStatusApi, 'getImportStatusRequest').mockReturnValue(new Promise(() => {}));
+			vi.spyOn(getImportStatusApi, 'getImportStatusRequest').mockReturnValue(
+				// eslint-disable-next-line @typescript-eslint/no-empty-function
+				new Promise(() => {})
+			);
 		});
 
 		test('shows caldav-specific fields when CalDAV type is selected', async () => {

--- a/src/actions/modals/edit-modal/edit-modal.test.tsx
+++ b/src/actions/modals/edit-modal/edit-modal.test.tsx
@@ -551,9 +551,7 @@ describe('the edit calendar modal is composed by', () => {
 							store
 						});
 						await user.click(screen.getByText(/black/i));
-						await user.click(
-							within(screen.getByTestId(TEST_SELECTORS.DROPDOWN)).getByText(/red/i)
-						);
+						await user.click(within(screen.getByTestId(TEST_SELECTORS.DROPDOWN)).getByText(/red/i));
 						await user.click(screen.getByText('OK'));
 
 						expect(spy).toHaveBeenCalledTimes(1);
@@ -647,9 +645,7 @@ describe('the edit calendar modal is composed by', () => {
 					await user.type(title, newCalendarName);
 
 					await user.click(screen.getByText(/black/i));
-					await user.click(
-						within(screen.getByTestId(TEST_SELECTORS.DROPDOWN)).getByText(/red/i)
-					);
+					await user.click(within(screen.getByTestId(TEST_SELECTORS.DROPDOWN)).getByText(/red/i));
 
 					await user.click(screen.getAllByTestId('icon: Square')[0]);
 					await user.click(screen.getByText('OK'));

--- a/src/actions/modals/edit-modal/edit-modal.test.tsx
+++ b/src/actions/modals/edit-modal/edit-modal.test.tsx
@@ -273,7 +273,7 @@ describe('the edit calendar modal is composed by', () => {
 					store
 				});
 
-				expect(screen.getByTestId('icon: Square')).toBeVisible();
+				expect(screen.getAllByTestId('icon: Square')[0]).toBeVisible();
 			});
 			test(' an informative string to explain the checkbox meaning', async () => {
 				const closeFn = vi.fn();
@@ -312,7 +312,7 @@ describe('the edit calendar modal is composed by', () => {
 					store
 				});
 
-				const sharingSection = screen.getByText(`Sharing of this folder`);
+				const sharingSection = screen.getByText('Internal sharing');
 				expect(sharingSection).toBeVisible();
 			});
 			test('it shows a list of all users this folder has been shared to and their relative roles', async () => {
@@ -340,7 +340,7 @@ describe('the edit calendar modal is composed by', () => {
 					});
 
 					expect(screen.getByTestId('MainEditModal')).toBeInTheDocument();
-					expect(screen.getByText(/public - viewer/i)).toBeVisible();
+					expect(screen.getByTestId('icon: CheckmarkSquare')).toBeVisible();
 				});
 				test('public user has only the revoke action available', async () => {
 					const closeFn = vi.fn();
@@ -353,7 +353,8 @@ describe('the edit calendar modal is composed by', () => {
 
 					expect(screen.queryByRole('button', { name: /resend/i })).not.toBeInTheDocument();
 					expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
-					expect(screen.getByRole('button', { name: /revoke/i })).toBeInTheDocument();
+					expect(screen.queryByRole('button', { name: /revoke/i })).not.toBeInTheDocument();
+					expect(screen.getByTestId('icon: CheckmarkSquare')).toBeVisible();
 				});
 			});
 			describe('normal users have 3 buttons', () => {
@@ -550,7 +551,9 @@ describe('the edit calendar modal is composed by', () => {
 							store
 						});
 						await user.click(screen.getByText(/black/i));
-						await user.click(screen.getByText(/red/i));
+						await user.click(
+							within(screen.getByTestId(TEST_SELECTORS.DROPDOWN)).getByText(/red/i)
+						);
 						await user.click(screen.getByText('OK'));
 
 						expect(spy).toHaveBeenCalledTimes(1);
@@ -616,7 +619,7 @@ describe('the edit calendar modal is composed by', () => {
 						});
 
 						await user.click(screen.getByTestId('icon: CheckmarkSquare'));
-						await user.click(screen.getByTestId('icon: Square'));
+						await user.click(screen.getAllByTestId('icon: Square')[0]);
 						await user.click(screen.getByText('OK'));
 
 						expect(spy).not.toHaveBeenCalled();
@@ -644,9 +647,11 @@ describe('the edit calendar modal is composed by', () => {
 					await user.type(title, newCalendarName);
 
 					await user.click(screen.getByText(/black/i));
-					await user.click(screen.getByText(/red/i));
+					await user.click(
+						within(screen.getByTestId(TEST_SELECTORS.DROPDOWN)).getByText(/red/i)
+					);
 
-					await user.click(screen.getByTestId('icon: Square'));
+					await user.click(screen.getAllByTestId('icon: Square')[0]);
 					await user.click(screen.getByText('OK'));
 
 					expect(spy).toHaveBeenCalledTimes(1);

--- a/src/actions/modals/edit-modal/edit-modal.test.tsx
+++ b/src/actions/modals/edit-modal/edit-modal.test.tsx
@@ -624,9 +624,7 @@ describe('the edit calendar modal is composed by', () => {
 					});
 				});
 				test('if the user changes all of the above it will trigger all the operations in a batch', async () => {
-					// disable console.warn raised by soapFetch
-					vi.spyOn(console, 'warn').mockImplementation(vi.fn());
-					const spy = vi.spyOn(BatchAction, 'batchRequest');
+					const spy = vi.spyOn(BatchAction, 'batchRequest').mockResolvedValue({});
 
 					const closeFn = vi.fn();
 
@@ -642,7 +640,7 @@ describe('the edit calendar modal is composed by', () => {
 					});
 
 					await user.clear(title);
-					await user.type(title, newCalendarName);
+					await user.pasteInto(title, newCalendarName);
 
 					await user.click(screen.getByText(/black/i));
 					await user.click(within(screen.getByTestId(TEST_SELECTORS.DROPDOWN)).getByText(/red/i));

--- a/src/actions/modals/edit-modal/edit-modal.tsx
+++ b/src/actions/modals/edit-modal/edit-modal.tsx
@@ -95,7 +95,6 @@ export const EditModal: FC<EditModalProps> = ({ onClose, folderId }) => {
 
 			{(modal === 'share' && folder && (
 				<ShareCalendarModal
-					folderName={folder.name}
 					folderId={folderId}
 					closeFn={onClose}
 					onGoBack={onGoBack}

--- a/src/actions/modals/edit-modal/parts/main-edit-modal.tsx
+++ b/src/actions/modals/edit-modal/parts/main-edit-modal.tsx
@@ -42,13 +42,13 @@ import { GranteeChip } from './grantee-chip';
 import { ShareCalendarUrls } from './share-calendar-urls';
 import { useEditModalContext } from 'commons/edit-modal-context';
 import { isCaldavChild } from 'commons/utilities';
-import { PUBLIC_SHARE_ZID, SHARE_USER_TYPE } from 'constants/index';
 import { FOLDER_OPERATIONS } from 'constants/api';
 import { CALENDARS_STANDARD_COLORS } from 'constants/calendar';
+import { PUBLIC_SHARE_ZID, SHARE_USER_TYPE } from 'constants/index';
 import { folderAction } from 'store/actions/calendar-actions';
-import { FolderAction } from 'types/soap/soap-actions';
 import { sendShareCalendarNotification } from 'store/actions/send-share-calendar-notification';
 import { useAppDispatch } from 'store/redux/hooks';
+import { FolderAction } from 'types/soap/soap-actions';
 import { containPublicShareGrant } from 'utils/calendars-share';
 
 const Square = styled.div<{ $color: AnyColor }>`
@@ -509,7 +509,8 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 								<Text weight="bold">{t('share.label.internal_sharing', 'Internal sharing')}</Text>
 								<Button
 									type="ghost"
-									label={t('label.add_share', 'Add share +')}
+									label={t('label.add_share', 'Add share')}
+									icon="Plus"
 									onClick={onShare}
 									size="small"
 								/>

--- a/src/actions/modals/edit-modal/parts/main-edit-modal.tsx
+++ b/src/actions/modals/edit-modal/parts/main-edit-modal.tsx
@@ -590,7 +590,7 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 								)}
 							/>
 
-							{isSharedWithPublic && <ShareCalendarUrls calendarName={folder.name} />}
+							{defaultSharedWithPublic && <ShareCalendarUrls calendarName={folder.name} />}
 						</Container>
 					)}
 				</Container>

--- a/src/actions/modals/edit-modal/parts/main-edit-modal.tsx
+++ b/src/actions/modals/edit-modal/parts/main-edit-modal.tsx
@@ -508,8 +508,8 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 							>
 								<Text weight="bold">{t('share.label.internal_sharing', 'Internal sharing')}</Text>
 								<Button
-									type="outlined"
-									label={t('label.add_share', 'Add share')}
+									type="ghost"
+									label={t('label.add_share', 'Add share +')}
 									onClick={onShare}
 									size="small"
 								/>

--- a/src/actions/modals/edit-modal/parts/main-edit-modal.tsx
+++ b/src/actions/modals/edit-modal/parts/main-edit-modal.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React, { FC, useCallback, useMemo, useState } from 'react';
+import React, { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import styled from '@emotion/styled';
 import {
@@ -183,9 +183,16 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 		[grant]
 	);
 
+	const hasUserToggledPublicRef = useRef(false);
 	const [folderName, setFolderName] = useState(defaultFolderName);
 	const [freeBusy, setFreeBusy] = useState(defaultFreeBusy);
 	const [isSharedWithPublic, setIsSharedWithPublic] = useState(defaultSharedWithPublic);
+
+	useEffect(() => {
+		if (!hasUserToggledPublicRef.current) {
+			setIsSharedWithPublic(defaultSharedWithPublic);
+		}
+	}, [defaultSharedWithPublic]);
 
 	const toggleFreeBusy = useCallback(() => setFreeBusy((c) => !c), []);
 
@@ -583,14 +590,17 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 							<Checkbox
 								value={isSharedWithPublic}
 								defaultChecked={isSharedWithPublic}
-								onClick={(): void => setIsSharedWithPublic((prev) => !prev)}
+								onClick={(): void => {
+									hasUserToggledPublicRef.current = true;
+									setIsSharedWithPublic((prev) => !prev);
+								}}
 								label={t(
 									'share.options.share_calendar_with.public',
 									'Share with public (view only, no password required)'
 								)}
 							/>
 
-							{defaultSharedWithPublic && <ShareCalendarUrls calendarName={folder.name} />}
+							{isSharedWithPublic && <ShareCalendarUrls calendarName={folder.name} />}
 						</Container>
 					)}
 				</Container>

--- a/src/actions/modals/edit-modal/parts/main-edit-modal.tsx
+++ b/src/actions/modals/edit-modal/parts/main-edit-modal.tsx
@@ -512,7 +512,7 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 									label={t('label.add_share', 'Add share')}
 									icon="Plus"
 									onClick={onShare}
-									size="small"
+									size="medium"
 								/>
 							</Container>
 

--- a/src/actions/modals/edit-modal/parts/main-edit-modal.tsx
+++ b/src/actions/modals/edit-modal/parts/main-edit-modal.tsx
@@ -512,7 +512,7 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 									label={t('label.add_share', 'Add share')}
 									icon="Plus"
 									onClick={onShare}
-									size="medium"
+									size="small"
 								/>
 							</Container>
 

--- a/src/actions/modals/edit-modal/parts/main-edit-modal.tsx
+++ b/src/actions/modals/edit-modal/parts/main-edit-modal.tsx
@@ -510,6 +510,7 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 							<Divider />
 
 							<Container
+								data-testid="internalSharingHeader"
 								orientation="horizontal"
 								mainAlignment="space-between"
 								crossAlignment="center"

--- a/src/actions/modals/edit-modal/parts/main-edit-modal.tsx
+++ b/src/actions/modals/edit-modal/parts/main-edit-modal.tsx
@@ -26,7 +26,7 @@ import {
 	Tooltip,
 	useSnackbar
 } from '@zextras/carbonio-design-system';
-import { useUserAccounts } from '@zextras/carbonio-shell-ui';
+import { useUserAccounts, useUserSettings } from '@zextras/carbonio-shell-ui';
 import {
 	FOLDER_VIEW,
 	FOLDERS,
@@ -35,17 +35,18 @@ import {
 	Grant,
 	hasId
 } from '@zextras/carbonio-ui-commons';
-import { compact, find, includes, isEmpty, map } from 'lodash';
+import { compact, find, includes, map } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { GranteeChip } from './grantee-chip';
 import { ShareCalendarUrls } from './share-calendar-urls';
 import { useEditModalContext } from 'commons/edit-modal-context';
 import { isCaldavChild } from 'commons/utilities';
-import { SHARE_USER_TYPE } from 'constants/index';
+import { PUBLIC_SHARE_ZID, SHARE_USER_TYPE } from 'constants/index';
 import { FOLDER_OPERATIONS } from 'constants/api';
 import { CALENDARS_STANDARD_COLORS } from 'constants/calendar';
 import { folderAction } from 'store/actions/calendar-actions';
+import { FolderAction } from 'types/soap/soap-actions';
 import { sendShareCalendarNotification } from 'store/actions/send-share-calendar-notification';
 import { useAppDispatch } from 'store/redux/hooks';
 import { containPublicShareGrant } from 'utils/calendars-share';
@@ -159,6 +160,7 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 
 	const [t] = useTranslation();
 	const accounts = useUserAccounts();
+	const userSettings = useUserSettings();
 	const createSnackbar = useSnackbar();
 	const dispatch = useAppDispatch();
 	const { setModal, onClose, setActiveGrant } = useEditModalContext();
@@ -174,10 +176,16 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 		[colors, folder.color]
 	);
 
-	const isCalendarPubliclyShared = useMemo(() => containPublicShareGrant(grant), [grant]);
+	const defaultSharedWithPublic = useMemo(() => containPublicShareGrant(grant), [grant]);
+	const isPublicShareEnabled = userSettings?.attrs?.zimbraPublicSharingEnabled === 'TRUE';
+	const internalGrants = useMemo(
+		() => grant.filter((g) => g.gt !== SHARE_USER_TYPE.PUBLIC),
+		[grant]
+	);
 
 	const [folderName, setFolderName] = useState(defaultFolderName);
 	const [freeBusy, setFreeBusy] = useState(defaultFreeBusy);
+	const [isSharedWithPublic, setIsSharedWithPublic] = useState(defaultSharedWithPublic);
 
 	const toggleFreeBusy = useCallback(() => setFreeBusy((c) => !c), []);
 
@@ -241,7 +249,17 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 						id: folder.id
 					}
 				: undefined;
-		const actionsArray = compact([actionRename, actionColor, actionFreeBusy]);
+		let actionPublicShare: FolderAction | undefined;
+		if (isSharedWithPublic !== defaultSharedWithPublic) {
+			actionPublicShare = defaultSharedWithPublic
+				? { id: folder.id, zid: PUBLIC_SHARE_ZID, op: FOLDER_OPERATIONS.REVOKE_GRANT }
+				: {
+						id: folder.id,
+						op: FOLDER_OPERATIONS.GRANT,
+						grant: [{ gt: SHARE_USER_TYPE.PUBLIC, perm: 'r', pw: '' }]
+					};
+		}
+		const actionsArray = compact([actionRename, actionColor, actionFreeBusy, actionPublicShare]);
 		if (actionsArray.length) {
 			const actions = actionsArray.length > 1 ? actionsArray : actionsArray[0];
 			folderAction(actions).then((res: { Fault?: string }) => {
@@ -277,6 +295,8 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 		defaultColor?.value,
 		freeBusy,
 		defaultFreeBusy,
+		isSharedWithPublic,
+		defaultSharedWithPublic,
 		onClose,
 		createSnackbar,
 		t
@@ -463,8 +483,8 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 						)}
 					/>
 
-					{/* Calendar sharing */}
-					{!isEmpty(folder?.acl) && !(folder.isLink && folder.owner) && (
+					{/* Internal sharing */}
+					{!(folder.isLink && folder.owner) && (
 						<Container
 							mainAlignment="flex-start"
 							crossAlignment="flex-start"
@@ -473,43 +493,47 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 						>
 							<Divider />
 
-							<Text weight="bold">
-								{t('label.sharing_of_this_folder', 'Sharing of this folder')}
-							</Text>
+							<Container
+								orientation="horizontal"
+								mainAlignment="space-between"
+								crossAlignment="center"
+								height="fit"
+							>
+								<Text weight="bold">{t('share.label.internal_sharing', 'Internal sharing')}</Text>
+								<Button
+									type="outlined"
+									label={t('label.add_share', 'Add share')}
+									onClick={onShare}
+									size="small"
+								/>
+							</Container>
 
-							{grant && grant.length > 0 && (
+							{internalGrants.length > 0 && (
 								<Container
 									style={{ overflowY: 'auto' }}
 									mainAlignment="flex-start"
-									height={grant.length === 1 ? '1.375rem' : '3.25rem'}
+									height={internalGrants.length === 1 ? '1.375rem' : '3.25rem'}
 									maxHeight={'3.25rem'}
 									padding={{ right: 'small' }}
 									gap="0.5rem"
 								>
-									{map(grant, (item, index) => (
+									{map(internalGrants, (item, index) => (
 										<Container orientation="horizontal" mainAlignment="flex-end" key={index}>
 											<StyledContainer crossAlignment="flex-start">
 												<GranteeChip grant={item} />
 											</StyledContainer>
 											<Container orientation="horizontal" mainAlignment="flex-end" width={'fit'}>
-												{item.gt !== SHARE_USER_TYPE.PUBLIC && (
-													<>
-														<Tooltip
-															label={t('tooltip.edit', 'Edit share properties')}
-															placement="top"
-														>
-															<Button
-																type="outlined"
-																label={t('label.edit', 'Edit')}
-																onClick={(): void => {
-																	onEdit(item);
-																}}
-																size="small"
-															/>
-														</Tooltip>
-														<Padding horizontal="extrasmall" />
-													</>
-												)}
+												<Tooltip label={t('tooltip.edit', 'Edit share properties')} placement="top">
+													<Button
+														type="outlined"
+														label={t('label.edit', 'Edit')}
+														onClick={(): void => {
+															onEdit(item);
+														}}
+														size="small"
+													/>
+												</Tooltip>
+												<Padding horizontal="extrasmall" />
 												<Tooltip label={t('revoke_access', 'Revoke access')} placement="top">
 													<Button
 														type="outlined"
@@ -521,25 +545,21 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 														size="small"
 													/>
 												</Tooltip>
-												{item.gt !== SHARE_USER_TYPE.PUBLIC && (
-													<>
-														<Padding horizontal="extrasmall" />
-														<Tooltip
-															label={t('tooltip.resend', 'Send mail notification about this share')}
-															placement="top"
-															maxWidth="18.75rem"
-														>
-															<Button
-																type="outlined"
-																label={t('label.resend', 'Resend')}
-																onClick={(): void => {
-																	onResend(item);
-																}}
-																size="small"
-															/>
-														</Tooltip>
-													</>
-												)}
+												<Padding horizontal="extrasmall" />
+												<Tooltip
+													label={t('tooltip.resend', 'Send mail notification about this share')}
+													placement="top"
+													maxWidth="18.75rem"
+												>
+													<Button
+														type="outlined"
+														label={t('label.resend', 'Resend')}
+														onClick={(): void => {
+															onResend(item);
+														}}
+														size="small"
+													/>
+												</Tooltip>
 											</Container>
 										</Container>
 									))}
@@ -548,8 +568,31 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 						</Container>
 					)}
 
-					{/* Shared access links */}
-					{isCalendarPubliclyShared && <ShareCalendarUrls calendarName={folder.name} />}
+					{/* Public sharing */}
+					{isPublicShareEnabled && !(folder.isLink && folder.owner) && (
+						<Container
+							mainAlignment="flex-start"
+							crossAlignment="flex-start"
+							orientation="vertical"
+							gap="1rem"
+						>
+							<Divider />
+
+							<Text weight="bold">{t('share.label.public_sharing', 'Public sharing')}</Text>
+
+							<Checkbox
+								value={isSharedWithPublic}
+								defaultChecked={isSharedWithPublic}
+								onClick={(): void => setIsSharedWithPublic((prev) => !prev)}
+								label={t(
+									'share.options.share_calendar_with.public',
+									'Share with public (view only, no password required)'
+								)}
+							/>
+
+							{isSharedWithPublic && <ShareCalendarUrls calendarName={folder.name} />}
+						</Container>
+					)}
 				</Container>
 			</ModalBody>
 			<Divider />
@@ -557,8 +600,6 @@ export const MainEditModal: FC<MainEditModalProps> = ({ folder, totalAppointment
 				onConfirm={onConfirm}
 				confirmLabel={t('label.ok', 'OK')}
 				confirmDisabled={disabled}
-				onSecondaryAction={onShare}
-				secondaryActionLabel={t('label.add_share', 'Add share')}
 			/>
 		</Container>
 	);

--- a/src/actions/modals/edit-modal/parts/share-calendar-urls.tsx
+++ b/src/actions/modals/edit-modal/parts/share-calendar-urls.tsx
@@ -90,7 +90,7 @@ export const ShareCalendarUrls: FC<ShareCalendarUrlsProps> = ({ calendarName }):
 			</Container>
 
 			<Text overflow="break-word" color="secondary">
-				{t('message.share_calendar_url_note', 'Anyone with these links can view your calendar.')}
+				{t('label.share_note', 'Anyone with these links can view your calendar.')}
 			</Text>
 		</Container>
 	);

--- a/src/actions/modals/edit-modal/parts/share-calendar-urls.tsx
+++ b/src/actions/modals/edit-modal/parts/share-calendar-urls.tsx
@@ -51,12 +51,7 @@ export const ShareCalendarUrls: FC<ShareCalendarUrlsProps> = ({ calendarName }):
 	);
 
 	return (
-		<Container
-			mainAlignment="flex-start"
-			crossAlignment="flex-start"
-			orientation="vertical"
-			gap="0.5rem"
-		>
+		<>
 			<Container orientation="horizontal" mainAlignment="flex-start" gap={'0.5rem'}>
 				<Tooltip label={t('tooltip.copy_ics_url', 'Copy ICS url')} placement="top">
 					<Button
@@ -92,6 +87,6 @@ export const ShareCalendarUrls: FC<ShareCalendarUrlsProps> = ({ calendarName }):
 			<Text overflow="break-word" color="secondary">
 				{t('label.share_note', 'Anyone with these links can view your calendar.')}
 			</Text>
-		</Container>
+		</>
 	);
 };

--- a/src/actions/modals/edit-modal/parts/share-calendar-urls.tsx
+++ b/src/actions/modals/edit-modal/parts/share-calendar-urls.tsx
@@ -25,13 +25,6 @@ export const ShareCalendarUrls: FC<ShareCalendarUrlsProps> = ({ calendarName }):
 
 	const user = useMemo(() => accounts[0].name, [accounts]);
 	const domain = useMemo(() => getCarbonioDomain(), []);
-	const title = useMemo(
-		() =>
-			t('label.public_share_urls', {
-				defaultValue: 'Public share URLS'
-			}),
-		[t]
-	);
 	const icsLinkLabel = useMemo(() => t('label.ics_url', 'ICS URL'), [t]);
 	const webcalLinkLabel = useMemo(() => t('label.webcal_url', 'WebCAL URL'), [t]);
 	const caldavLinkLabel = useMemo(() => t('label.caldav_url', 'CalDAV URL'), [t]);
@@ -64,55 +57,41 @@ export const ShareCalendarUrls: FC<ShareCalendarUrlsProps> = ({ calendarName }):
 			orientation="vertical"
 			gap="0.5rem"
 		>
-			<Text weight="bold">{title}</Text>
+			<Container orientation="horizontal" mainAlignment="flex-start" gap={'0.5rem'}>
+				<Tooltip label={t('tooltip.copy_ics_url', 'Copy ICS url')} placement="top">
+					<Button
+						label={icsLinkLabel}
+						icon="Copy"
+						size="small"
+						type="outlined"
+						onClick={createLinkClickHandler(icsLinkLabel, CALENDARS_SHARE_LINK_TYPES.ics)}
+					/>
+				</Tooltip>
 
-			<Container gap="1rem" mainAlignment="flex-start" crossAlignment="flex-start">
-				<Text overflow="break-word">
-					{t('message.share_calendar_url_msg', {
-						title: calendarName,
-						defaultValue:
-							'You can quickly share {{title}} with your collaborators using one of these URLs:'
-					})}
-				</Text>
-				<Container orientation="horizontal" mainAlignment="flex-start" gap={'0.5rem'}>
-					<Tooltip label={t('tooltip.copy_ics_url', 'Copy ICS url')} placement="top">
-						<Button
-							label={icsLinkLabel}
-							icon="Copy"
-							size="small"
-							type="outlined"
-							onClick={createLinkClickHandler(icsLinkLabel, CALENDARS_SHARE_LINK_TYPES.ics)}
-						/>
-					</Tooltip>
+				<Tooltip label={t('tooltip.copy_webcal_url', 'Copy WebCAL url')} placement="top">
+					<Button
+						label={webcalLinkLabel}
+						icon="Copy"
+						size="small"
+						type="outlined"
+						onClick={createLinkClickHandler(webcalLinkLabel, CALENDARS_SHARE_LINK_TYPES.webcal)}
+					/>
+				</Tooltip>
 
-					<Tooltip label={t('tooltip.copy_webcal_url', 'Copy WebCAL url')} placement="top">
-						<Button
-							label={webcalLinkLabel}
-							icon="Copy"
-							size="small"
-							type="outlined"
-							onClick={createLinkClickHandler(webcalLinkLabel, CALENDARS_SHARE_LINK_TYPES.webcal)}
-						/>
-					</Tooltip>
-
-					<Tooltip label={t('tooltip.copy_caldav_url', 'Copy CalDAV url')} placement="top">
-						<Button
-							label={caldavLinkLabel}
-							icon="Copy"
-							size="small"
-							type="outlined"
-							onClick={createLinkClickHandler(caldavLinkLabel, CALENDARS_SHARE_LINK_TYPES.caldav)}
-						/>
-					</Tooltip>
-				</Container>
-
-				<Text overflow="break-word" color="secondary">
-					{t(
-						'message.share_calendar_url_note',
-						'Only your collaborators can access your data using these URLs.'
-					)}
-				</Text>
+				<Tooltip label={t('tooltip.copy_caldav_url', 'Copy CalDAV url')} placement="top">
+					<Button
+						label={caldavLinkLabel}
+						icon="Copy"
+						size="small"
+						type="outlined"
+						onClick={createLinkClickHandler(caldavLinkLabel, CALENDARS_SHARE_LINK_TYPES.caldav)}
+					/>
+				</Tooltip>
 			</Container>
+
+			<Text overflow="break-word" color="secondary">
+				{t('message.share_calendar_url_note', 'Anyone with these links can view your calendar.')}
+			</Text>
 		</Container>
 	);
 };

--- a/src/actions/modals/edit-modal/parts/tests/main-edit-modal.test.tsx
+++ b/src/actions/modals/edit-modal/parts/tests/main-edit-modal.test.tsx
@@ -351,6 +351,95 @@ describe('MainEditModal', () => {
 			});
 		});
 
+		describe('Public share URLs', () => {
+			it('should show URLs immediately when checkbox is checked, before saving', async () => {
+				const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+				const grant: Array<Grant> = [];
+
+				const { user } = setupTest(
+					<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={grant} />,
+					{ store }
+				);
+
+				expect(screen.queryByText('Public share URLS')).not.toBeInTheDocument();
+
+				await user.click(screen.getByText(/share with public/i));
+
+				expect(screen.getByText('Public share URLS')).toBeVisible();
+			});
+
+			it('should hide URLs when checkbox is unchecked', async () => {
+				const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+				const grant: Array<Grant> = [{ gt: SHARE_USER_TYPE.PUBLIC, perm: 'r' }];
+
+				const { user } = setupTest(
+					<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={grant} />,
+					{ store }
+				);
+
+				expect(screen.getByText('Public share URLS')).toBeVisible();
+
+				await user.click(screen.getByText(/share with public/i));
+
+				expect(screen.queryByText('Public share URLS')).not.toBeInTheDocument();
+			});
+		});
+
+		describe('State resync when grant prop changes', () => {
+			it('should sync checkbox to checked when grant prop adds a public grant and user has not interacted', () => {
+				const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+
+				const { rerender } = setupTest(
+					<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={[]} />,
+					{ store }
+				);
+
+				expect(screen.getAllByTestId('icon: Square').length).toBeGreaterThan(0);
+
+				rerender(
+					<MainEditModalTestWrapper
+						folder={folder}
+						totalAppointments={0}
+						grant={[{ gt: SHARE_USER_TYPE.PUBLIC, perm: 'r' }]}
+					/>
+				);
+
+				expect(screen.getByTestId('icon: CheckmarkSquare')).toBeVisible();
+			});
+
+			it('should sync checkbox to unchecked when grant prop removes the public grant and user has not interacted', () => {
+				const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+				const publicGrant: Array<Grant> = [{ gt: SHARE_USER_TYPE.PUBLIC, perm: 'r' }];
+
+				const { rerender } = setupTest(
+					<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={publicGrant} />,
+					{ store }
+				);
+
+				expect(screen.getByTestId('icon: CheckmarkSquare')).toBeVisible();
+
+				rerender(<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={[]} />);
+
+				expect(screen.getAllByTestId('icon: Square').length).toBeGreaterThan(0);
+			});
+
+			it('should not sync when user has already interacted with the checkbox', async () => {
+				const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+
+				const { user, rerender } = setupTest(
+					<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={[]} />,
+					{ store }
+				);
+
+				await user.click(screen.getByText(/share with public/i));
+				expect(screen.getByTestId('icon: CheckmarkSquare')).toBeVisible();
+
+				rerender(<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={[]} />);
+
+				expect(screen.getByTestId('icon: CheckmarkSquare')).toBeVisible();
+			});
+		});
+
 		describe('on OK click', () => {
 			it('should send a GRANT action when checkbox is toggled on for a not-yet-shared calendar', async () => {
 				const spy = vi

--- a/src/actions/modals/edit-modal/parts/tests/main-edit-modal.test.tsx
+++ b/src/actions/modals/edit-modal/parts/tests/main-edit-modal.test.tsx
@@ -8,8 +8,10 @@ import React from 'react';
 import { faker } from '@faker-js/faker';
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import { FOLDER_VIEW, Grant, useFolderStore } from '@zextras/carbonio-ui-commons';
+import * as shell from '@zextras/carbonio-shell-ui';
 
 import { generateFolder } from '../../../../../__test__/mocks/folders/folders-generator';
+import defaultSettings from '../../../../../__test__/mocks/settings/default-settings';
 import { setupTest, screen } from '../../../../../__test__/test-setup';
 import { EditModalContext, EditModalContextType } from '../../../../../commons/edit-modal-context';
 import { SHARE_USER_TYPE } from '../../../../../constants';
@@ -36,10 +38,13 @@ const MainEditModalTestWrapper = (props: MainEditModalProps): React.JSX.Element 
 };
 
 describe('MainEditModal', () => {
+	beforeEach(() => {
+		vi.spyOn(shell, 'useUserSettings').mockReturnValue(defaultSettings);
+	});
+
+	const store = configureStore({ reducer: combineReducers(reducers) });
+
 	it('should render the title', () => {
-		const store = configureStore({
-			reducer: combineReducers(reducers)
-		});
 		const folder = generateFolder({ view: FOLDER_VIEW.appointment });
 		const totalAppointments = faker.number.int({ min: 1, max: 100 });
 		const grant: Array<Grant> = [];
@@ -56,9 +61,6 @@ describe('MainEditModal', () => {
 	});
 
 	it('should not render the public share urls buttons if there is no public access', () => {
-		const store = configureStore({
-			reducer: combineReducers(reducers)
-		});
 		const folder = generateFolder({ view: FOLDER_VIEW.appointment });
 		const totalAppointments = faker.number.int({ min: 1, max: 100 });
 		const grant: Array<Grant> = [];
@@ -76,9 +78,6 @@ describe('MainEditModal', () => {
 	});
 
 	it('should render the public share urls buttons if there is a public access', () => {
-		const store = configureStore({
-			reducer: combineReducers(reducers)
-		});
 		const folder = generateFolder({ view: FOLDER_VIEW.appointment });
 		const totalAppointments = faker.number.int({ min: 1, max: 100 });
 		const grant: Array<Grant> = [
@@ -101,9 +100,6 @@ describe('MainEditModal', () => {
 	});
 
 	it('should disable the name input for caldav child with read-only permissions', () => {
-		const store = configureStore({
-			reducer: combineReducers(reducers)
-		});
 		const parentFolderId = faker.string.uuid();
 		const caldavParentFolder = {
 			...generateFolder({
@@ -144,5 +140,213 @@ describe('MainEditModal', () => {
 		// Check that the name input is disabled
 		const nameInput = screen.getByDisplayValue(caldavChildFolder.name);
 		expect(nameInput).toBeDisabled();
+	});
+
+	describe('Internal sharing section', () => {
+		it('should render the "Internal sharing" header for non-linked folders', () => {
+			const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+			const grant: Array<Grant> = [];
+
+			setupTest(<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={grant} />, {
+				store
+			});
+
+			expect(screen.getByText('Internal sharing')).toBeVisible();
+		});
+
+		it('should not render the "Internal sharing" section for linked folders', () => {
+			const folder = {
+				...generateFolder({ view: FOLDER_VIEW.appointment }),
+				isLink: true as const,
+				owner: 'someone@example.com',
+				reminder: false,
+				broken: false
+			};
+			const grant: Array<Grant> = [];
+
+			setupTest(<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={grant} />, {
+				store
+			});
+
+			expect(screen.queryByText('Internal sharing')).not.toBeInTheDocument();
+		});
+
+		it('should render the "Add share" button next to the "Internal sharing" header', () => {
+			const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+			const grant: Array<Grant> = [];
+
+			setupTest(<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={grant} />, {
+				store
+			});
+
+			expect(screen.getByRole('button', { name: /add share/i })).toBeVisible();
+		});
+
+		it('should call setModal("share") when the "Add share" button is clicked', async () => {
+			const setModal = vi.fn();
+			const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+			const grant: Array<Grant> = [];
+
+			const context = {
+				setModal,
+				onClose: vi.fn(),
+				roleOptions: [],
+				setActiveGrant: vi.fn()
+			} satisfies EditModalContextType;
+
+			const { user } = setupTest(
+				<EditModalContext.Provider value={context}>
+					<MainEditModal folder={folder} totalAppointments={0} grant={grant} />
+				</EditModalContext.Provider>,
+				{ store }
+			);
+
+			await user.click(screen.getByRole('button', { name: /add share/i }));
+
+			expect(setModal).toHaveBeenCalledWith('share');
+		});
+
+		it('should render internal grants in the "Internal sharing" list', () => {
+			const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+			const grant: Array<Grant> = [{ gt: SHARE_USER_TYPE.USER, perm: 'r', d: 'user@example.com' }];
+
+			setupTest(<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={grant} />, {
+				store
+			});
+
+			expect(screen.getByText(/user@example\.com/)).toBeVisible();
+		});
+
+		it('should not render a public grant chip in the "Internal sharing" list', () => {
+			const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+			const grant: Array<Grant> = [{ gt: SHARE_USER_TYPE.PUBLIC, perm: 'r' }];
+
+			setupTest(<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={grant} />, {
+				store
+			});
+
+			// The internal grants list should have no rows (public grant is filtered out)
+			expect(screen.queryByRole('button', { name: /resend/i })).not.toBeInTheDocument();
+		});
+
+		it('should not render "Add share" in the modal footer', () => {
+			const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+			const grant: Array<Grant> = [];
+
+			setupTest(<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={grant} />, {
+				store
+			});
+
+			const footerButtons = screen.getAllByRole('button');
+			const addShareFooterButton = footerButtons.find(
+				(btn) => btn.textContent === 'Add share' && btn.closest('[data-testid="modal-footer"]')
+			);
+			expect(addShareFooterButton).toBeUndefined();
+		});
+	});
+
+	describe('Public sharing section', () => {
+		it('should render when zimbraPublicSharingEnabled is TRUE', () => {
+			const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+			const grant: Array<Grant> = [];
+
+			setupTest(<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={grant} />, {
+				store
+			});
+
+			expect(screen.getByText('Public sharing')).toBeVisible();
+		});
+
+		it('should not render when zimbraPublicSharingEnabled is FALSE', () => {
+			vi.spyOn(shell, 'useUserSettings').mockReturnValue({
+				...defaultSettings,
+				attrs: { ...defaultSettings.attrs, zimbraPublicSharingEnabled: 'FALSE' }
+			});
+
+			const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+			const grant: Array<Grant> = [];
+
+			setupTest(<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={grant} />, {
+				store
+			});
+
+			expect(screen.queryByText('Public sharing')).not.toBeInTheDocument();
+		});
+
+		it('should not render for linked folders', () => {
+			const folder = {
+				...generateFolder({ view: FOLDER_VIEW.appointment }),
+				isLink: true as const,
+				owner: 'someone@example.com',
+				reminder: false,
+				broken: false
+			};
+			const grant: Array<Grant> = [];
+
+			setupTest(<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={grant} />, {
+				store
+			});
+
+			expect(screen.queryByText('Public sharing')).not.toBeInTheDocument();
+		});
+
+		describe('Public sharing checkbox', () => {
+			it('should be checked when calendar is already publicly shared', () => {
+				const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+				const grant: Array<Grant> = [{ gt: SHARE_USER_TYPE.PUBLIC, perm: 'r' }];
+
+				setupTest(
+					<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={grant} />,
+					{ store }
+				);
+
+				expect(screen.getByTestId('icon: CheckmarkSquare')).toBeVisible();
+			});
+
+			it('should be unchecked when calendar is not publicly shared', () => {
+				const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+				const grant: Array<Grant> = [];
+
+				setupTest(
+					<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={grant} />,
+					{ store }
+				);
+
+				const checkboxes = screen.getAllByTestId('icon: Square');
+				expect(checkboxes.length).toBeGreaterThan(0);
+			});
+
+			it('should toggle to checked on click', async () => {
+				const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+				const grant: Array<Grant> = [];
+
+				const { user } = setupTest(
+					<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={grant} />,
+					{ store }
+				);
+
+				const publicCheckboxLabel = screen.getByText(/share with public/i);
+				await user.click(publicCheckboxLabel);
+
+				expect(screen.getByTestId('icon: CheckmarkSquare')).toBeVisible();
+			});
+
+			it('should be hidden when zimbraPublicSharingEnabled is FALSE', () => {
+				vi.spyOn(shell, 'useUserSettings').mockReturnValue({
+					...defaultSettings,
+					attrs: { ...defaultSettings.attrs, zimbraPublicSharingEnabled: 'FALSE' }
+				});
+
+				const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+				const grant: Array<Grant> = [];
+
+				setupTest(
+					<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={grant} />,
+					{ store }
+				);
+
+				expect(screen.queryByText(/share with public/i)).not.toBeInTheDocument();
+			});
+		});
 	});
 });

--- a/src/actions/modals/edit-modal/parts/tests/main-edit-modal.test.tsx
+++ b/src/actions/modals/edit-modal/parts/tests/main-edit-modal.test.tsx
@@ -251,7 +251,9 @@ describe('MainEditModal', () => {
 			});
 
 			expect(
-				within(screen.getByTestId('internalSharingHeader')).getByRole('button', { name: 'Add share' })
+				within(screen.getByTestId('internalSharingHeader')).getByRole('button', {
+					name: 'Add share'
+				})
 			).toBeVisible();
 		});
 	});

--- a/src/actions/modals/edit-modal/parts/tests/main-edit-modal.test.tsx
+++ b/src/actions/modals/edit-modal/parts/tests/main-edit-modal.test.tsx
@@ -184,7 +184,7 @@ describe('MainEditModal', () => {
 			expect(screen.queryByText('Internal sharing')).not.toBeInTheDocument();
 		});
 
-		it('should render the "Add share +" button next to the "Internal sharing" header', () => {
+		it('should render the "Add share" button next to the "Internal sharing" header', () => {
 			const folder = generateFolder({ view: FOLDER_VIEW.appointment });
 			const grant: Array<Grant> = [];
 
@@ -192,10 +192,10 @@ describe('MainEditModal', () => {
 				store
 			});
 
-			expect(screen.getByRole('button', { name: 'Add share +' })).toBeVisible();
+			expect(screen.getByRole('button', { name: 'Add share' })).toBeVisible();
 		});
 
-		it('should call setModal("share") when the "Add share +" button is clicked', async () => {
+		it('should call setModal("share") when the "Add share" button is clicked', async () => {
 			const setModal = vi.fn();
 			const folder = generateFolder({ view: FOLDER_VIEW.appointment });
 			const grant: Array<Grant> = [];
@@ -214,7 +214,7 @@ describe('MainEditModal', () => {
 				{ store }
 			);
 
-			await user.click(screen.getByRole('button', { name: 'Add share +' }));
+			await user.click(screen.getByRole('button', { name: 'Add share' }));
 
 			expect(setModal).toHaveBeenCalledWith('share');
 		});
@@ -242,7 +242,7 @@ describe('MainEditModal', () => {
 			expect(screen.queryByRole('button', { name: /resend/i })).not.toBeInTheDocument();
 		});
 
-		it('should not render "Add share +" in the modal footer', () => {
+		it('should not render "Add share" in the modal footer', () => {
 			const folder = generateFolder({ view: FOLDER_VIEW.appointment });
 			const grant: Array<Grant> = [];
 
@@ -252,7 +252,7 @@ describe('MainEditModal', () => {
 
 			const footerButtons = screen.getAllByRole('button');
 			const addShareFooterButton = footerButtons.find(
-				(btn) => btn.textContent === 'Add share +' && btn.closest('[data-testid="modal-footer"]')
+				(btn) => btn.textContent === 'Add share' && btn.closest('[data-testid="modal-footer"]')
 			);
 			expect(addShareFooterButton).toBeUndefined();
 		});

--- a/src/actions/modals/edit-modal/parts/tests/main-edit-modal.test.tsx
+++ b/src/actions/modals/edit-modal/parts/tests/main-edit-modal.test.tsx
@@ -184,7 +184,7 @@ describe('MainEditModal', () => {
 			expect(screen.queryByText('Internal sharing')).not.toBeInTheDocument();
 		});
 
-		it('should render the "Add share" button next to the "Internal sharing" header', () => {
+		it('should render the "Add share +" button next to the "Internal sharing" header', () => {
 			const folder = generateFolder({ view: FOLDER_VIEW.appointment });
 			const grant: Array<Grant> = [];
 
@@ -192,10 +192,10 @@ describe('MainEditModal', () => {
 				store
 			});
 
-			expect(screen.getByRole('button', { name: /add share/i })).toBeVisible();
+			expect(screen.getByRole('button', { name: 'Add share +' })).toBeVisible();
 		});
 
-		it('should call setModal("share") when the "Add share" button is clicked', async () => {
+		it('should call setModal("share") when the "Add share +" button is clicked', async () => {
 			const setModal = vi.fn();
 			const folder = generateFolder({ view: FOLDER_VIEW.appointment });
 			const grant: Array<Grant> = [];
@@ -214,7 +214,7 @@ describe('MainEditModal', () => {
 				{ store }
 			);
 
-			await user.click(screen.getByRole('button', { name: /add share/i }));
+			await user.click(screen.getByRole('button', { name: 'Add share +' }));
 
 			expect(setModal).toHaveBeenCalledWith('share');
 		});
@@ -242,7 +242,7 @@ describe('MainEditModal', () => {
 			expect(screen.queryByRole('button', { name: /resend/i })).not.toBeInTheDocument();
 		});
 
-		it('should not render "Add share" in the modal footer', () => {
+		it('should not render "Add share +" in the modal footer', () => {
 			const folder = generateFolder({ view: FOLDER_VIEW.appointment });
 			const grant: Array<Grant> = [];
 
@@ -252,7 +252,7 @@ describe('MainEditModal', () => {
 
 			const footerButtons = screen.getAllByRole('button');
 			const addShareFooterButton = footerButtons.find(
-				(btn) => btn.textContent === 'Add share' && btn.closest('[data-testid="modal-footer"]')
+				(btn) => btn.textContent === 'Add share +' && btn.closest('[data-testid="modal-footer"]')
 			);
 			expect(addShareFooterButton).toBeUndefined();
 		});

--- a/src/actions/modals/edit-modal/parts/tests/main-edit-modal.test.tsx
+++ b/src/actions/modals/edit-modal/parts/tests/main-edit-modal.test.tsx
@@ -7,15 +7,15 @@ import React from 'react';
 
 import { faker } from '@faker-js/faker';
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
-import { FOLDER_VIEW, Grant, useFolderStore } from '@zextras/carbonio-ui-commons';
 import * as shell from '@zextras/carbonio-shell-ui';
+import { FOLDER_VIEW, Grant, useFolderStore } from '@zextras/carbonio-ui-commons';
 
 import { generateFolder } from '../../../../../__test__/mocks/folders/folders-generator';
 import defaultSettings from '../../../../../__test__/mocks/settings/default-settings';
 import { setupTest, screen } from '../../../../../__test__/test-setup';
 import { EditModalContext, EditModalContextType } from '../../../../../commons/edit-modal-context';
-import { FOLDER_OPERATIONS } from '../../../../../constants/api';
 import { PUBLIC_SHARE_ZID, SHARE_USER_TYPE } from '../../../../../constants';
+import { FOLDER_OPERATIONS } from '../../../../../constants/api';
 import * as FolderAction from '../../../../../soap/folder-action-request';
 import { reducers } from '../../../../../store/redux';
 import { MainEditModal, MainEditModalProps } from '../main-edit-modal';
@@ -62,7 +62,7 @@ describe('MainEditModal', () => {
 		expect(screen.getByText('Edit and share calendar')).toBeVisible();
 	});
 
-	it('should not render the public share urls buttons if there is no public access', () => {
+	it('should not render the URL buttons if there is no public access', () => {
 		const folder = generateFolder({ view: FOLDER_VIEW.appointment });
 		const totalAppointments = faker.number.int({ min: 1, max: 100 });
 		const grant: Array<Grant> = [];
@@ -76,18 +76,15 @@ describe('MainEditModal', () => {
 			{ store }
 		);
 
-		expect(screen.queryByText('Public share URLS')).not.toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: /ICS URL/i })).not.toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: /WebCAL URL/i })).not.toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: /CalDAV URL/i })).not.toBeInTheDocument();
 	});
 
-	it('should render the public share urls buttons if there is a public access', () => {
+	it('should render all three URL buttons and the note text when there is a public access', () => {
 		const folder = generateFolder({ view: FOLDER_VIEW.appointment });
 		const totalAppointments = faker.number.int({ min: 1, max: 100 });
-		const grant: Array<Grant> = [
-			{
-				gt: SHARE_USER_TYPE.PUBLIC,
-				perm: 'r'
-			}
-		];
+		const grant: Array<Grant> = [{ gt: SHARE_USER_TYPE.PUBLIC, perm: 'r' }];
 
 		setupTest(
 			<MainEditModalTestWrapper
@@ -98,7 +95,21 @@ describe('MainEditModal', () => {
 			{ store }
 		);
 
-		expect(screen.getByText('Public share URLS')).toBeVisible();
+		expect(screen.getByRole('button', { name: /ICS URL/i })).toBeVisible();
+		expect(screen.getByRole('button', { name: /WebCAL URL/i })).toBeVisible();
+		expect(screen.getByRole('button', { name: /CalDAV URL/i })).toBeVisible();
+		expect(screen.getByText('Anyone with these links can view your calendar.')).toBeVisible();
+	});
+
+	it('should not render the old "Public share URLS" heading within the public sharing section', () => {
+		const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+		const grant: Array<Grant> = [{ gt: SHARE_USER_TYPE.PUBLIC, perm: 'r' }];
+
+		setupTest(<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={grant} />, {
+			store
+		});
+
+		expect(screen.queryByText('Public share URLS')).not.toBeInTheDocument();
 	});
 
 	it('should disable the name input for caldav child with read-only permissions', () => {
@@ -352,7 +363,7 @@ describe('MainEditModal', () => {
 		});
 
 		describe('Public share URLs', () => {
-			it('should show URLs immediately when checkbox is checked, before saving', async () => {
+			it('should show all URL buttons and note text immediately when checkbox is checked, before saving', async () => {
 				const folder = generateFolder({ view: FOLDER_VIEW.appointment });
 				const grant: Array<Grant> = [];
 
@@ -361,14 +372,17 @@ describe('MainEditModal', () => {
 					{ store }
 				);
 
-				expect(screen.queryByText('Public share URLS')).not.toBeInTheDocument();
+				expect(screen.queryByRole('button', { name: /ICS URL/i })).not.toBeInTheDocument();
 
 				await user.click(screen.getByText(/share with public/i));
 
-				expect(screen.getByText('Public share URLS')).toBeVisible();
+				expect(screen.getByRole('button', { name: /ICS URL/i })).toBeVisible();
+				expect(screen.getByRole('button', { name: /WebCAL URL/i })).toBeVisible();
+				expect(screen.getByRole('button', { name: /CalDAV URL/i })).toBeVisible();
+				expect(screen.getByText('Anyone with these links can view your calendar.')).toBeVisible();
 			});
 
-			it('should hide URLs when checkbox is unchecked', async () => {
+			it('should hide all URL buttons when checkbox is unchecked', async () => {
 				const folder = generateFolder({ view: FOLDER_VIEW.appointment });
 				const grant: Array<Grant> = [{ gt: SHARE_USER_TYPE.PUBLIC, perm: 'r' }];
 
@@ -377,11 +391,13 @@ describe('MainEditModal', () => {
 					{ store }
 				);
 
-				expect(screen.getByText('Public share URLS')).toBeVisible();
+				expect(screen.getByRole('button', { name: /ICS URL/i })).toBeVisible();
 
 				await user.click(screen.getByText(/share with public/i));
 
-				expect(screen.queryByText('Public share URLS')).not.toBeInTheDocument();
+				expect(screen.queryByRole('button', { name: /ICS URL/i })).not.toBeInTheDocument();
+				expect(screen.queryByRole('button', { name: /WebCAL URL/i })).not.toBeInTheDocument();
+				expect(screen.queryByRole('button', { name: /CalDAV URL/i })).not.toBeInTheDocument();
 			});
 		});
 
@@ -442,9 +458,7 @@ describe('MainEditModal', () => {
 
 		describe('on OK click', () => {
 			it('should send a GRANT action when checkbox is toggled on for a not-yet-shared calendar', async () => {
-				const spy = vi
-					.spyOn(FolderAction, 'folderActionRequest')
-					.mockResolvedValue({});
+				const spy = vi.spyOn(FolderAction, 'folderActionRequest').mockResolvedValue({});
 				const folder = generateFolder({ view: FOLDER_VIEW.appointment });
 				const grant: Array<Grant> = [];
 
@@ -466,9 +480,7 @@ describe('MainEditModal', () => {
 			});
 
 			it('should send a REVOKE_GRANT action when checkbox is toggled off for an already-shared calendar', async () => {
-				const spy = vi
-					.spyOn(FolderAction, 'folderActionRequest')
-					.mockResolvedValue({});
+				const spy = vi.spyOn(FolderAction, 'folderActionRequest').mockResolvedValue({});
 				const folder = generateFolder({ view: FOLDER_VIEW.appointment });
 				const grant: Array<Grant> = [{ gt: SHARE_USER_TYPE.PUBLIC, perm: 'r' }];
 
@@ -490,9 +502,7 @@ describe('MainEditModal', () => {
 			});
 
 			it('should not send any public sharing action when checkbox state is unchanged', async () => {
-				const spy = vi
-					.spyOn(FolderAction, 'folderActionRequest')
-					.mockResolvedValue({});
+				const spy = vi.spyOn(FolderAction, 'folderActionRequest').mockResolvedValue({});
 				const folder = generateFolder({ view: FOLDER_VIEW.appointment });
 				const grant: Array<Grant> = [];
 

--- a/src/actions/modals/edit-modal/parts/tests/main-edit-modal.test.tsx
+++ b/src/actions/modals/edit-modal/parts/tests/main-edit-modal.test.tsx
@@ -12,7 +12,7 @@ import { FOLDER_VIEW, Grant, useFolderStore } from '@zextras/carbonio-ui-commons
 
 import { generateFolder } from '../../../../../__test__/mocks/folders/folders-generator';
 import defaultSettings from '../../../../../__test__/mocks/settings/default-settings';
-import { setupTest, screen } from '../../../../../__test__/test-setup';
+import { setupTest, screen, within } from '../../../../../__test__/test-setup';
 import { EditModalContext, EditModalContextType } from '../../../../../commons/edit-modal-context';
 import { PUBLIC_SHARE_ZID, SHARE_USER_TYPE } from '../../../../../constants';
 import { FOLDER_OPERATIONS } from '../../../../../constants/api';
@@ -242,7 +242,7 @@ describe('MainEditModal', () => {
 			expect(screen.queryByRole('button', { name: /resend/i })).not.toBeInTheDocument();
 		});
 
-		it('should not render "Add share" in the modal footer', () => {
+		it('should render the "Add share" button inside the internal sharing header', () => {
 			const folder = generateFolder({ view: FOLDER_VIEW.appointment });
 			const grant: Array<Grant> = [];
 
@@ -250,11 +250,9 @@ describe('MainEditModal', () => {
 				store
 			});
 
-			const footerButtons = screen.getAllByRole('button');
-			const addShareFooterButton = footerButtons.find(
-				(btn) => btn.textContent === 'Add share' && btn.closest('[data-testid="modal-footer"]')
-			);
-			expect(addShareFooterButton).toBeUndefined();
+			expect(
+				within(screen.getByTestId('internalSharingHeader')).getByRole('button', { name: 'Add share' })
+			).toBeVisible();
 		});
 	});
 

--- a/src/actions/modals/edit-modal/parts/tests/main-edit-modal.test.tsx
+++ b/src/actions/modals/edit-modal/parts/tests/main-edit-modal.test.tsx
@@ -14,7 +14,9 @@ import { generateFolder } from '../../../../../__test__/mocks/folders/folders-ge
 import defaultSettings from '../../../../../__test__/mocks/settings/default-settings';
 import { setupTest, screen } from '../../../../../__test__/test-setup';
 import { EditModalContext, EditModalContextType } from '../../../../../commons/edit-modal-context';
-import { SHARE_USER_TYPE } from '../../../../../constants';
+import { FOLDER_OPERATIONS } from '../../../../../constants/api';
+import { PUBLIC_SHARE_ZID, SHARE_USER_TYPE } from '../../../../../constants';
+import * as FolderAction from '../../../../../soap/folder-action-request';
 import { reducers } from '../../../../../store/redux';
 import { MainEditModal, MainEditModalProps } from '../main-edit-modal';
 
@@ -346,6 +348,73 @@ describe('MainEditModal', () => {
 				);
 
 				expect(screen.queryByText(/share with public/i)).not.toBeInTheDocument();
+			});
+		});
+
+		describe('on OK click', () => {
+			it('should send a GRANT action when checkbox is toggled on for a not-yet-shared calendar', async () => {
+				const spy = vi
+					.spyOn(FolderAction, 'folderActionRequest')
+					.mockResolvedValue({});
+				const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+				const grant: Array<Grant> = [];
+
+				const { user } = setupTest(
+					<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={grant} />,
+					{ store }
+				);
+
+				await user.click(screen.getByText(/share with public/i));
+				await user.click(screen.getByText('OK'));
+
+				expect(spy).toHaveBeenCalledWith(
+					expect.objectContaining({
+						op: FOLDER_OPERATIONS.GRANT,
+						id: folder.id,
+						grant: [{ gt: SHARE_USER_TYPE.PUBLIC, perm: 'r', pw: '' }]
+					})
+				);
+			});
+
+			it('should send a REVOKE_GRANT action when checkbox is toggled off for an already-shared calendar', async () => {
+				const spy = vi
+					.spyOn(FolderAction, 'folderActionRequest')
+					.mockResolvedValue({});
+				const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+				const grant: Array<Grant> = [{ gt: SHARE_USER_TYPE.PUBLIC, perm: 'r' }];
+
+				const { user } = setupTest(
+					<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={grant} />,
+					{ store }
+				);
+
+				await user.click(screen.getByText(/share with public/i));
+				await user.click(screen.getByText('OK'));
+
+				expect(spy).toHaveBeenCalledWith(
+					expect.objectContaining({
+						op: FOLDER_OPERATIONS.REVOKE_GRANT,
+						id: folder.id,
+						zid: PUBLIC_SHARE_ZID
+					})
+				);
+			});
+
+			it('should not send any public sharing action when checkbox state is unchanged', async () => {
+				const spy = vi
+					.spyOn(FolderAction, 'folderActionRequest')
+					.mockResolvedValue({});
+				const folder = generateFolder({ view: FOLDER_VIEW.appointment });
+				const grant: Array<Grant> = [];
+
+				const { user } = setupTest(
+					<MainEditModalTestWrapper folder={folder} totalAppointments={0} grant={grant} />,
+					{ store }
+				);
+
+				await user.click(screen.getByText('OK'));
+
+				expect(spy).not.toHaveBeenCalled();
 			});
 		});
 	});

--- a/src/actions/modals/edit-modal/parts/tests/share-calendar-urls.test.tsx
+++ b/src/actions/modals/edit-modal/parts/tests/share-calendar-urls.test.tsx
@@ -48,7 +48,7 @@ vi.mock('@zextras/carbonio-ui-commons', async () => {
 });
 
 describe('ShareCalendarUrl', () => {
-describe.each(BUTTONS)('$label url button', ({ label, type, tooltip }) => {
+	describe.each(BUTTONS)('$label url button', ({ label, type, tooltip }) => {
 		it('should be rendered with the proper label and icon', () => {
 			const calendarName = faker.word.words(3);
 

--- a/src/actions/modals/edit-modal/parts/tests/share-calendar-urls.test.tsx
+++ b/src/actions/modals/edit-modal/parts/tests/share-calendar-urls.test.tsx
@@ -48,36 +48,7 @@ vi.mock('@zextras/carbonio-ui-commons', async () => {
 });
 
 describe('ShareCalendarUrl', () => {
-	it('should render the title', () => {
-		const calendarName = faker.word.words(3);
-
-		setupTest(<ShareCalendarUrls calendarName={calendarName} />);
-
-		expect(screen.getByText(/Public share URLs/i)).toBeVisible();
-	});
-
-	it('should render the text under the title', () => {
-		const calendarName = faker.word.words(3);
-
-		setupTest(<ShareCalendarUrls calendarName={calendarName} />);
-
-		expect(
-			screen.getByText(
-				`You can quickly share ${calendarName} with your collaborators using one of these URLs:`
-			)
-		).toBeVisible();
-	});
-
-	it('should render the note text', () => {
-		const calendarName = faker.word.words(3);
-
-		setupTest(<ShareCalendarUrls calendarName={calendarName} />);
-		expect(
-			screen.getByText('Only your collaborators can access your data using these URLs.')
-		).toBeVisible();
-	});
-
-	describe.each(BUTTONS)('$label url button', ({ label, type, tooltip }) => {
+describe.each(BUTTONS)('$label url button', ({ label, type, tooltip }) => {
 		it('should be rendered with the proper label and icon', () => {
 			const calendarName = faker.word.words(3);
 

--- a/src/actions/modals/share-calendar-modal.test.tsx
+++ b/src/actions/modals/share-calendar-modal.test.tsx
@@ -392,28 +392,6 @@ describe('Shared Calendar modal', () => {
 
 			expect(shareNotes).toBeVisible();
 		});
-		test('shows the "add and close" info sentence with an icon', () => {
-			const closeFn = vi.fn();
-			const grant = [
-				{
-					zid: '1',
-					gt: 'usr',
-					perm: 'r'
-				} as const
-			];
-
-			setupTest(<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />, {
-				store
-			});
-
-			const infoContainer = screen.getByTestId('addAndCloseInfoContainer');
-			expect(
-				within(infoContainer).getByText(
-					/By clicking on "Add and close", you'll return to the calendar view\./i
-				)
-			).toBeVisible();
-			expect(within(infoContainer).getByTestId('icon: InfoOutline')).toBeVisible();
-		});
 	});
 	describe('Modal footer', () => {
 		it('should have the confirm button disabled when the user did not interact with the modal', async () => {

--- a/src/actions/modals/share-calendar-modal.test.tsx
+++ b/src/actions/modals/share-calendar-modal.test.tsx
@@ -30,7 +30,7 @@ describe('Shared Calendar modal', () => {
 	const store = configureStore({ reducer: combineReducers(reducers) });
 
 	describe('Modal header', () => {
-		it('should display the title "Share" followed by the calendar name', () => {
+		it('should display the title "Add internal share"', () => {
 			const closeFn = vi.fn();
 			const grant = [
 				{
@@ -40,17 +40,10 @@ describe('Shared Calendar modal', () => {
 				} as const
 			];
 
-			const title = 'testName';
-			setupTest(
-				<ShareCalendarModal
-					folderName={title}
-					folderId={'testId1'}
-					closeFn={closeFn}
-					grant={grant}
-				/>,
-				{ store }
-			);
-			expect(screen.getByText(`Share ${title}`)).toBeVisible();
+			setupTest(<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />, {
+				store
+			});
+			expect(screen.getByText('Add internal share')).toBeVisible();
 		});
 		it('should display the close button and on click will call the modal onclose', async () => {
 			const closeFn = vi.fn();
@@ -78,104 +71,9 @@ describe('Shared Calendar modal', () => {
 		});
 	});
 	describe('Modal body', () => {
-		describe('the field to enable user to share to public', () => {
-			it('is checked by default if user shared already the calendar to public', () => {
-				const closeFn = vi.fn();
-				const grant = [
-					{
-						gt: SHARE_USER_TYPE.PUBLIC,
-						inh: '1',
-						perm: 'r',
-						pw: ''
-					} as const
-				];
-
-				setupTest(
-					<ShareCalendarModal
-						folderName={'testName'}
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
-					{ store }
-				);
-
-				const checkedPublicShare = within(
-					screen.getByTestId('publicShareCheckboxContainer')
-				).getByTestId(checkedIcon);
-
-				expect(checkedPublicShare).toBeVisible();
-			});
-			it('is not checked by default if the calendar is not shared with public', () => {
-				const closeFn = vi.fn();
-				const grant = [
-					{
-						zid: '1',
-						gt: 'usr',
-						perm: 'r'
-					} as const
-				];
-
-				setupTest(
-					<ShareCalendarModal
-						folderName={'testName'}
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
-					{ store }
-				);
-
-				const uncheckedPublicShare = within(
-					screen.getByTestId('publicShareCheckboxContainer')
-				).getByTestId('icon: Square');
-
-				expect(uncheckedPublicShare).toBeVisible();
-			});
-			test('checked on click', async () => {
-				const closeFn = vi.fn();
-				const grant = [
-					{
-						zid: '1',
-						gt: 'usr',
-						perm: 'r'
-					} as const
-				];
-
-				const { user } = setupTest(
-					<ShareCalendarModal
-						folderName={'testName'}
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
-					{ store }
-				);
-
-				const uncheckedPublicShare = within(
-					screen.getByTestId('publicShareCheckboxContainer')
-				).getByTestId('icon: Square');
-
-				await user.click(uncheckedPublicShare);
-
-				const checkedPublicShare = within(
-					screen.getByTestId('publicShareCheckboxContainer')
-				).getByTestId(checkedIcon);
-
-				expect(checkedPublicShare).toBeVisible();
-			});
-		});
-		test('when zimbraPublicSharingEnabled is FALSE the option "public" is not displayed', async () => {
-			vi.spyOn(shell, 'useUserSettings').mockReturnValue({
-				...defaultSettings,
-				attrs: { zimbraPublicSharingEnabled: 'FALSE' }
-			});
-
-			setupTest(<ShareCalendarModal folderName={'testName'} folderId={'testId1'} />, { store });
-
-			const publicShareSection = screen.queryByTestId('publicShareCheckboxContainer');
-
-			expect(publicShareSection).not.toBeInTheDocument();
+		it('should not render the public share section', () => {
+			setupTest(<ShareCalendarModal folderId={'testId1'} />, { store });
+			expect(screen.queryByTestId('publicShareCheckboxContainer')).not.toBeInTheDocument();
 		});
 		it('should render every component', async () => {
 			const closeFn = vi.fn();
@@ -573,36 +471,6 @@ describe('Shared Calendar modal', () => {
 		});
 	});
 	describe('Modal footer', () => {
-		it('should have the confirm button enabled when share publicly checkbox is clicked', async () => {
-			const closeFn = vi.fn();
-			const grant = [
-				{
-					zid: '1',
-					gt: 'usr',
-					perm: 'r'
-				} as const
-			];
-
-			const { user } = setupTest(
-				<ShareCalendarModal
-					folderName={'testName'}
-					folderId={'testId1'}
-					closeFn={closeFn}
-					grant={grant}
-				/>,
-				{ store }
-			);
-
-			const uncheckedPublicShare = within(
-				screen.getByTestId('publicShareCheckboxContainer')
-			).getByTestId('icon: Square');
-
-			await user.click(uncheckedPublicShare);
-
-			const confirmButton = screen.getByText(/Confirm/i);
-
-			expect(confirmButton).toBeEnabled();
-		});
 		it('should have the confirm button disabled when the user did not interact with the modal', async () => {
 			const closeFn = vi.fn();
 			const grant = [
@@ -665,39 +533,6 @@ describe('Shared Calendar modal', () => {
 				await act(async () => {
 					await vi.advanceTimersToNextTimerAsync();
 				});
-			});
-			test('when public is checked it will trigger a grant operation with grant type public', async () => {
-				const spy = vi.spyOn(FolderAction, 'folderActionRequest');
-				const closeFn = vi.fn();
-				const grant: Grant[] | undefined = [];
-
-				const { user } = setupTest(
-					<ShareCalendarModal
-						folderName={'testName'}
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
-					{ store }
-				);
-
-				const uncheckedPublicShare = within(
-					screen.getByTestId('publicShareCheckboxContainer')
-				).getByTestId('icon: Square');
-
-				await user.click(uncheckedPublicShare);
-
-				const confirmButton = screen.getByText(/Confirm/i);
-
-				await user.click(confirmButton);
-
-				expect(spy).toHaveBeenCalledTimes(1);
-				expect(spy).toHaveBeenCalledWith(
-					expect.objectContaining({
-						grant: [expect.objectContaining({ gt: SHARE_USER_TYPE.PUBLIC })],
-						op: FOLDER_OPERATIONS.GRANT
-					})
-				);
 			});
 			test('when a chip is added it will trigger a grant operation with grant type user', async () => {
 				const spy = vi.spyOn(FolderAction, 'folderActionRequest');

--- a/src/actions/modals/share-calendar-modal.test.tsx
+++ b/src/actions/modals/share-calendar-modal.test.tsx
@@ -55,11 +55,7 @@ describe('Shared Calendar modal', () => {
 				} as const
 			];
 			const { user } = setupTest(
-				<ShareCalendarModal
-					folderId={'testId1'}
-					closeFn={closeFn}
-					grant={grant}
-				/>,
+				<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />,
 				{ store }
 			);
 			const closeBtn = within(screen.getByTestId('ShareCalendarModal')).getByTestId('icon: Close');
@@ -84,14 +80,9 @@ describe('Shared Calendar modal', () => {
 				} as const
 			];
 
-			setupTest(
-				<ShareCalendarModal
-					folderId={'testId1'}
-					closeFn={closeFn}
-					grant={grant}
-				/>,
-				{ store }
-			);
+			setupTest(<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />, {
+				store
+			});
 
 			const chipInput = screen.getByRole('textbox', {
 				name: /Recipients e-mail addresses/i
@@ -122,14 +113,9 @@ describe('Shared Calendar modal', () => {
 				} as const
 			];
 
-			setupTest(
-				<ShareCalendarModal
-					folderId={'testId1'}
-					closeFn={closeFn}
-					grant={grant}
-				/>,
-				{ store }
-			);
+			setupTest(<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />, {
+				store
+			});
 			const chipInput = screen.getByRole('textbox', {
 				name: /Recipients e-mail addresses/i
 			});
@@ -147,14 +133,9 @@ describe('Shared Calendar modal', () => {
 					} as const
 				];
 
-				setupTest(
-					<ShareCalendarModal
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
-					{ store }
-				);
+				setupTest(<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />, {
+					store
+				});
 
 				const uncheckedPrivate = within(screen.getByTestId('privateCheckboxContainer')).getByTestId(
 					'icon: Square'
@@ -173,11 +154,7 @@ describe('Shared Calendar modal', () => {
 				];
 
 				const { user } = setupTest(
-					<ShareCalendarModal
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
+					<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />,
 					{ store }
 				);
 
@@ -204,11 +181,7 @@ describe('Shared Calendar modal', () => {
 				];
 
 				const { user } = setupTest(
-					<ShareCalendarModal
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
+					<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />,
 					{ store }
 				);
 				const infoPrivateCheckbox = screen.getByTestId('icon: InfoOutline');
@@ -233,14 +206,9 @@ describe('Shared Calendar modal', () => {
 					} as const
 				];
 
-				setupTest(
-					<ShareCalendarModal
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
-					{ store }
-				);
+				setupTest(<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />, {
+					store
+				});
 				expect(screen.getByText(/viewer/i)).toBeVisible();
 			});
 			test('the select has 4 options', async () => {
@@ -254,11 +222,7 @@ describe('Shared Calendar modal', () => {
 				];
 
 				const { user } = setupTest(
-					<ShareCalendarModal
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
+					<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />,
 					{ store }
 				);
 
@@ -300,14 +264,9 @@ describe('Shared Calendar modal', () => {
 					} as const
 				];
 
-				setupTest(
-					<ShareCalendarModal
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
-					{ store }
-				);
+				setupTest(<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />, {
+					store
+				});
 
 				const sendNotificationCheckbox = within(
 					screen.getByTestId('sendNotificationCheckboxContainer')
@@ -325,14 +284,9 @@ describe('Shared Calendar modal', () => {
 					} as const
 				];
 
-				setupTest(
-					<ShareCalendarModal
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
-					{ store }
-				);
+				setupTest(<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />, {
+					store
+				});
 
 				const sendNotificationCheckbox = within(
 					screen.getByTestId('sendNotificationCheckboxContainer')
@@ -358,11 +312,7 @@ describe('Shared Calendar modal', () => {
 				];
 
 				const { user } = setupTest(
-					<ShareCalendarModal
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
+					<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />,
 					{ store }
 				);
 
@@ -391,14 +341,9 @@ describe('Shared Calendar modal', () => {
 					} as const
 				];
 
-				setupTest(
-					<ShareCalendarModal
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
-					{ store }
-				);
+				setupTest(<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />, {
+					store
+				});
 
 				const standardMessage = screen.getByRole('textbox', {
 					name: /Add a note to standard message/i
@@ -416,14 +361,9 @@ describe('Shared Calendar modal', () => {
 					} as const
 				];
 
-				setupTest(
-					<ShareCalendarModal
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
-					{ store }
-				);
+				setupTest(<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />, {
+					store
+				});
 
 				const standardMessage = screen.getByRole('textbox', {
 					name: /Add a note to standard message/i
@@ -442,14 +382,9 @@ describe('Shared Calendar modal', () => {
 				} as const
 			];
 
-			setupTest(
-				<ShareCalendarModal
-					folderId={'testId1'}
-					closeFn={closeFn}
-					grant={grant}
-				/>,
-				{ store }
-			);
+			setupTest(<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />, {
+				store
+			});
 
 			const shareNotes = screen.getByText(/note:/i);
 
@@ -467,14 +402,9 @@ describe('Shared Calendar modal', () => {
 				} as const
 			];
 
-			setupTest(
-				<ShareCalendarModal
-					folderId={'testId1'}
-					closeFn={closeFn}
-					grant={grant}
-				/>,
-				{ store }
-			);
+			setupTest(<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />, {
+				store
+			});
 
 			const confirmButton = screen.getByText(/Confirm/i);
 
@@ -491,11 +421,7 @@ describe('Shared Calendar modal', () => {
 			];
 
 			const { user } = setupTest(
-				<ShareCalendarModal
-					folderId={'testId1'}
-					closeFn={closeFn}
-					grant={grant}
-				/>,
+				<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />,
 				{ store }
 			);
 			const chipInput = screen.getByRole('textbox', {
@@ -524,11 +450,7 @@ describe('Shared Calendar modal', () => {
 				const grant: Grant[] | undefined = [];
 
 				const { user } = setupTest(
-					<ShareCalendarModal
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
+					<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />,
 					{ store }
 				);
 
@@ -561,11 +483,7 @@ describe('Shared Calendar modal', () => {
 				const grant: Grant[] | undefined = [];
 
 				const { user } = setupTest(
-					<ShareCalendarModal
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
+					<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />,
 					{ store }
 				);
 
@@ -598,11 +516,7 @@ describe('Shared Calendar modal', () => {
 				const grant: Grant[] | undefined = [];
 
 				const { user } = setupTest(
-					<ShareCalendarModal
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
+					<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />,
 					{ store }
 				);
 
@@ -639,11 +553,7 @@ describe('Shared Calendar modal', () => {
 				const grant: Grant[] | undefined = [];
 
 				const { user } = setupTest(
-					<ShareCalendarModal
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
+					<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />,
 					{ store }
 				);
 
@@ -680,11 +590,7 @@ describe('Shared Calendar modal', () => {
 				const grant: Grant[] | undefined = [];
 
 				const { user } = setupTest(
-					<ShareCalendarModal
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
+					<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />,
 					{ store }
 				);
 
@@ -721,11 +627,7 @@ describe('Shared Calendar modal', () => {
 				const grant: Grant[] | undefined = [];
 
 				const { user } = setupTest(
-					<ShareCalendarModal
-						folderId={'testId1'}
-						closeFn={closeFn}
-						grant={grant}
-					/>,
+					<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />,
 					{ store }
 				);
 
@@ -763,11 +665,7 @@ describe('Shared Calendar modal', () => {
 					const grant: Grant[] | undefined = [];
 
 					const { user } = setupTest(
-						<ShareCalendarModal
-							folderId={'testId1'}
-							closeFn={closeFn}
-							grant={grant}
-						/>,
+						<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />,
 						{ store }
 					);
 					const chipInput = screen.getByRole('textbox', {
@@ -792,11 +690,7 @@ describe('Shared Calendar modal', () => {
 					const grant: Grant[] | undefined = [];
 
 					const { user } = setupTest(
-						<ShareCalendarModal
-							folderId={'testId1'}
-							closeFn={closeFn}
-							grant={grant}
-						/>,
+						<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />,
 						{ store }
 					);
 					const chipInput = screen.getByRole('textbox', {

--- a/src/actions/modals/share-calendar-modal.test.tsx
+++ b/src/actions/modals/share-calendar-modal.test.tsx
@@ -406,7 +406,7 @@ describe('Shared Calendar modal', () => {
 				store
 			});
 
-			const confirmButton = screen.getByText(/Confirm/i);
+			const confirmButton = screen.getByText(/Add and close/i);
 
 			expect(confirmButton).toBeEnabled();
 		});
@@ -427,7 +427,7 @@ describe('Shared Calendar modal', () => {
 			const chipInput = screen.getByRole('textbox', {
 				name: /Recipients e-mail addresses/i
 			});
-			const confirmButton = screen.getByText(/Confirm/i);
+			const confirmButton = screen.getByText(/Add and close/i);
 
 			await user.type(chipInput, 'ale@test.com');
 			await user.tab();
@@ -461,7 +461,7 @@ describe('Shared Calendar modal', () => {
 				await user.type(chipInput, 'user1@email.it');
 				await user.tab();
 
-				const confirmButton = screen.getByText(/Confirm/i);
+				const confirmButton = screen.getByText(/Add and close/i);
 
 				expect(confirmButton).toBeEnabled();
 
@@ -499,7 +499,7 @@ describe('Shared Calendar modal', () => {
 
 				await user.click(privateCheckbox);
 
-				const confirmButton = screen.getByText(/Confirm/i);
+				const confirmButton = screen.getByText(/Add and close/i);
 
 				await user.click(confirmButton);
 
@@ -536,7 +536,7 @@ describe('Shared Calendar modal', () => {
 
 				await user.click(noPermissionRoleOption);
 
-				const confirmButton = screen.getByText(/Confirm/i);
+				const confirmButton = screen.getByText(/Add and close/i);
 
 				await user.click(confirmButton);
 
@@ -573,7 +573,7 @@ describe('Shared Calendar modal', () => {
 
 				await user.click(viewerRoleOption);
 
-				const confirmButton = screen.getByText(/Confirm/i);
+				const confirmButton = screen.getByText(/Add and close/i);
 
 				await user.click(confirmButton);
 
@@ -610,7 +610,7 @@ describe('Shared Calendar modal', () => {
 
 				await user.click(adminRoleOption);
 
-				const confirmButton = screen.getByText(/Confirm/i);
+				const confirmButton = screen.getByText(/Add and close/i);
 
 				await user.click(confirmButton);
 
@@ -647,7 +647,7 @@ describe('Shared Calendar modal', () => {
 
 				await user.click(managerRoleOption);
 
-				const confirmButton = screen.getByText(/Confirm/i);
+				const confirmButton = screen.getByText(/Add and close/i);
 
 				await user.click(confirmButton);
 
@@ -657,6 +657,60 @@ describe('Shared Calendar modal', () => {
 						grant: [expect.objectContaining({ perm: 'rwidx' })]
 					})
 				);
+			});
+			describe('snackbar feedback', () => {
+				test('shows a success snackbar when the folder action succeeds', async () => {
+					vi.spyOn(FolderAction, 'folderActionRequest').mockResolvedValue({});
+					const closeFn = vi.fn();
+					const grant: Grant[] | undefined = [];
+
+					const { user } = setupTest(
+						<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />,
+						{ store }
+					);
+
+					const chipInput = screen.getByRole('textbox', {
+						name: /Recipients e-mail addresses/i
+					});
+					await user.type(chipInput, 'user1@email.it');
+					await user.tab();
+
+					const confirmButton = screen.getByRole('button', { name: /Add and close/i });
+					await act(async () => {
+						await user.click(confirmButton);
+					});
+
+					await waitFor(() => {
+						expect(screen.getByText('Calendar shared successfully')).toBeVisible();
+					});
+				});
+				test('shows an error snackbar when the folder action fails', async () => {
+					vi.spyOn(FolderAction, 'folderActionRequest').mockResolvedValue({
+						Fault: { Detail: { Error: { Code: 'service.FAILURE' } } }
+					});
+					const closeFn = vi.fn();
+					const grant: Grant[] | undefined = [];
+
+					const { user } = setupTest(
+						<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />,
+						{ store }
+					);
+
+					const chipInput = screen.getByRole('textbox', {
+						name: /Recipients e-mail addresses/i
+					});
+					await user.type(chipInput, 'user1@email.it');
+					await user.tab();
+
+					const confirmButton = screen.getByRole('button', { name: /Add and close/i });
+					await act(async () => {
+						await user.click(confirmButton);
+					});
+
+					await waitFor(() => {
+						expect(screen.getByText('Something went wrong, please try again')).toBeVisible();
+					});
+				});
 			});
 			describe('if send notification about this share is checked', () => {
 				test('it will send a share notification to recipients', async () => {
@@ -674,7 +728,7 @@ describe('Shared Calendar modal', () => {
 					await user.type(chipInput, 'user1@email.it');
 					await user.tab();
 
-					const confirmButton = screen.getByRole('button', { name: /Confirm/i });
+					const confirmButton = screen.getByRole('button', { name: /Add and close/i });
 					await user.click(confirmButton);
 
 					await waitFor(() => {
@@ -702,7 +756,7 @@ describe('Shared Calendar modal', () => {
 					});
 					const customMessage = 'custom Message';
 					await user.type(standardMessage, customMessage);
-					const confirmButton = screen.getByRole('button', { name: /Confirm/i });
+					const confirmButton = screen.getByRole('button', { name: /Add and close/i });
 					expect(confirmButton).toBeEnabled();
 					await user.click(confirmButton);
 

--- a/src/actions/modals/share-calendar-modal.test.tsx
+++ b/src/actions/modals/share-calendar-modal.test.tsx
@@ -184,7 +184,9 @@ describe('Shared Calendar modal', () => {
 					<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />,
 					{ store }
 				);
-				const infoPrivateCheckbox = screen.getByTestId('icon: InfoOutline');
+				const infoPrivateCheckbox = within(
+					screen.getByTestId('privateCheckboxContainer')
+				).getByTestId('icon: InfoOutline');
 
 				expect(infoPrivateCheckbox).toBeVisible();
 
@@ -390,6 +392,28 @@ describe('Shared Calendar modal', () => {
 
 			expect(shareNotes).toBeVisible();
 		});
+		test('shows the "add and close" info sentence with an icon', () => {
+			const closeFn = vi.fn();
+			const grant = [
+				{
+					zid: '1',
+					gt: 'usr',
+					perm: 'r'
+				} as const
+			];
+
+			setupTest(<ShareCalendarModal folderId={'testId1'} closeFn={closeFn} grant={grant} />, {
+				store
+			});
+
+			const infoContainer = screen.getByTestId('addAndCloseInfoContainer');
+			expect(
+				within(infoContainer).getByText(
+					/By clicking on "Add and close", you'll return to the calendar view\./i
+				)
+			).toBeVisible();
+			expect(within(infoContainer).getByTestId('icon: InfoOutline')).toBeVisible();
+		});
 	});
 	describe('Modal footer', () => {
 		it('should have the confirm button disabled when the user did not interact with the modal', async () => {
@@ -406,9 +430,9 @@ describe('Shared Calendar modal', () => {
 				store
 			});
 
-			const confirmButton = screen.getByText(/Add and close/i);
+			const confirmButton = screen.getByRole('button', { name: /Add and close/i });
 
-			expect(confirmButton).toBeEnabled();
+			expect(confirmButton).toBeDisabled();
 		});
 		it('should have the confirm button enabled when at least a chip is inserted without errors', async () => {
 			const closeFn = vi.fn();
@@ -427,13 +451,12 @@ describe('Shared Calendar modal', () => {
 			const chipInput = screen.getByRole('textbox', {
 				name: /Recipients e-mail addresses/i
 			});
-			const confirmButton = screen.getByText(/Add and close/i);
 
 			await user.type(chipInput, 'ale@test.com');
 			await user.tab();
 
 			expect(screen.getByText('ale@test.com')).toBeInTheDocument();
-			expect(confirmButton).toBeEnabled();
+			expect(screen.getByRole('button', { name: /Add and close/i })).toBeEnabled();
 		});
 		// this corner case is currently not testable as integration components can't be tested and the fallback component does not cover this case
 		test.todo('when at least a chip inside chipInput has errors, the confirm button is disabled');
@@ -461,7 +484,7 @@ describe('Shared Calendar modal', () => {
 				await user.type(chipInput, 'user1@email.it');
 				await user.tab();
 
-				const confirmButton = screen.getByText(/Add and close/i);
+				const confirmButton = screen.getByRole('button', { name: /Add and close/i });
 
 				expect(confirmButton).toBeEnabled();
 
@@ -499,7 +522,7 @@ describe('Shared Calendar modal', () => {
 
 				await user.click(privateCheckbox);
 
-				const confirmButton = screen.getByText(/Add and close/i);
+				const confirmButton = screen.getByRole('button', { name: /Add and close/i });
 
 				await user.click(confirmButton);
 
@@ -536,7 +559,7 @@ describe('Shared Calendar modal', () => {
 
 				await user.click(noPermissionRoleOption);
 
-				const confirmButton = screen.getByText(/Add and close/i);
+				const confirmButton = screen.getByRole('button', { name: /Add and close/i });
 
 				await user.click(confirmButton);
 
@@ -573,7 +596,7 @@ describe('Shared Calendar modal', () => {
 
 				await user.click(viewerRoleOption);
 
-				const confirmButton = screen.getByText(/Add and close/i);
+				const confirmButton = screen.getByRole('button', { name: /Add and close/i });
 
 				await user.click(confirmButton);
 
@@ -610,7 +633,7 @@ describe('Shared Calendar modal', () => {
 
 				await user.click(adminRoleOption);
 
-				const confirmButton = screen.getByText(/Add and close/i);
+				const confirmButton = screen.getByRole('button', { name: /Add and close/i });
 
 				await user.click(confirmButton);
 
@@ -647,7 +670,7 @@ describe('Shared Calendar modal', () => {
 
 				await user.click(managerRoleOption);
 
-				const confirmButton = screen.getByText(/Add and close/i);
+				const confirmButton = screen.getByRole('button', { name: /Add and close/i });
 
 				await user.click(confirmButton);
 

--- a/src/actions/modals/share-calendar-modal.test.tsx
+++ b/src/actions/modals/share-calendar-modal.test.tsx
@@ -56,7 +56,6 @@ describe('Shared Calendar modal', () => {
 			];
 			const { user } = setupTest(
 				<ShareCalendarModal
-					folderName={'testName'}
 					folderId={'testId1'}
 					closeFn={closeFn}
 					grant={grant}
@@ -87,7 +86,6 @@ describe('Shared Calendar modal', () => {
 
 			setupTest(
 				<ShareCalendarModal
-					folderName={'testName'}
 					folderId={'testId1'}
 					closeFn={closeFn}
 					grant={grant}
@@ -126,7 +124,6 @@ describe('Shared Calendar modal', () => {
 
 			setupTest(
 				<ShareCalendarModal
-					folderName={'testName'}
 					folderId={'testId1'}
 					closeFn={closeFn}
 					grant={grant}
@@ -152,7 +149,6 @@ describe('Shared Calendar modal', () => {
 
 				setupTest(
 					<ShareCalendarModal
-						folderName={'testName'}
 						folderId={'testId1'}
 						closeFn={closeFn}
 						grant={grant}
@@ -178,7 +174,6 @@ describe('Shared Calendar modal', () => {
 
 				const { user } = setupTest(
 					<ShareCalendarModal
-						folderName={'testName'}
 						folderId={'testId1'}
 						closeFn={closeFn}
 						grant={grant}
@@ -210,7 +205,6 @@ describe('Shared Calendar modal', () => {
 
 				const { user } = setupTest(
 					<ShareCalendarModal
-						folderName={'testName'}
 						folderId={'testId1'}
 						closeFn={closeFn}
 						grant={grant}
@@ -241,7 +235,6 @@ describe('Shared Calendar modal', () => {
 
 				setupTest(
 					<ShareCalendarModal
-						folderName={'testName'}
 						folderId={'testId1'}
 						closeFn={closeFn}
 						grant={grant}
@@ -262,7 +255,6 @@ describe('Shared Calendar modal', () => {
 
 				const { user } = setupTest(
 					<ShareCalendarModal
-						folderName={'testName'}
 						folderId={'testId1'}
 						closeFn={closeFn}
 						grant={grant}
@@ -310,7 +302,6 @@ describe('Shared Calendar modal', () => {
 
 				setupTest(
 					<ShareCalendarModal
-						folderName={'testName'}
 						folderId={'testId1'}
 						closeFn={closeFn}
 						grant={grant}
@@ -336,7 +327,6 @@ describe('Shared Calendar modal', () => {
 
 				setupTest(
 					<ShareCalendarModal
-						folderName={'testName'}
 						folderId={'testId1'}
 						closeFn={closeFn}
 						grant={grant}
@@ -369,7 +359,6 @@ describe('Shared Calendar modal', () => {
 
 				const { user } = setupTest(
 					<ShareCalendarModal
-						folderName={'testName'}
 						folderId={'testId1'}
 						closeFn={closeFn}
 						grant={grant}
@@ -404,7 +393,6 @@ describe('Shared Calendar modal', () => {
 
 				setupTest(
 					<ShareCalendarModal
-						folderName={'testName'}
 						folderId={'testId1'}
 						closeFn={closeFn}
 						grant={grant}
@@ -430,7 +418,6 @@ describe('Shared Calendar modal', () => {
 
 				setupTest(
 					<ShareCalendarModal
-						folderName={'testName'}
 						folderId={'testId1'}
 						closeFn={closeFn}
 						grant={grant}
@@ -457,7 +444,6 @@ describe('Shared Calendar modal', () => {
 
 			setupTest(
 				<ShareCalendarModal
-					folderName={'testName'}
 					folderId={'testId1'}
 					closeFn={closeFn}
 					grant={grant}
@@ -483,7 +469,6 @@ describe('Shared Calendar modal', () => {
 
 			setupTest(
 				<ShareCalendarModal
-					folderName={'testName'}
 					folderId={'testId1'}
 					closeFn={closeFn}
 					grant={grant}
@@ -507,7 +492,6 @@ describe('Shared Calendar modal', () => {
 
 			const { user } = setupTest(
 				<ShareCalendarModal
-					folderName={'testName'}
 					folderId={'testId1'}
 					closeFn={closeFn}
 					grant={grant}
@@ -541,7 +525,6 @@ describe('Shared Calendar modal', () => {
 
 				const { user } = setupTest(
 					<ShareCalendarModal
-						folderName={'testName'}
 						folderId={'testId1'}
 						closeFn={closeFn}
 						grant={grant}
@@ -579,7 +562,6 @@ describe('Shared Calendar modal', () => {
 
 				const { user } = setupTest(
 					<ShareCalendarModal
-						folderName={'testName'}
 						folderId={'testId1'}
 						closeFn={closeFn}
 						grant={grant}
@@ -617,7 +599,6 @@ describe('Shared Calendar modal', () => {
 
 				const { user } = setupTest(
 					<ShareCalendarModal
-						folderName={'testName'}
 						folderId={'testId1'}
 						closeFn={closeFn}
 						grant={grant}
@@ -659,7 +640,6 @@ describe('Shared Calendar modal', () => {
 
 				const { user } = setupTest(
 					<ShareCalendarModal
-						folderName={'testName'}
 						folderId={'testId1'}
 						closeFn={closeFn}
 						grant={grant}
@@ -701,7 +681,6 @@ describe('Shared Calendar modal', () => {
 
 				const { user } = setupTest(
 					<ShareCalendarModal
-						folderName={'testName'}
 						folderId={'testId1'}
 						closeFn={closeFn}
 						grant={grant}
@@ -743,7 +722,6 @@ describe('Shared Calendar modal', () => {
 
 				const { user } = setupTest(
 					<ShareCalendarModal
-						folderName={'testName'}
 						folderId={'testId1'}
 						closeFn={closeFn}
 						grant={grant}
@@ -786,7 +764,6 @@ describe('Shared Calendar modal', () => {
 
 					const { user } = setupTest(
 						<ShareCalendarModal
-							folderName={'testName'}
 							folderId={'testId1'}
 							closeFn={closeFn}
 							grant={grant}
@@ -816,7 +793,6 @@ describe('Shared Calendar modal', () => {
 
 					const { user } = setupTest(
 						<ShareCalendarModal
-							folderName={'testName'}
 							folderId={'testId1'}
 							closeFn={closeFn}
 							grant={grant}

--- a/src/actions/modals/share-calendar-modal.tsx
+++ b/src/actions/modals/share-calendar-modal.tsx
@@ -440,6 +440,23 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 					</Text>
 				</Row>
 			</Container>
+			<Container
+				data-testid="addAndCloseInfoContainer"
+				padding={{ top: 'small', bottom: 'small' }}
+				mainAlignment="center"
+				crossAlignment="flex-start"
+				height="fit"
+				orientation="horizontal"
+				gap="0.25rem"
+			>
+				<Icon icon="InfoOutline" size="medium" color="secondary" />
+				<Text overflow="break-word" size="small" color="secondary">
+					{t(
+						'share.note.add_and_close_info',
+						'By clicking on "Add and close", you\'ll return to the calendar view.'
+					)}
+				</Text>
+			</Container>
 			<ModalFooter
 				onConfirm={onConfirm}
 				label={t('label.add_and_close', 'Add and close')}

--- a/src/actions/modals/share-calendar-modal.tsx
+++ b/src/actions/modals/share-calendar-modal.tsx
@@ -218,6 +218,15 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 							});
 						}
 					});
+			} else {
+				createSnackbar({
+					key: `folder-action-failed`,
+					replace: true,
+					severity: 'error',
+					hideButton: true,
+					label: t('label.error_try_again', 'Something went wrong, please try again'),
+					autoHideTimeout: 3000
+				});
 			}
 		});
 		closeFn && closeFn();
@@ -433,7 +442,7 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 			</Container>
 			<ModalFooter
 				onConfirm={onConfirm}
-				label={t('label.confirm', 'Confirm')}
+				label={t('label.add_and_close', 'Add and close')}
 				disabled={disabled}
 				secondaryAction={onGoBack}
 				secondaryLabel={secondaryLabel}

--- a/src/actions/modals/share-calendar-modal.tsx
+++ b/src/actions/modals/share-calendar-modal.tsx
@@ -440,24 +440,7 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 					</Text>
 				</Row>
 			</Container>
-			<Container
-				data-testid="addAndCloseInfoContainer"
-				padding={{ bottom: 'small' }}
-				mainAlignment="flex-start"
-				crossAlignment="center"
-				height="fit"
-				orientation="horizontal"
-				gap="0.25rem"
-			>
-				<Icon icon="InfoOutline" size="medium" color="secondary" />
-				<Text overflow="break-word" size="small" color="secondary">
-					{t(
-						'share.note.add_and_close_info',
-						'By clicking on "Add and close", you\'ll return to the calendar view.'
-					)}
-				</Text>
-			</Container>
-			<ModalFooter
+<ModalFooter
 				onConfirm={onConfirm}
 				label={t('label.add_and_close', 'Add and close')}
 				disabled={disabled}

--- a/src/actions/modals/share-calendar-modal.tsx
+++ b/src/actions/modals/share-calendar-modal.tsx
@@ -440,14 +440,13 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 					</Text>
 				</Row>
 			</Container>
-<ModalFooter
+			<ModalFooter
 				onConfirm={onConfirm}
 				label={t('label.add_and_close', 'Add and close')}
 				disabled={disabled}
 				secondaryAction={onGoBack}
 				secondaryLabel={secondaryLabel}
 				tooltip={confirmTooltip}
-				paddingTop="0"
 			/>
 		</Container>
 	);

--- a/src/actions/modals/share-calendar-modal.tsx
+++ b/src/actions/modals/share-calendar-modal.tsx
@@ -21,7 +21,7 @@ import {
 	Tooltip,
 	useSnackbar
 } from '@zextras/carbonio-design-system';
-import { useUserAccounts, useUserSettings } from '@zextras/carbonio-shell-ui';
+import { useUserAccounts } from '@zextras/carbonio-shell-ui';
 import {
 	ContactInputItem,
 	Grant,
@@ -31,7 +31,7 @@ import {
 import { filter, find, map, some } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
-import { PUBLIC_SHARE_ZID, SHARE_USER_TYPE } from '../../constants';
+import { SHARE_USER_TYPE } from '../../constants';
 import { FOLDER_OPERATIONS } from '../../constants/api';
 import { findLabel, ShareCalendarRoleOptions } from '../../settings/components/utils';
 import { folderAction } from '../../store/actions/calendar-actions';
@@ -86,7 +86,6 @@ export const SharePrivateCheckbox: FC<SharePrivateCheckboxProps> = ({
 };
 
 export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
-	folderName,
 	folderId,
 	closeFn,
 	onGoBack,
@@ -94,13 +93,8 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 	grant
 }): ReactElement => {
 	const [t] = useTranslation();
-	const userSettings = useUserSettings();
-	const defaultSharedWithPublic = useMemo(() => grant?.find((gr) => gr.gt === 'pub'), [grant]);
-	const [isSharedWithPublic, setIsSharedWithPublic] = useState(!!defaultSharedWithPublic);
-
-	const title = useMemo(() => `${t('label.share', 'Share')} ${folderName}`, [folderName, t]);
+	const title = t('label.add_internal_share', 'Add internal share');
 	const internalShareLabel = t('share.label.internal_sharing', 'Internal sharing');
-	const publicShareLabel = t('share.label.public_sharing', 'Public sharing');
 	const recipientsAddressDescriptionLabel = t(
 		'share.description.recipients_address',
 		'Enter internal addresses only. External recipients won’t be able to access the calendar.'
@@ -119,11 +113,6 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 	const [contacts, setContacts] = useState<ContactInputItem[]>([]);
 
 	const [allowToSeePrvtAppt, setAllowToSeePrvtAppt] = useState(false);
-
-	const isShareWithPublicOptionsChanged = useMemo(
-		() => !!defaultSharedWithPublic !== isSharedWithPublic,
-		[defaultSharedWithPublic, isSharedWithPublic]
-	);
 
 	const shareCalendarRoleOptions = useMemo(
 		() => ShareCalendarRoleOptions(grant?.[0]?.perm?.includes('p')),
@@ -180,39 +169,6 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 		setShareWithUserRole(shareRole);
 	}, []);
 
-	const publicShareAction = useMemo((): Array<{
-		id: string;
-		zid?: string;
-		op: string;
-		grant?: Grant[];
-	}> => {
-		if (isShareWithPublicOptionsChanged) {
-			if (defaultSharedWithPublic) {
-				return [
-					{
-						id: folderId,
-						zid: PUBLIC_SHARE_ZID,
-						op: FOLDER_OPERATIONS.REVOKE_GRANT
-					}
-				];
-			}
-			return [
-				{
-					id: folderId,
-					op: FOLDER_OPERATIONS.GRANT,
-					grant: [
-						{
-							gt: SHARE_USER_TYPE.PUBLIC,
-							perm: 'r',
-							pw: ''
-						}
-					]
-				}
-			];
-		}
-		return [];
-	}, [defaultSharedWithPublic, folderId, isShareWithPublicOptionsChanged]);
-
 	const onConfirm = useCallback((): void => {
 		const grantUsersAction: FolderAction[] = map(contacts, (contactInputItem) => ({
 			id: folderId,
@@ -228,9 +184,7 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 			]
 		}));
 
-		const folderActions = grantUsersAction.concat(publicShareAction);
-
-		const folderActionToSend = folderActions.length > 1 ? folderActions : folderActions[0];
+		const folderActionToSend = grantUsersAction.length > 1 ? grantUsersAction : grantUsersAction[0];
 
 		folderAction(folderActionToSend).then((res) => {
 			if (!res.Fault) {
@@ -275,7 +229,6 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 		createSnackbar,
 		dispatch,
 		folderId,
-		publicShareAction,
 		sendNotification,
 		shareWithUserRole,
 		standardMessage,
@@ -283,11 +236,8 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 	]);
 
 	const disabled = useMemo(
-		() =>
-			(!contacts.length && !isShareWithPublicOptionsChanged) ||
-			some(contacts, 'error') ||
-			contactInputHasError,
-		[contactInputHasError, contacts, isShareWithPublicOptionsChanged]
+		() => !contacts.length || some(contacts, 'error') || contactInputHasError,
+		[contactInputHasError, contacts]
 	);
 
 	const confirmTooltip = useMemo(() => {
@@ -302,8 +252,6 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 		}
 		return undefined;
 	}, [contactInputHasError, disabled, t]);
-
-	const isPublicShareEnabled = userSettings?.attrs?.zimbraPublicSharingEnabled === 'TRUE';
 
 	useEffect(() => {
 		const changesToAdd: ContactInputItem[] = [];
@@ -376,31 +324,6 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 			style={{ overflowY: 'auto' }}
 		>
 			<ModalHeader onClose={closeFn} title={title} showCloseIcon />
-			<Divider />
-			<Container crossAlignment="flex-start" padding={{ top: 'large' }}>
-				<Text size="medium" weight="bold" color="gray0">
-					{publicShareLabel}
-				</Text>
-			</Container>
-			{isPublicShareEnabled && (
-				<Container
-					padding={{ vertical: 'large' }}
-					mainAlignment="center"
-					crossAlignment="flex-start"
-					height="fit"
-					data-testid={'publicShareCheckboxContainer'}
-				>
-					<Checkbox
-						value={isSharedWithPublic}
-						defaultChecked={isSharedWithPublic}
-						onClick={(): void => setIsSharedWithPublic((prevValue) => !prevValue)}
-						label={t(
-							'share.options.share_calendar_with.public',
-							'Share with public (view only, no password required)'
-						)}
-					/>
-				</Container>
-			)}
 			<Divider />
 			<Container crossAlignment="flex-start" padding={{ top: 'large' }}>
 				<Text size="medium" weight="bold" color="gray0">

--- a/src/actions/modals/share-calendar-modal.tsx
+++ b/src/actions/modals/share-calendar-modal.tsx
@@ -442,9 +442,9 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 			</Container>
 			<Container
 				data-testid="addAndCloseInfoContainer"
-				padding={{ top: 'small', bottom: 'small' }}
-				mainAlignment="center"
-				crossAlignment="flex-start"
+				padding={{ bottom: 'small' }}
+				mainAlignment="flex-start"
+				crossAlignment="center"
 				height="fit"
 				orientation="horizontal"
 				gap="0.25rem"
@@ -464,6 +464,7 @@ export const ShareCalendarModal: FC<ShareCalendarModalProps> = ({
 				secondaryAction={onGoBack}
 				secondaryLabel={secondaryLabel}
 				tooltip={confirmTooltip}
+				paddingTop="0"
 			/>
 		</Container>
 	);

--- a/src/types/i18next.ts
+++ b/src/types/i18next.ts
@@ -8,7 +8,8 @@ import { i18n, WithT, TFunction } from 'i18next';
 export type Namespace = string | string[];
 
 export interface TransProps<E extends Element = HTMLDivElement>
-	extends React.HTMLProps<E>, Partial<WithT> {
+	extends React.HTMLProps<E>,
+		Partial<WithT> {
 	children?: React.ReactNode;
 	components?: readonly React.ReactNode[] | { [tagName: string]: React.ReactNode };
 	count?: number;

--- a/src/types/i18next.ts
+++ b/src/types/i18next.ts
@@ -8,8 +8,7 @@ import { i18n, WithT, TFunction } from 'i18next';
 export type Namespace = string | string[];
 
 export interface TransProps<E extends Element = HTMLDivElement>
-	extends React.HTMLProps<E>,
-		Partial<WithT> {
+	extends React.HTMLProps<E>, Partial<WithT> {
 	children?: React.ReactNode;
 	components?: readonly React.ReactNode[] | { [tagName: string]: React.ReactNode };
 	count?: number;

--- a/src/types/share-calendar.ts
+++ b/src/types/share-calendar.ts
@@ -6,7 +6,6 @@
 import { Grant } from '@zextras/carbonio-ui-commons';
 
 export type ShareCalendarModalProps = {
-	folderName?: string;
 	folderId: string;
 	closeFn?: () => void;
 	onGoBack?: () => void;

--- a/src/types/share-calendar.ts
+++ b/src/types/share-calendar.ts
@@ -6,7 +6,7 @@
 import { Grant } from '@zextras/carbonio-ui-commons';
 
 export type ShareCalendarModalProps = {
-	folderName: string;
+	folderName?: string;
 	folderId: string;
 	closeFn?: () => void;
 	onGoBack?: () => void;

--- a/src/view/search/search-view.test.tsx
+++ b/src/view/search/search-view.test.tsx
@@ -45,6 +45,7 @@ describe('SearchView', () => {
 	};
 
 	beforeEach(() => {
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
 		vi.spyOn(console, 'warn').mockImplementation(() => {});
 	});
 


### PR DESCRIPTION
Split the sharing UI into separate 'Internal sharing' and 'Public sharing' sections inside the main modal. The 'Add share' button moves from the footer to next to the 'Internal sharing' header. The public sharing toggle moves inline into the main modal and is applied on OK. The sub-modal is renamed to 'Add internal share' and handles only internal shares.
refs: CO-3429