### PR TITLE
fix(CO-3632): exclude resources without an address from invite attendees and participants

### DIFF
--- a/src/normalizations/normalize-soap-message-from-editor.ts
+++ b/src/normalizations/normalize-soap-message-from-editor.ts
@@ -144,8 +144,10 @@ export const generateParticipantInformation = (resource: Editor): Array<Partial<
 					concat(
 						resource?.attendees,
 						resource?.optionalAttendees,
-						resource?.meetingRoom ?? [],
-						resource?.equipment ?? []
+						// Resources removed from the GAL lose their email (see CO-3632); without one they
+						// cannot be a valid mail recipient, so exclude them from the participant list.
+						(resource?.meetingRoom ?? []).filter((c) => !!c?.email),
+						(resource?.equipment ?? []).filter((c) => !!c?.email)
 					),
 					(attendee) => ({
 						a: attendee?.email ?? attendee?.label,
@@ -317,30 +319,37 @@ const generateInvite = (editor: Editor): any => {
 			}))
 		);
 
+	// Skip resources without an address: a calendar resource removed from the GAL (see CO-3632)
+	// loses its email, and sending an <at> element with no address makes the server reject the
+	// whole request with "missing attendee address".
 	editor?.meetingRoom &&
 		at.push(
-			...editor.meetingRoom.map((c) => ({
-				a: c?.email,
-				d: c.label,
-				role: PARTICIPANT_ROLE.NON_PARTICIPANT,
-				ptst: PARTICIPATION_STATUS.NEED_ACTION,
-				rsvp: true,
-				url: c?.email,
-				cutype: CALENDAR_RESOURCES.ROOM
-			}))
+			...editor.meetingRoom
+				.filter((c) => !!c?.email)
+				.map((c) => ({
+					a: c?.email,
+					d: c.label,
+					role: PARTICIPANT_ROLE.NON_PARTICIPANT,
+					ptst: PARTICIPATION_STATUS.NEED_ACTION,
+					rsvp: true,
+					url: c?.email,
+					cutype: CALENDAR_RESOURCES.ROOM
+				}))
 		);
 
 	editor?.equipment &&
 		at.push(
-			...editor.equipment.map((c) => ({
-				a: c?.email,
-				d: c.label,
-				role: PARTICIPANT_ROLE.NON_PARTICIPANT,
-				ptst: PARTICIPATION_STATUS.NEED_ACTION,
-				rsvp: true,
-				url: c?.email,
-				cutype: CALENDAR_RESOURCES.RESOURCE
-			}))
+			...editor.equipment
+				.filter((c) => !!c?.email)
+				.map((c) => ({
+					a: c?.email,
+					d: c.label,
+					role: PARTICIPANT_ROLE.NON_PARTICIPANT,
+					ptst: PARTICIPATION_STATUS.NEED_ACTION,
+					rsvp: true,
+					url: c?.email,
+					cutype: CALENDAR_RESOURCES.RESOURCE
+				}))
 		);
 
 	return {

--- a/src/normalizations/tests/normalize-soap-message-from-editor.test.ts
+++ b/src/normalizations/tests/normalize-soap-message-from-editor.test.ts
@@ -136,6 +136,60 @@ describe('normalize soap message from editor', () => {
 					ptst: PARTICIPATION_STATUS.NEED_ACTION
 				});
 			});
+			describe('resources without an address (CO-3632)', () => {
+				test('a meeting room / equipment with an email is kept as attendee and participant', () => {
+					const userAccount = getMockedAccountItem({ identity1: mainAccount });
+					shell.getUserAccount.mockImplementation(() => userAccount);
+
+					const editor = generateEditor({
+						context: {
+							folders: {},
+							dispatch: vi.fn(),
+							calendar: mainAccountEditorFolder,
+							meetingRoom: [{ email: 'room@example.com', label: 'Room A' }],
+							equipment: [{ email: 'beamer@example.com', label: 'Beamer' }]
+						}
+					});
+					const body = normalizeSoapMessageFromEditor(editor);
+
+					const addresses = body.m.inv.comp[0].at.map((a: { a?: string }) => a.a);
+					expect(addresses).toEqual(
+						expect.arrayContaining(['room@example.com', 'beamer@example.com'])
+					);
+					const participantAddresses = body.m.e.map((e: { a?: string }) => e.a);
+					expect(participantAddresses).toEqual(
+						expect.arrayContaining(['room@example.com', 'beamer@example.com'])
+					);
+				});
+
+				test('a meeting room / equipment without an email is excluded from attendees and participants', () => {
+					const userAccount = getMockedAccountItem({ identity1: mainAccount });
+					shell.getUserAccount.mockImplementation(() => userAccount);
+
+					const editor = generateEditor({
+						context: {
+							folders: {},
+							dispatch: vi.fn(),
+							calendar: mainAccountEditorFolder,
+							meetingRoom: [{ email: undefined, label: 'Deleted Room' }] as never,
+							equipment: [{ email: '', label: 'Deleted Beamer' }] as never
+						}
+					});
+					const body = normalizeSoapMessageFromEditor(editor);
+
+					// the invite must not carry an <at> without an address (server rejects the request)
+					body.m.inv.comp[0].at.forEach((attendee: { a?: string }) => {
+						expect(attendee.a).toBeTruthy();
+					});
+					const attendeeLabels = body.m.inv.comp[0].at.map((a: { d?: string }) => a.d);
+					expect(attendeeLabels).not.toContain('Deleted Room');
+					expect(attendeeLabels).not.toContain('Deleted Beamer');
+					// and neither should the participant (<e>) list use the label as an address
+					const participantAddresses = body.m.e.map((e: { a?: string }) => e.a);
+					expect(participantAddresses).not.toContain('Deleted Room');
+					expect(participantAddresses).not.toContain('Deleted Beamer');
+				});
+			});
 			describe('and he is not using identities ', () => {
 				test('there wont be a sentBy parameter', () => {
 					const userAccount = getMockedAccountItem({ identity1: mainAccount, identity2: identity });


### PR DESCRIPTION
## Summary

When a calendar resource is removed from the GAL, its email becomes empty. As a result, the editor generated an `<at>` element without an address, causing the server to reject the entire `ModifyAppointment` request with:

> `invalid request: missing attendee address`

This is the warning users encountered when attempting to edit the appointment.

## Changes

- Filter out resource attendees that do not have an email address in `generateInvite()`.
- Apply the same filtering in `generateParticipantInformation()`, where a missing email previously fell back to the resource's label, which would otherwise have been used as the `To:` address.
- Add regression tests covering resource attendees both with and without an email address.

## Impact

- Prevents invalid attendee entries from being included in appointment updates.
- Allows appointments containing removed calendar resources to be edited successfully.

## Related
https://github.com/zextras/carbonio-mailbox/pull/1106