### PR TITLE
fix: correct timezone handling for start and end times

### DIFF
--- a/src/shared/invite-response/parts/invite-header-part.tsx
+++ b/src/shared/invite-response/parts/invite-header-part.tsx
@@ -36,13 +36,13 @@ export const InviteHeaderPart: FC<InviteHeaderPartProps> = ({
 	const allDay = invite.allDay ?? false;
 
 	const localStartTime = useMemo(
-		() => moment(invite.start?.d ?? invite.start.u).valueOf(),
-		[invite.start?.d, invite.start.u]
+		() => invite.start?.u ?? moment(invite.start?.d).valueOf(),
+		[invite.start?.d, invite.start?.u]
 	);
 
 	const localEndTime = useMemo(
-		() => moment(invite.end?.d ?? invite.end.u).valueOf(),
-		[invite.end?.d, invite.end.u]
+		() => invite.end?.u ?? moment(invite.end?.d).valueOf(),
+		[invite.end?.d, invite.end?.u]
 	);
 
 	const originalDate = useGetDateRangeConvertedToTimezone(localStartTime ?? 0, localEndTime ?? 0, {
@@ -105,7 +105,7 @@ export const InviteHeaderPart: FC<InviteHeaderPartProps> = ({
 				)}
 				{method !== MESSAGE_METHOD.COUNTER && (
 					<Text overflow="ellipsis" color="secondary" weight="bold" size="small">
-						{originalDate}
+						{convertedDate}
 					</Text>
 				)}
 

--- a/src/shared/invite-response/tests/invite-response.test.tsx
+++ b/src/shared/invite-response/tests/invite-response.test.tsx
@@ -174,7 +174,7 @@ describe('invite response component', () => {
 
 				expect(localTimeString).toBeVisible();
 			});
-			test('if the event is created with a different timezone there is an icon with a tooltip showing the local timezone', async () => {
+			test('if the event is created with a different timezone the main text shows the viewer local time and the tooltip shows the creation timezone', async () => {
 				setupFoldersStore();
 				const mailMsg = buildMailMessageType(MESSAGE_METHOD.REQUEST, MESSAGE_TYPE.SINGLE, false, {
 					invite: [
@@ -190,16 +190,24 @@ describe('invite response component', () => {
 					store
 				});
 
+				// The main displayed time must be in the viewer's local timezone (Europe/Berlin),
+				// not in the organizer's creation timezone (Asia/Kolkata).
+				const localTimeString = await screen.findByText(
+					'Tuesday, January 30, 2024, 9:00 – 9:30 AM GMT+01:00 Europe/Berlin'
+				);
+				expect(localTimeString).toBeVisible();
+
 				const timezoneIcon = await screen.findByTestId('icon: GlobeOutline');
 
 				expect(timezoneIcon).toBeVisible();
 
-				user.hover(timezoneIcon);
+				await user.hover(timezoneIcon);
 
 				const tooltipTitleString = await screen.findByText(/Date and time on creation/i);
 
+				// The creation timezone time (Asia/Kolkata) is shown only in the tooltip.
 				const tooltipLocalTime = await screen.findByText(
-					'Tuesday, January 30, 2024, 1:30 – 2:00 PM GMT+05:30 Asia/Kolkata'
+					/Tuesday, January 30, 2024, 1:30 – 2:00 PM GMT\+05:30 Asia\/Kolkata/i
 				);
 
 				expect(tooltipTitleString).toBeVisible();


### PR DESCRIPTION
The bug: In an invitation email, the appointment time is shown in the organizer's creation timezone (10:00 Rome) instead of the attendee's local timezone (13:00 Maldives). The calendar grid is correct because it renders the absolute instant in local time.

Root cause — [invite-header-part.tsx]

It computes originalDate (creation tz) and convertedDate (local tz) but displays originalDate as the main text and never renders convertedDate. The proven-correct sibling [time-info-row.tsx] does the opposite — local time as main text, creation tz in the globe tooltip.
It also builds the timestamp from the wall-clock string first (moment(invite.start?.d ?? u)), which mis-converts across timezones; the absolute instant invite.start.u should be preferred (as [invite-reply-part.tsx:56-59] already does).
Why existing tests didn't catch it: the "local time" test runs with creation tz == viewer tz (so the two strings are equal), and the cross-tz test only asserts the tooltip, never the main text.

The fix is two small changes plus a regression test, all aligned with patterns already in the codebase.

Changes
[invite-header-part.tsx]

Display convertedDate (viewer's local time) as the main text instead of originalDate. The globe tooltip keeps originalDate (creation tz), matching its "Date and time on creation timezone:" label.
Build the timestamp from the absolute instant invite.start.u first (u ?? moment(d)), instead of the bare wall-clock string d which gets mis-parsed in the viewer's tz across timezones — mirroring the u ?? moment(d) ordering already used in invite-reply-part.tsx.
 — extended the cross-timezone test (creation tz Asia/Kolkata, viewer tz Europe/Berlin) to assert both that the main text shows the viewer's local time and the tooltip shows the creation-tz time. The previous test only matched the main text (which happened to be the creation-tz string due to the bug), so it never actually exercised the tooltip.