### PR TITLE
refactor(ci): migrate to jenkins-lib-common v2.8.5

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 library(
-    identifier: 'jenkins-lib-common@v2.7.0',
+    identifier: 'jenkins-lib-common@v2.8.5',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-lib-common.git',


### PR DESCRIPTION
## Summary

Migrates the CI pipeline from the deprecated `jenkins-lib-ui` / `zapp-jenkins-lib` to `jenkins-lib-common@v2.8.1`, using `uiPipeline()` — consistent with all other Carbonio UI modules (mails, files, contacts, tasks, etc.).