### PR TITLE
feat(CO-3905): add import appointments modal and related functionality

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -24,24 +24,25 @@ import { FOLDER_VIEW, useInitializeFolders, useFoldersMap } from '@zextras/carbo
 import { map } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
-import { AuthGuard } from './auth-guard';
-import { CenteredSpinner } from './components/CenteredSpinner';
-import { SyncDataHandler } from './components/sync-data-handler';
-import { QuotaRefreshHandler } from './components/quota-refresh-handler';
-import { CALENDAR_APP_ID, CALENDAR_BOARD_ID, CALENDAR_ROUTE } from './constants';
-import { CalendarIntegrations } from './constants/event-actions';
-import { useOnClickNewButton } from './hooks/on-click-new-button';
-import { getSettingsSubSections } from './settings/sub-sections';
 import { createAppointmentIntegration } from './shared/create-apppointment-integration';
-import { InviteResponseComp } from './shared/invite-response/invite-response';
-import { getCalendarGroupsRequest } from './soap/get-calendar-groups-request';
-import { StoreProvider } from './store/redux';
-import { useAppDispatch } from './store/redux/hooks';
-import { updateCalendarGroupsStore } from './store/zustand/calendar-group-store';
-import { GlobalModalManager } from './view/global-modal-manager';
 import Notifications from './view/notifications';
-import { AppointmentReminder } from './view/reminder/appointment-reminder';
-import { InitializeTags } from './view/tags/initialize-tags';
+import { AuthGuard } from 'auth-guard';
+import { CenteredSpinner } from 'components/CenteredSpinner';
+import { QuotaRefreshHandler } from 'components/quota-refresh-handler';
+import { SyncDataHandler } from 'components/sync-data-handler';
+import { CalendarIntegrations } from 'constants/event-actions';
+import { CALENDAR_APP_ID, CALENDAR_BOARD_ID, CALENDAR_ROUTE } from 'constants/index';
+import { useOnClickNewButton } from 'hooks/on-click-new-button';
+import { getSettingsSubSections } from 'settings/sub-sections';
+import { ImportAppointmentsModalComp } from 'shared/import-appointments-integration';
+import { InviteResponseComp } from 'shared/invite-response/invite-response';
+import { getCalendarGroupsRequest } from 'soap/get-calendar-groups-request';
+import { StoreProvider } from 'store/redux';
+import { useAppDispatch } from 'store/redux/hooks';
+import { updateCalendarGroupsStore } from 'store/zustand/calendar-group-store';
+import { GlobalModalManager } from 'view/global-modal-manager';
+import { AppointmentReminder } from 'view/reminder/appointment-reminder';
+import { InitializeTags } from 'view/tags/initialize-tags';
 
 const LazyCalendarView = lazy(
 	() => import(/* webpackChunkName: "calendar-view" */ './view/calendar/calendar-view')
@@ -202,6 +203,10 @@ const AppRegistrations = (): null => {
 		registerComponents({
 			id: 'invites-reply',
 			component: InviteResponseComp
+		});
+		registerComponents({
+			id: CalendarIntegrations.IMPORT_APPOINTMENTS,
+			component: ImportAppointmentsModalComp
 		});
 	}, [calendars, dispatch, newAction]);
 

--- a/src/constants/event-actions.ts
+++ b/src/constants/event-actions.ts
@@ -42,7 +42,8 @@ export const GROUP_ACTIONS = {
 };
 
 export const CalendarIntegrations = {
-	CREATE_APPOINTMENT: 'create_appointment'
+	CREATE_APPOINTMENT: 'create_appointment',
+	IMPORT_APPOINTMENTS: 'import_appointments'
 } as const;
 
 export type ObjectValues<T> = T[keyof T];

--- a/src/shared/import-appointments-integration/import-appointments-modal.test.tsx
+++ b/src/shared/import-appointments-integration/import-appointments-modal.test.tsx
@@ -1,0 +1,135 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { waitFor } from '@testing-library/react';
+import { JSNS } from '@zextras/carbonio-shell-ui';
+import { FOLDERS } from '@zextras/carbonio-ui-commons';
+
+import { ImportAppointmentsModalComp } from './import-appointments-modal';
+import { setupTest, screen } from '@test-setup';
+import { generateFolder } from '@test-utils/folders/folders-generator';
+import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
+import { populateFoldersStore } from '@test-utils/store/folders';
+import { generateApiErrorResponse } from 'test/generators/api';
+import {
+	ImportAppointmentsRequest,
+	ImportAppointmentsResponse
+} from 'types/soap/importAppointments';
+
+const successResponse: ImportAppointmentsResponse = {
+	appt: [{ n: 1, ids: '0001' }],
+	_jsns: JSNS.mail
+};
+
+const seedCalendars = (): void => {
+	populateFoldersStore({
+		view: 'appointment',
+		noSharedAccounts: true,
+		customFolders: [
+			generateFolder({ id: '2001', name: 'Work', view: 'appointment', l: FOLDERS.USER_ROOT }),
+			generateFolder({ id: '2002', name: 'Personal', view: 'appointment', l: FOLDERS.USER_ROOT })
+		]
+	});
+};
+
+describe('ImportAppointmentsModal', () => {
+	beforeEach(() => {
+		seedCalendars();
+	});
+
+	it('renders the title, filename description, calendar selector and actions', () => {
+		setupTest(
+			<ImportAppointmentsModalComp
+				messageId="123"
+				part="2"
+				fileName="Coffee_party.ics"
+				onClose={vi.fn()}
+			/>
+		);
+
+		expect(screen.getByText('Import to Calendars')).toBeVisible();
+		expect(
+			screen.getByText(
+				'The appointments contained in "Coffee_party.ics" will be imported into the selected calendar.'
+			)
+		).toBeVisible();
+		expect(screen.getByText('Select the destination calendar:')).toBeVisible();
+		expect(screen.getByText('Destination calendar')).toBeVisible();
+		expect(screen.getByRole('button', { name: /^import$/i })).toBeVisible();
+	});
+
+	it('imports the attachment into the default calendar and notifies success', async () => {
+		const importInterceptor = createSoapAPIInterceptor<
+			ImportAppointmentsRequest,
+			ImportAppointmentsResponse
+		>('ImportAppointments', successResponse);
+		createSoapAPIInterceptor('NoOp', {});
+		const onClose = vi.fn();
+
+		const { user } = setupTest(
+			<ImportAppointmentsModalComp messageId="123" part="2" fileName="a.ics" onClose={onClose} />
+		);
+
+		await user.click(screen.getByRole('button', { name: /^import$/i }));
+
+		const params = await importInterceptor;
+		expect(params).toEqual({
+			_jsns: JSNS.mail,
+			ct: 'text/calendar',
+			l: FOLDERS.CALENDAR,
+			content: { mid: '123', part: '2' }
+		});
+		expect(onClose).toHaveBeenCalled();
+		await waitFor(() => expect(screen.getByText('Import successful')).toBeVisible());
+	});
+
+	it('imports into the calendar chosen in the destination selector', async () => {
+		const importInterceptor = createSoapAPIInterceptor<
+			ImportAppointmentsRequest,
+			ImportAppointmentsResponse
+		>('ImportAppointments', successResponse);
+		createSoapAPIInterceptor('NoOp', {});
+
+		const { user } = setupTest(
+			<ImportAppointmentsModalComp messageId="55" part="3" fileName="a.ics" onClose={vi.fn()} />
+		);
+
+		// open the destination-calendar select (its default value is the primary "Calendar")
+		await user.click(screen.getByText('Calendar'));
+		await user.click(screen.getByText('Work'));
+		await user.click(screen.getByRole('button', { name: /^import$/i }));
+
+		const params = await importInterceptor;
+		expect(params).toMatchObject({ l: '2001', content: { mid: '55', part: '3' } });
+	});
+
+	it('notifies an error when the import fails', async () => {
+		createSoapAPIInterceptor('ImportAppointments', generateApiErrorResponse());
+
+		const { user } = setupTest(
+			<ImportAppointmentsModalComp messageId="1" part="2" fileName="a.ics" onClose={vi.fn()} />
+		);
+
+		await user.click(screen.getByRole('button', { name: /^import$/i }));
+
+		await waitFor(() =>
+			expect(screen.getByText('Something went wrong, please try again')).toBeVisible()
+		);
+	});
+
+	it('closes without importing when the close icon is clicked', async () => {
+		const onClose = vi.fn();
+
+		const { user } = setupTest(
+			<ImportAppointmentsModalComp messageId="1" part="2" fileName="a.ics" onClose={onClose} />
+		);
+
+		await user.click(screen.getByTestId('icon: Close'));
+
+		expect(onClose).toHaveBeenCalled();
+	});
+});

--- a/src/shared/import-appointments-integration/import-appointments-modal.tsx
+++ b/src/shared/import-appointments-integration/import-appointments-modal.tsx
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React, { ReactElement, useCallback, useMemo, useState } from 'react';
+
+import {
+	Divider,
+	ModalBody,
+	ModalFooter,
+	ModalHeader,
+	Padding,
+	Text,
+	useSnackbar
+} from '@zextras/carbonio-design-system';
+import { useUserSettings } from '@zextras/carbonio-shell-ui';
+import { FOLDERS, Folder } from '@zextras/carbonio-ui-commons';
+import { useTranslation } from 'react-i18next';
+
+import { PREFS_DEFAULTS } from '../../constants';
+import { importAppointmentsRequest } from '../../soap/import-appointments-request';
+import { NoOpRequest } from '../../soap/noop-request';
+import { StoreProvider } from '../../store/redux';
+import { CalendarSelector } from '../../view/editor/parts/calendar-selector';
+
+export type ImportAppointmentsModalProps = {
+	messageId: string;
+	part: string;
+	fileName?: string;
+	onClose: () => void;
+};
+
+export const ImportAppointmentsModal = ({
+	messageId,
+	part,
+	fileName,
+	onClose
+}: ImportAppointmentsModalProps): ReactElement => {
+	const [t] = useTranslation();
+	const createSnackbar = useSnackbar();
+	const { zimbraPrefDefaultCalendarId } = useUserSettings().prefs;
+	const [selectedCalendar, setSelectedCalendar] = useState<Folder | undefined>();
+
+	const calendarId = useMemo(
+		() =>
+			selectedCalendar?.id ??
+			(zimbraPrefDefaultCalendarId as string) ??
+			PREFS_DEFAULTS.DEFAULT_CALENDAR_ID ??
+			FOLDERS.CALENDAR,
+		[selectedCalendar?.id, zimbraPrefDefaultCalendarId]
+	);
+
+	const onConfirm = useCallback(() => {
+		onClose();
+		createSnackbar({
+			key: 'import ongoing',
+			replace: true,
+			severity: 'info',
+			label: t('label.import_calendar_ongoing', 'Import into the selected calendar in progress.'),
+			hideButton: true
+		});
+		importAppointmentsRequest({ folderId: calendarId, mid: messageId, part })
+			.then(() => NoOpRequest())
+			.then(() => {
+				createSnackbar({
+					key: 'import success',
+					replace: true,
+					severity: 'success',
+					label: t('label.import_calendar_success', 'Import successful'),
+					autoHideTimeout: 3000,
+					hideButton: true
+				});
+			})
+			.catch(() => {
+				createSnackbar({
+					key: 'import failed',
+					replace: true,
+					severity: 'error',
+					label: t('label.error_try_again', 'Something went wrong, please try again'),
+					autoHideTimeout: 3000,
+					hideButton: true
+				});
+			});
+	}, [onClose, createSnackbar, t, calendarId, messageId, part]);
+
+	return (
+		<>
+			<ModalHeader
+				title={t('import_to_calendar', 'Import to Calendars')}
+				showCloseIcon
+				onClose={onClose}
+			/>
+			<Divider />
+			<ModalBody>
+				<Text overflow="break-word">
+					{t('message.import_appointment_from_email', {
+						fileName,
+						defaultValue:
+							'The appointments contained in {{fileName}} will be imported into the selected calendar.'
+					})}
+				</Text>
+				<Padding top="medium" />
+				<Text overflow="break-word">
+					{t('label.select_destination_calendar', 'Select the destination calendar:')}
+				</Text>
+				<Padding top="small" />
+				<CalendarSelector
+					calendarId={calendarId}
+					onCalendarChange={setSelectedCalendar}
+					excludeTrash
+					label={t('label.destination_calendar', 'Destination calendar')}
+				/>
+			</ModalBody>
+			<Divider />
+			<ModalFooter onConfirm={onConfirm} onClose={onClose} confirmLabel={t('import', 'Import')} />
+		</>
+	);
+};
+
+/**
+ * Self-contained wrapper exposed to other modules (e.g. Mails) through the Shell
+ * component registry. It is rendered inside the consumer module's own modal
+ * manager, so it must bring its own providers.
+ */
+export const ImportAppointmentsModalComp = (props: ImportAppointmentsModalProps): ReactElement => (
+	<StoreProvider>
+		<ImportAppointmentsModal {...props} />
+	</StoreProvider>
+);

--- a/src/shared/import-appointments-integration/import-appointments-modal.tsx
+++ b/src/shared/import-appointments-integration/import-appointments-modal.tsx
@@ -45,7 +45,7 @@ export const ImportAppointmentsModal = ({
 	const calendarId = useMemo(
 		() =>
 			selectedCalendar?.id ??
-			(zimbraPrefDefaultCalendarId as string) ??
+			zimbraPrefDefaultCalendarId ??
 			PREFS_DEFAULTS.DEFAULT_CALENDAR_ID ??
 			FOLDERS.CALENDAR,
 		[selectedCalendar?.id, zimbraPrefDefaultCalendarId]

--- a/src/shared/import-appointments-integration/import-appointments-modal.tsx
+++ b/src/shared/import-appointments-integration/import-appointments-modal.tsx
@@ -18,11 +18,11 @@ import { useUserSettings } from '@zextras/carbonio-shell-ui';
 import { FOLDERS, Folder } from '@zextras/carbonio-ui-commons';
 import { useTranslation } from 'react-i18next';
 
-import { PREFS_DEFAULTS } from '../../constants';
-import { importAppointmentsRequest } from '../../soap/import-appointments-request';
-import { NoOpRequest } from '../../soap/noop-request';
-import { StoreProvider } from '../../store/redux';
-import { CalendarSelector } from '../../view/editor/parts/calendar-selector';
+import { PREFS_DEFAULTS } from 'constants/index';
+import { importAppointmentsRequest } from 'soap/import-appointments-request';
+import { NoOpRequest } from 'soap/noop-request';
+import { StoreProvider } from 'store/redux';
+import { CalendarSelector } from 'view/editor/parts/calendar-selector';
 
 export type ImportAppointmentsModalProps = {
 	messageId: string;
@@ -97,7 +97,7 @@ export const ImportAppointmentsModal = ({
 					{t('message.import_appointment_from_email', {
 						fileName,
 						defaultValue:
-							'The appointments contained in {{fileName}} will be imported into the selected calendar.'
+							'The appointments contained in "{{fileName}}" will be imported into the selected calendar.'
 					})}
 				</Text>
 				<Padding top="medium" />

--- a/src/shared/import-appointments-integration/index.tsx
+++ b/src/shared/import-appointments-integration/index.tsx
@@ -1,0 +1,6 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+export { ImportAppointmentsModalComp } from './import-appointments-modal';

--- a/src/soap/import-appointments-request.ts
+++ b/src/soap/import-appointments-request.ts
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { JSNS } from '@zextras/carbonio-shell-ui';
+import { ErrorSoapBodyResponse, legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
+
+import {
+	ImportAppointmentsRequest,
+	ImportAppointmentsResponse
+} from 'types/soap/importAppointments';
+
+export type ImportAppointmentsParams = {
+	/** Target calendar folder id the appointments will be imported into (ImportAppointmentsRequest `l`) */
+	folderId: string;
+	/** Id of the message the ICS attachment belongs to */
+	mid: string;
+	/** Part name of the ICS attachment within the message */
+	part: string;
+	/** Content type of the imported data. Defaults to `text/calendar` */
+	ct?: string;
+};
+
+export const importAppointmentsRequest = async ({
+	folderId,
+	mid,
+	part,
+	ct = 'text/calendar'
+}: ImportAppointmentsParams): Promise<ImportAppointmentsResponse> =>
+	legacySoapFetch<ImportAppointmentsRequest, ImportAppointmentsResponse | ErrorSoapBodyResponse>(
+		'ImportAppointments',
+		{
+			_jsns: JSNS.mail,
+			ct,
+			l: folderId,
+			content: { mid, part }
+		}
+	).then((response) => {
+		if ('Fault' in response) {
+			throw new Error(response.Fault.Reason.Text, { cause: response.Fault });
+		}
+		return response;
+	});

--- a/src/soap/tests/import-appointments-request.test.ts
+++ b/src/soap/tests/import-appointments-request.test.ts
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { JSNS } from '@zextras/carbonio-shell-ui';
+import { ErrorSoapBodyResponse } from '@zextras/carbonio-ui-soap-lib';
+
+import { createSoapAPIInterceptor } from '@test-utils/network/msw/create-api-interceptor';
+import { importAppointmentsRequest } from 'soap/import-appointments-request';
+import { generateApiErrorResponse } from 'test/generators/api';
+import {
+	ImportAppointmentsRequest,
+	ImportAppointmentsResponse
+} from 'types/soap/importAppointments';
+
+const response: ImportAppointmentsResponse = {
+	appt: [{ n: 1, ids: '0001' }],
+	_jsns: JSNS.mail
+};
+
+describe('importAppointmentsRequest', () => {
+	it('should call the ImportAppointments API with the correct parameters', async () => {
+		const apiCallInterceptor = createSoapAPIInterceptor<
+			ImportAppointmentsRequest,
+			ImportAppointmentsResponse
+		>('ImportAppointments', response);
+
+		await importAppointmentsRequest({ folderId: '10', mid: '123', part: '2' });
+		const apiParams = await apiCallInterceptor;
+
+		expect(apiParams).toEqual({
+			_jsns: JSNS.mail,
+			ct: 'text/calendar',
+			l: '10',
+			content: { mid: '123', part: '2' }
+		});
+	});
+
+	it('should forward a custom content type when provided', async () => {
+		const apiCallInterceptor = createSoapAPIInterceptor<
+			ImportAppointmentsRequest,
+			ImportAppointmentsResponse
+		>('ImportAppointments', response);
+
+		await importAppointmentsRequest({ folderId: '10', mid: '123', part: '2', ct: 'ics' });
+		const apiParams = await apiCallInterceptor;
+
+		expect(apiParams.ct).toBe('ics');
+	});
+
+	it('should raise an error if the API call fails', async () => {
+		const faultyResponse = generateApiErrorResponse();
+		createSoapAPIInterceptor<ImportAppointmentsRequest, ErrorSoapBodyResponse>(
+			'ImportAppointments',
+			faultyResponse
+		);
+
+		await expect(
+			importAppointmentsRequest({ folderId: '10', mid: '123', part: '2' })
+		).rejects.toThrow(faultyResponse.Fault.Reason.Text);
+	});
+});

--- a/src/types/soap/importAppointments.ts
+++ b/src/types/soap/importAppointments.ts
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { JSNS } from '@zextras/carbonio-shell-ui';
+
+export type ImportAppointmentsRequest = {
+	_jsns: typeof JSNS.mail;
+	ct: string;
+	l: string;
+	content: {
+		mid?: string;
+		part?: string;
+		aid?: string;
+		_content?: string;
+	};
+};
+
+export type ImportAppointmentsResponse = {
+	_jsns: typeof JSNS.mail;
+	appt?: Array<{ n?: number; ids?: string }>;
+};


### PR DESCRIPTION
This PR introduces an “Import appointments” integration to allow importing calendar appointments (ICS) from an email attachment into a chosen calendar, exposing the modal through the Shell component registry.

**Changes:**
- Added SOAP request/response typings and a `importAppointmentsRequest` SOAP client helper.
- Implemented an import modal (with calendar destination selector) and registered it via `registerComponents`.
- Added unit/integration tests for both the SOAP request helper and the modal behavior; added a `dev-deploy` convenience script.

Related PR: https://github.com/zextras/carbonio-mails-ui/pull/1283