### PR TITLE
fix: use current identity displayName for organizer on resend

### DIFF
--- a/src/normalizations/normalize-editor.ts
+++ b/src/normalizations/normalize-editor.ts
@@ -4,12 +4,14 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { getUserAccount } from '@zextras/carbonio-shell-ui';
 import { getRoot, LinkFolder, getPrefs } from '@zextras/carbonio-ui-commons';
 import { endOfDay, set, startOfDay } from 'date-fns';
 import { filter, find, isNil, map, omitBy } from 'lodash';
 
 import { extractBody, extractHtmlBody } from '../commons/body-message-renderer';
 import type { EditorContext } from '../commons/editor-generator';
+import { getIdentityItems } from '../commons/get-identity-items';
 import { CALENDAR_RESOURCES, PREFS_DEFAULTS } from '../constants';
 import { PARTICIPANT_ROLE } from '../constants/api';
 import { CRB_XPARAMS, CRB_XPROPS } from '../constants/xprops';
@@ -168,9 +170,17 @@ export const normalizeEditor = ({
 	context: EditorContext;
 }): Editor => {
 	if (event && invite) {
+		const account = getUserAccount();
+		const isOrganizerCurrentUser = event.resource.organizer?.email === account?.name;
+		// event.resource.organizer.name is frozen at the time the invite was created/last sent;
+		// if the logged-in user is the organizer, prefer the identity's current display name
+		// so a displayName change is picked up without needing a full app reload.
+		const currentIdentityFullName = isOrganizerCurrentUser
+			? find(getIdentityItems(), ['identityName', 'DEFAULT'])?.fullName
+			: undefined;
 		const organizer = {
 			email: event.resource.organizer?.email ?? '',
-			fullName: event.resource.organizer?.name
+			fullName: currentIdentityFullName ?? event.resource.organizer?.name
 		};
 		const isSeries = event?.resource?.isRecurrent;
 		const isInstance = context.isInstance ?? !!event?.resource?.ridZ;

--- a/src/normalizations/tests/normalize-editor.test.ts
+++ b/src/normalizations/tests/normalize-editor.test.ts
@@ -10,6 +10,7 @@ import { FOLDERS } from '@zextras/carbonio-ui-commons';
 import { createEmptyEditor } from '../../commons/editor-generator';
 import mockedData from '../../test/generators';
 import { normalizeEditor } from '../normalize-editor';
+import { mockedAccount } from '@test-mocks/@zextras/carbonio-shell-ui';
 
 describe('normalizeEditor', () => {
 	test('If event and invite are not available, it will return empty editor', () => {
@@ -265,6 +266,59 @@ describe('normalizeEditor', () => {
 			});
 
 			expect(result.compNum).toBe(0);
+		});
+	});
+	describe('normalize organizer property', () => {
+		test('if the logged-in user is the organizer, fullName is taken from the current DEFAULT identity instead of the invite snapshot', () => {
+			const folders = mockedData.calendars.getCalendarsMap();
+			const emptyEditor = createEmptyEditor('1', folders);
+			const staleName = 'Stale Old Display Name';
+			const currentIdentityFullName = mockedAccount.identities.identity[0]._attrs
+				?.zimbraPrefFromDisplay as string;
+			const event = mockedData.getEvent({
+				resource: {
+					organizer: {
+						email: mockedAccount.name,
+						name: staleName
+					}
+				}
+			});
+			const invite = mockedData.getInvite({ event });
+
+			const result = normalizeEditor({
+				invite,
+				event,
+				emptyEditor,
+				context: { folders, dispatch: vi.fn() }
+			});
+
+			expect(result.organizer?.fullName).toBe(currentIdentityFullName);
+			expect(result.organizer?.fullName).not.toBe(staleName);
+		});
+		test('if the logged-in user is not the organizer, fullName is taken from the invite snapshot', () => {
+			const folders = mockedData.calendars.getCalendarsMap();
+			const emptyEditor = createEmptyEditor('1', folders);
+			const event = mockedData.getEvent({
+				resource: {
+					organizer: {
+						email: 'someone-else@example.com',
+						name: 'Someone Else'
+					}
+				}
+			});
+			const invite = mockedData.getInvite({ event });
+
+			const result = normalizeEditor({
+				invite,
+				event,
+				emptyEditor,
+				context: { folders, dispatch: vi.fn() }
+			});
+
+			expect(result.organizer).toStrictEqual({
+				email: 'someone-else@example.com',
+				fullName: 'Someone Else'
+			});
 		});
 	});
 });


### PR DESCRIPTION
Editing and resending an existing appointment kept using the organizer's displayName snapshotted in the invite at creation time, so attendees kept seeing the old name after the organizer changed their zimbraPrefFromDisplay. When the logged-in user is the organizer, the fresh name from the current DEFAULT identity is used instead.

refs: CO-3643