### PR TITLE
feat(CO-3751): display appointment creator in shared calendars

### DIFF
--- a/src/normalizations/normalize-calendar-events.ts
+++ b/src/normalizations/normalize-calendar-events.ts
@@ -89,7 +89,8 @@ const normalizeEventResource = ({
 		appt?.or?.d || appt?.or?.a
 			? {
 					name: appt?.or?.d,
-					email: appt?.or?.a
+					email: appt?.or?.a,
+					sentBy: appt?.or?.sentBy
 				}
 			: undefined,
 	compNum: appt.compNum,

--- a/src/shared/invite-response/parts/invite-header-part.tsx
+++ b/src/shared/invite-response/parts/invite-header-part.tsx
@@ -14,6 +14,7 @@ import { MESSAGE_METHOD } from 'constants/api';
 import { useGetDateRangeConvertedToTimezone } from 'hooks/use-get-date-range-converted-to-timezone';
 import { Invite } from 'types/store/invite';
 import { parseDateFromICS } from 'utils/dates';
+import { isSentOnBehalfOf } from 'utils/organizer';
 
 type InviteHeaderPartProps = {
 	mailMsg: any;
@@ -84,18 +85,31 @@ export const InviteHeaderPart: FC<InviteHeaderPartProps> = ({
 						{mailMsg.subject}
 					</Text>
 				)}
-				{method !== MESSAGE_METHOD.COUNTER && (
-					<Trans
-						i18nKey="message.organizer_invited_you"
-						values={{
-							organizer: invite.organizer?.d ?? invite.organizer?.a,
-							title: mailMsg.subject ?? invite?.name
-						}}
-						defaults="<text>{{organizer}} invited you to an event <bold>{{title}}</bold></text>"
-						components={{ bold: <strong />, text: <Text /> }}
-						t={t}
-					/>
-				)}
+				{method !== MESSAGE_METHOD.COUNTER &&
+					(isSentOnBehalfOf(invite.organizer) ? (
+						<Trans
+							i18nKey="message.organizer_invited_you_on_behalf_of"
+							values={{
+								organizer: invite.organizer?.sentBy,
+								owner: invite.organizer?.a,
+								title: mailMsg.subject ?? invite?.name
+							}}
+							defaults="<text>{{organizer}} invited you to an event <bold>{{title}}</bold> on behalf of <bold>{{owner}}</bold></text>"
+							components={{ bold: <strong />, text: <Text /> }}
+							t={t}
+						/>
+					) : (
+						<Trans
+							i18nKey="message.organizer_invited_you"
+							values={{
+								organizer: invite.organizer?.d ?? invite.organizer?.a,
+								title: mailMsg.subject ?? invite?.name
+							}}
+							defaults="<text>{{organizer}} invited you to an event <bold>{{title}}</bold></text>"
+							components={{ bold: <strong />, text: <Text /> }}
+							t={t}
+						/>
+					))}
 			</Row>
 			<Row width="100%" mainAlignment="flex-start">
 				{method === MESSAGE_METHOD.COUNTER && mailMsg.parent !== FOLDERS.SENT && (

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -84,6 +84,7 @@ export type EventResource = {
 		| {
 				name?: string;
 				email?: string;
+				sentBy?: string;
 		  }
 		| undefined;
 	room?: any;

--- a/src/types/store/invite.ts
+++ b/src/types/store/invite.ts
@@ -39,6 +39,8 @@ export type InviteOrganizer = {
 	a: string;
 	d: string;
 	url: string;
+	/** Address of the user who created the appointment on behalf of the organizer (ICS ORGANIZER;SENT-BY) */
+	sentBy?: string;
 };
 
 export type InviteDescription = {

--- a/src/utils/organizer.test.ts
+++ b/src/utils/organizer.test.ts
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { getAppointmentCreatorEmail, isAppointmentCreatedBy, isSentOnBehalfOf } from './organizer';
+
+const ORGANIZER = 'organizer@test.com';
+const DELEGATE = 'delegate@test.com';
+
+describe('isSentOnBehalfOf', () => {
+	test.each`
+		organizer                                         | expected
+		${undefined}                                      | ${false}
+		${{ a: ORGANIZER }}                               | ${false}
+		${{ a: ORGANIZER, sentBy: ORGANIZER }}            | ${false}
+		${{ a: ORGANIZER, sentBy: 'Organizer@Test.com' }} | ${false}
+		${{ a: ORGANIZER, sentBy: DELEGATE }}             | ${true}
+	`('returns $expected for $organizer', ({ organizer, expected }) => {
+		expect(isSentOnBehalfOf(organizer)).toBe(expected);
+	});
+});
+
+describe('getAppointmentCreatorEmail', () => {
+	test('returns the delegate address when the appointment is created on behalf of the organizer', () => {
+		expect(getAppointmentCreatorEmail({ a: ORGANIZER, sentBy: DELEGATE })).toBe(DELEGATE);
+	});
+
+	test('returns the organizer address when there is no delegation', () => {
+		expect(getAppointmentCreatorEmail({ a: ORGANIZER })).toBe(ORGANIZER);
+	});
+
+	test('returns undefined when there is no organizer', () => {
+		expect(getAppointmentCreatorEmail(undefined)).toBeUndefined();
+	});
+});
+
+describe('isAppointmentCreatedBy', () => {
+	test('matches the delegate ignoring the address case, as the mailbox does', () => {
+		expect(isAppointmentCreatedBy({ a: ORGANIZER, sentBy: 'Delegate@Test.com' }, DELEGATE)).toBe(
+			true
+		);
+	});
+
+	test('does not match the organizer when the appointment is created by a delegate', () => {
+		expect(isAppointmentCreatedBy({ a: ORGANIZER, sentBy: DELEGATE }, ORGANIZER)).toBe(false);
+	});
+
+	test('matches the organizer when there is no delegation', () => {
+		expect(isAppointmentCreatedBy({ a: ORGANIZER }, ORGANIZER)).toBe(true);
+	});
+});

--- a/src/utils/organizer.ts
+++ b/src/utils/organizer.ts
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+type OrganizerLike = { a?: string; sentBy?: string } | undefined;
+
+// the mailbox stores sentBy as it is received, while it matches addresses ignoring their case
+const isTheSameAddress = (first: string | undefined, second: string | undefined): boolean =>
+	!!first && !!second && first.toLowerCase() === second.toLowerCase();
+
+/**
+ * An appointment is sent on behalf of the organizer when a delegate creates it on a shared calendar:
+ * the organizer remains the calendar owner while sentBy holds the delegate address (ICS SENT-BY).
+ */
+export const isSentOnBehalfOf = (organizer: OrganizerLike): boolean =>
+	!!organizer?.sentBy && !isTheSameAddress(organizer.sentBy, organizer.a);
+
+export const getAppointmentCreatorEmail = (organizer: OrganizerLike): string | undefined =>
+	isSentOnBehalfOf(organizer) ? organizer?.sentBy : organizer?.a;
+
+export const isAppointmentCreatedBy = (
+	organizer: OrganizerLike,
+	address: string | undefined
+): boolean => isTheSameAddress(getAppointmentCreatorEmail(organizer), address);

--- a/src/view/event-panel-view/details-part.tsx
+++ b/src/view/event-panel-view/details-part.tsx
@@ -195,7 +195,7 @@ export const DetailsPart = ({
 					{invite && (
 						<FreeBusyStatusRowComponent
 							freeBusy={event.resource.freeBusy}
-							organizerName={invite?.organizer?.a}
+							organizer={invite?.organizer}
 						/>
 					)}
 					{event?.resource?.tags?.length > 0 && <TagsRow event={event} hideIcon />}

--- a/src/view/event-panel-view/organizer-part.tsx
+++ b/src/view/event-panel-view/organizer-part.tsx
@@ -112,7 +112,7 @@ export const OrganizerPart = ({
 
 	const onBehalfOfRow = isSentOnBehalf ? (
 		<Row mainAlignment="flex-start" width="100%" data-testid={'OnBehalfOf'}>
-			<Text color="secondary" size="small">
+			<Text color="secondary" size="small" overflow="break-word">
 				<Trans
 					i18nKey="message.on_behalf_of"
 					defaults="on behalf of <strong>{{owner}}</strong>"

--- a/src/view/event-panel-view/organizer-part.tsx
+++ b/src/view/event-panel-view/organizer-part.tsx
@@ -170,7 +170,7 @@ export const OrganizerPart = ({
 						takeAvailableSpace
 						padding={{ left: 'small' }}
 					>
-						<Text size={fontSize}>
+						<Text size={fontSize} overflow="break-word">
 							{calendarOwner ? (
 								<Trans
 									i18nKey="message.somebody_invited_owner"
@@ -203,7 +203,7 @@ export const OrganizerPart = ({
 							takeAvailableSpace
 							padding={{ left: 'small' }}
 						>
-							<Text size={fontSize}>
+							<Text size={fontSize} overflow="break-word">
 								<Trans
 									i18nKey="message.somebody_is_organizer"
 									defaults="<strong>{{somebody}}</strong> is the organizer"

--- a/src/view/event-panel-view/organizer-part.tsx
+++ b/src/view/event-panel-view/organizer-part.tsx
@@ -21,6 +21,11 @@ import { Trans } from 'react-i18next';
 import { isIcsOrCaldavExternalFolder } from 'commons/utilities';
 import { copyEmailToClipboard, sendMsg } from 'store/actions/participant-displayer-actions';
 import { Invite, InviteOrganizer } from 'types/store/invite';
+import {
+	getAppointmentCreatorEmail,
+	isAppointmentCreatedBy,
+	isSentOnBehalfOf
+} from 'utils/organizer';
 
 type OrganizerPartProps = {
 	invite: Invite;
@@ -57,6 +62,22 @@ export const OrganizerPart = ({
 	);
 	const iAmAttendee = useMemo(() => showAttendeePerspective ?? false, [showAttendeePerspective]);
 
+	const isSentOnBehalf = useMemo(() => isSentOnBehalfOf(organizer), [organizer]);
+	const creatorEmail = useMemo(() => getAppointmentCreatorEmail(organizer) ?? '', [organizer]);
+	// SENT-BY only carries an address, so the delegate has no display name to fall back on
+	const creatorName = useMemo(
+		() => (isSentOnBehalf ? '' : organizer.d),
+		[isSentOnBehalf, organizer.d]
+	);
+	const creatorLabel = useMemo(
+		() => creatorName || creatorEmail || organizer.url || '',
+		[creatorEmail, creatorName, organizer.url]
+	);
+	const iAmTheCreator = useMemo(
+		() => isAppointmentCreatedBy(organizer, account.name),
+		[account.name, organizer]
+	);
+
 	const organizerChip = (
 		<Row
 			mainAlignment="flex-start"
@@ -64,7 +85,7 @@ export const OrganizerPart = ({
 			padding={{ top: 'extrasmall', bottom: 'extrasmall' }}
 		>
 			<Chip
-				label={organizer.a || organizer.d}
+				label={creatorEmail || creatorName}
 				background={'gray3'}
 				color="text"
 				data-testid={'Chip'}
@@ -75,19 +96,31 @@ export const OrganizerPart = ({
 						label: t('message.send_email', 'Send e-mail'),
 						type: 'button',
 						icon: 'EmailOutline',
-						onClick: () => sendMsg(organizer.a, organizer.d)
+						onClick: () => sendMsg(creatorEmail, creatorName)
 					},
 					{
 						id: 'action2',
 						label: t('message.copy', 'Copy'),
 						type: 'button',
 						icon: 'Copy',
-						onClick: () => copyEmailToClipboard(organizer.a, createSnackbar)
+						onClick: () => copyEmailToClipboard(creatorEmail, createSnackbar)
 					}
 				]}
 			/>
 		</Row>
 	);
+
+	const onBehalfOfRow = isSentOnBehalf ? (
+		<Row mainAlignment="flex-start" width="100%" data-testid={'OnBehalfOf'}>
+			<Text color="secondary" size="small">
+				<Trans
+					i18nKey="message.on_behalf_of"
+					defaults="on behalf of <strong>{{owner}}</strong>"
+					values={{ owner: organizer.a || organizer.d }}
+				/>
+			</Text>
+		</Row>
+	) : null;
 
 	return (
 		<Container
@@ -99,31 +132,38 @@ export const OrganizerPart = ({
 			padding={isSummary ? { top: 'small' } : { horizontal: 'large', vertical: 'medium' }}
 			background={'gray6'}
 		>
-			{invite?.organizer?.a === account.name && (
+			{iAmTheCreator && (
 				<Row mainAlignment="flex-start" crossAlignment="center" width="fill">
 					<Avatar
 						size={isSummary ? 'small' : 'large'}
 						label={account.name ?? account.displayName ?? ''}
 					/>
-					<Text style={{ padding: '0 0.5rem' }} size={fontSize}>
-						<Trans
-							i18nKey="message.you_are_organizer"
-							defaults="<Row><Text> <BoldText> You  </BoldText> are the organizer </Text></Row>"
-							components={{
-								Row: <Row />,
-								Text: <Text color="secondary" size={fontSize} />,
-								BoldText: <span style={{ fontWeight: 'bold', color: '#333333' }} />
-							}}
-						/>
-					</Text>
+					<Container
+						orientation="vertical"
+						mainAlignment="flex-start"
+						crossAlignment="flex-start"
+						width="fit"
+						height="fit"
+						padding={{ horizontal: 'small' }}
+					>
+						<Text size={fontSize}>
+							<Trans
+								i18nKey="message.you_are_organizer"
+								defaults="<Row><Text> <BoldText> You  </BoldText> are the organizer </Text></Row>"
+								components={{
+									Row: <Row />,
+									Text: <Text color="secondary" size={fontSize} />,
+									BoldText: <span style={{ fontWeight: 'bold', color: '#333333' }} />
+								}}
+							/>
+						</Text>
+						{onBehalfOfRow}
+					</Container>
 				</Row>
 			)}
 			{showAttendeePerspective ? (
 				<Row mainAlignment="flex-start" crossAlignment="flex-start" padding={{ vertical: 'small' }}>
-					<Avatar
-						label={organizer.d ?? organizer.a ?? organizer.url ?? ''}
-						size={isSummary ? 'small' : 'large'}
-					/>
+					<Avatar label={creatorLabel} size={isSummary ? 'small' : 'large'} />
 					<Row
 						mainAlignment="flex-start"
 						crossAlignment="center"
@@ -136,7 +176,7 @@ export const OrganizerPart = ({
 									i18nKey="message.somebody_invited_owner"
 									defaults="<strong>{{somebody}}</strong> invited {{owner}}"
 									values={{
-										somebody: organizer.d || organizer.a || organizer.url,
+										somebody: creatorLabel,
 										owner: calendarOwner
 									}}
 								/>
@@ -144,21 +184,19 @@ export const OrganizerPart = ({
 								<Trans
 									i18nKey="message.somebody_invited_you"
 									defaults="<strong>{{somebody}}</strong> invited you"
-									values={{ somebody: organizer.d || organizer.a || organizer.url }}
+									values={{ somebody: creatorLabel }}
 								/>
 							)}
 						</Text>
 						{organizerChip}
+						{onBehalfOfRow}
 					</Row>
 				</Row>
 			) : (
-				invite?.organizer?.a !== account.name &&
+				!iAmTheCreator &&
 				!iAmAttendee && (
 					<Row mainAlignment="flex-start" crossAlignment="center" width="fill">
-						<Avatar
-							size={isSummary ? 'small' : 'large'}
-							label={organizer.d ?? organizer.a ?? organizer.url ?? ''}
-						/>
+						<Avatar size={isSummary ? 'small' : 'large'} label={creatorLabel} />
 						<Row
 							mainAlignment="flex-start"
 							crossAlignment="flex-start"
@@ -169,10 +207,11 @@ export const OrganizerPart = ({
 								<Trans
 									i18nKey="message.somebody_is_organizer"
 									defaults="<strong>{{somebody}}</strong> is the organizer"
-									values={{ somebody: organizer.d || organizer.a }}
+									values={{ somebody: creatorLabel }}
 								/>
 							</Text>
 							{organizerChip}
+							{onBehalfOfRow}
 						</Row>
 					</Row>
 				)

--- a/src/view/event-panel-view/participants-part.tsx
+++ b/src/view/event-panel-view/participants-part.tsx
@@ -46,10 +46,7 @@ export const ParticipantsPart = ({
 				isSummary={isSummary}
 			/>
 			{isSummary && (
-				<FreeBusyStatusRow
-					freeBusy={event.resource.freeBusy}
-					organizerName={invite?.organizer?.a}
-				/>
+				<FreeBusyStatusRow freeBusy={event.resource.freeBusy} organizer={invite?.organizer} />
 			)}
 			{isSummary ? (
 				<ParticipantsDisplayerSmall participants={participants} event={event} />

--- a/src/view/event-panel-view/tests/organizer-part.test.tsx
+++ b/src/view/event-panel-view/tests/organizer-part.test.tsx
@@ -1,0 +1,141 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { useFolder } from '@zextras/carbonio-ui-commons';
+
+import { OrganizerPart } from '../organizer-part';
+import * as shell from '@test-mocks/@zextras/carbonio-shell-ui';
+import { screen, setupTest } from '@test-setup';
+import * as utilities from 'commons/utilities';
+
+vi.mock('@zextras/carbonio-ui-commons', async () => {
+	const actual = await vi.importActual('@zextras/carbonio-ui-commons');
+	return {
+		...actual,
+		useFolder: vi.fn()
+	};
+});
+
+vi.mock('commons/utilities', async () => {
+	const actual = await vi.importActual('commons/utilities');
+	return {
+		...actual,
+		isIcsOrCaldavExternalFolder: vi.fn()
+	};
+});
+
+const LOGGED_USER = 'logged-user@test.com';
+const SHARED_ACCOUNT = 'shared-account@test.com';
+const DELEGATE = 'delegate@test.com';
+
+const sharedCalendar = { id: 'shared-cal', f: '#', owner: SHARED_ACCOUNT };
+const ownCalendar = { id: 'own-cal', f: '#' };
+
+const buildInvite = (organizer: Record<string, unknown>, isOrganizer = false): unknown => ({
+	ciFolder: 'cal',
+	isOrganizer,
+	organizer,
+	attendees: [{ a: LOGGED_USER }]
+});
+
+describe('organizer part', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(utilities.isIcsOrCaldavExternalFolder).mockReturnValue(false);
+		shell.useUserAccount.mockReturnValue({
+			name: LOGGED_USER,
+			displayName: 'Me'
+		} as never);
+	});
+
+	describe('when the appointment is created on behalf of the organizer', () => {
+		test('the logged user delegate is shown as the organizer of the shared calendar', () => {
+			vi.mocked(useFolder).mockReturnValue(sharedCalendar as never);
+			const organizer = { a: SHARED_ACCOUNT, d: 'Shared Account', sentBy: LOGGED_USER };
+
+			setupTest(
+				<OrganizerPart
+					invite={buildInvite(organizer) as never}
+					organizer={organizer as never}
+					calendarOwner={SHARED_ACCOUNT}
+				/>
+			);
+
+			expect(screen.getByText(/You/)).toBeVisible();
+			expect(screen.getByText(/are the organizer/)).toBeVisible();
+			expect(screen.getByTestId('OnBehalfOf')).toHaveTextContent(SHARED_ACCOUNT);
+		});
+
+		test('another delegate is shown as the creator, with the organizer as the account it acts for', () => {
+			vi.mocked(useFolder).mockReturnValue(ownCalendar as never);
+			const organizer = { a: SHARED_ACCOUNT, d: 'Shared Account', sentBy: DELEGATE };
+
+			setupTest(
+				<OrganizerPart invite={buildInvite(organizer) as never} organizer={organizer as never} />
+			);
+
+			// the delegate is both the subject of the sentence and the address of the chip
+			expect(screen.getAllByText(DELEGATE)).not.toHaveLength(0);
+			expect(screen.getByText(/invited you/)).toBeVisible();
+			expect(screen.getByTestId('OnBehalfOf')).toHaveTextContent(SHARED_ACCOUNT);
+		});
+
+		test('the chip holds the delegate address, not the organizer one', () => {
+			vi.mocked(useFolder).mockReturnValue(ownCalendar as never);
+			const organizer = { a: SHARED_ACCOUNT, d: 'Shared Account', sentBy: DELEGATE };
+
+			setupTest(
+				<OrganizerPart invite={buildInvite(organizer) as never} organizer={organizer as never} />
+			);
+
+			expect(screen.getByTestId('Chip')).toHaveTextContent(DELEGATE);
+			expect(screen.getByTestId('Chip')).not.toHaveTextContent(SHARED_ACCOUNT);
+		});
+	});
+
+	describe('when the appointment is not created on behalf of the organizer', () => {
+		test('no "on behalf of" is shown and the organizer keeps being the subject', () => {
+			vi.mocked(useFolder).mockReturnValue(ownCalendar as never);
+			const organizer = { a: SHARED_ACCOUNT, d: 'Shared Account' };
+
+			setupTest(
+				<OrganizerPart invite={buildInvite(organizer) as never} organizer={organizer as never} />
+			);
+
+			expect(screen.getByText('Shared Account')).toBeVisible();
+			expect(screen.getByText(/invited you/)).toBeVisible();
+			expect(screen.queryByTestId('OnBehalfOf')).not.toBeInTheDocument();
+		});
+
+		test('a sentBy equal to the organizer is not treated as a delegation', () => {
+			vi.mocked(useFolder).mockReturnValue(ownCalendar as never);
+			const organizer = { a: SHARED_ACCOUNT, d: 'Shared Account', sentBy: SHARED_ACCOUNT };
+
+			setupTest(
+				<OrganizerPart invite={buildInvite(organizer) as never} organizer={organizer as never} />
+			);
+
+			expect(screen.getByText('Shared Account')).toBeVisible();
+			expect(screen.queryByTestId('OnBehalfOf')).not.toBeInTheDocument();
+		});
+
+		test('the logged user organizer keeps seeing itself as the organizer', () => {
+			vi.mocked(useFolder).mockReturnValue(ownCalendar as never);
+			const organizer = { a: LOGGED_USER, d: 'Me' };
+
+			setupTest(
+				<OrganizerPart
+					invite={buildInvite(organizer, true) as never}
+					organizer={organizer as never}
+				/>
+			);
+
+			expect(screen.getByText(/are the organizer/)).toBeVisible();
+			expect(screen.queryByTestId('OnBehalfOf')).not.toBeInTheDocument();
+		});
+	});
+});

--- a/src/view/event-summary-view/free-busy-status-row.test.tsx
+++ b/src/view/event-summary-view/free-busy-status-row.test.tsx
@@ -10,21 +10,42 @@ import { screen } from '@testing-library/react';
 
 import { FreeBusyStatusRow } from './free-busy-status-row';
 import { EVENT_DISPLAY_STATUS } from '../../constants/api';
+import { InviteOrganizer } from '../../types/store/invite';
 import * as shell from '@test-mocks/@zextras/carbonio-shell-ui';
 import { setupTest } from '@test-setup';
 
+const organizerWith = (a: string, sentBy?: string): InviteOrganizer => ({
+	a,
+	d: a,
+	url: a,
+	sentBy
+});
+
 describe('free busy status row', () => {
 	test.each`
-		freeBusy  | organizerName               | expected
-		${'busy'} | ${shell.mockedAccount.name} | ${/You set this appointment as/i}
-		${'busy'} | ${faker.internet.email()}   | ${/The organizer set this appointment as/}
+		freeBusy  | organizer                                  | expected
+		${'busy'} | ${organizerWith(shell.mockedAccount.name)} | ${/You set this appointment as/i}
+		${'busy'} | ${organizerWith(faker.internet.email())}   | ${/The organizer set this appointment as/}
 	`(
 		'will render a different subject depending if the user is organizer or not',
-		({ freeBusy, organizerName, expected }) => {
-			setupTest(<FreeBusyStatusRow freeBusy={freeBusy} organizerName={organizerName} />);
+		({ freeBusy, organizer, expected }) => {
+			setupTest(<FreeBusyStatusRow freeBusy={freeBusy} organizer={organizer} />);
 			expect(screen.getByText(expected)).toBeVisible();
 		}
 	);
+
+	test.each`
+		freeBusy  | organizer                                                          | expected
+		${'busy'} | ${organizerWith(faker.internet.email(), shell.mockedAccount.name)} | ${/You set this appointment as/i}
+		${'busy'} | ${organizerWith(faker.internet.email(), faker.internet.email())}   | ${/The organizer set this appointment as/}
+	`(
+		'will attribute the appointment to the delegate when it is created on behalf of the organizer',
+		({ freeBusy, organizer, expected }) => {
+			setupTest(<FreeBusyStatusRow freeBusy={freeBusy} organizer={organizer} />);
+			expect(screen.getByText(expected)).toBeVisible();
+		}
+	);
+
 	test.each`
 		freeBusyText        | freeBusyValue
 		${/busy/i}          | ${EVENT_DISPLAY_STATUS.BUSY}
@@ -33,7 +54,10 @@ describe('free busy status row', () => {
 		${/out of office/i} | ${EVENT_DISPLAY_STATUS.OUT_OF_OFFICE}
 	`('will render a different status', ({ freeBusyText, freeBusyValue }) => {
 		setupTest(
-			<FreeBusyStatusRow freeBusy={freeBusyValue} organizerName={faker.internet.email()} />
+			<FreeBusyStatusRow
+				freeBusy={freeBusyValue}
+				organizer={organizerWith(faker.internet.email())}
+			/>
 		);
 		expect(screen.getByText(freeBusyText)).toBeVisible();
 	});

--- a/src/view/event-summary-view/free-busy-status-row.tsx
+++ b/src/view/event-summary-view/free-busy-status-row.tsx
@@ -10,24 +10,25 @@ import { useUserAccount } from '@zextras/carbonio-shell-ui';
 import { toLower } from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { EVENT_DISPLAY_STATUS } from '../../constants/api';
-import { InviteFreeBusy, InviteOrganizer } from '../../types/store/invite';
+import { EVENT_DISPLAY_STATUS } from 'constants/api';
+import { InviteFreeBusy, InviteOrganizer } from 'types/store/invite';
+import { isAppointmentCreatedBy } from 'utils/organizer';
 
 export const FreeBusyStatusRowComponent = ({
 	freeBusy,
-	organizerName
+	organizer
 }: {
 	freeBusy: InviteFreeBusy;
-	organizerName: InviteOrganizer['a'];
+	organizer: InviteOrganizer | undefined;
 }): React.JSX.Element => {
 	const account = useUserAccount();
 	const [t] = useTranslation();
 	const whoSetThis = useMemo(
 		() =>
-			organizerName === account.name
+			isAppointmentCreatedBy(organizer, account.name)
 				? t('message.you', 'You')
 				: t('message.the_organizer', 'The organizer'),
-		[account.name, organizerName, t]
+		[account.name, organizer, t]
 	);
 
 	const status = useMemo(() => {
@@ -58,10 +59,10 @@ export const FreeBusyStatusRowComponent = ({
 
 export const FreeBusyStatusRow = ({
 	freeBusy,
-	organizerName
+	organizer
 }: {
 	freeBusy: InviteFreeBusy;
-	organizerName: InviteOrganizer['a'];
+	organizer: InviteOrganizer | undefined;
 }): React.JSX.Element => (
 	<Container
 		orientation="vertical"
@@ -82,7 +83,7 @@ export const FreeBusyStatusRow = ({
 		>
 			<Row mainAlignment="flex-start" crossAlignment="center" width="fill">
 				<Padding left={'1.5rem'} />
-				<FreeBusyStatusRowComponent organizerName={organizerName} freeBusy={freeBusy} />
+				<FreeBusyStatusRowComponent organizer={organizer} freeBusy={freeBusy} />
 			</Row>
 		</Container>
 	</Container>

--- a/src/view/search/search-list-item.tsx
+++ b/src/view/search/search-list-item.tsx
@@ -25,6 +25,7 @@ import { useAppDispatch, useAppSelector } from 'store/redux/hooks';
 import { selectInstanceInvite } from 'store/selectors/invites';
 import { ActionsContext } from 'types/actions';
 import { EventType } from 'types/event';
+import { isSentOnBehalfOf } from 'utils/organizer';
 
 const SearchListItem = ({ item }: { item: EventType }): React.ReactElement => {
 	const [t] = useTranslation();
@@ -32,7 +33,10 @@ const SearchListItem = ({ item }: { item: EventType }): React.ReactElement => {
 	const isPrivateLabel = t('is_private', 'Is private');
 	const isRecurrentLabel = t('label.recurrent', 'Recurrent appointment');
 	const hasAttachmentsLabel = t('has_attachments', 'Has attachments');
-	const organizerLabel = item.resource?.organizer?.name ?? item.resource?.organizer?.email;
+	const organizer = item.resource?.organizer;
+	const organizerLabel = isSentOnBehalfOf({ a: organizer?.email, sentBy: organizer?.sentBy })
+		? organizer?.sentBy
+		: (organizer?.name ?? organizer?.email);
 	const organizedByLabel = `${t('search.organized_by', 'organized by')} ${organizerLabel}`;
 
 	const dispatch = useAppDispatch();


### PR DESCRIPTION
This PR shows the real creator. Wherever an appointment names its organizer, the person who created it is now the subject, with an **on behalf of \<calendar owner\>** line beneath. Applies to the appointment panel, the summary popup, the search results, the reminder details, and the rich preview invitation email in Mails.
