### PR TITLE
fix(CO-3616): apply default appointment visibility setting to new appointments

### DIFF
--- a/src/carbonio-ui-soap-lib.ts
+++ b/src/carbonio-ui-soap-lib.ts
@@ -14,6 +14,7 @@ declare module '@zextras/carbonio-ui-soap-lib' {
 		zimbraPrefCalendarFirstDayOfWeek: string;
 		zimbraPrefCalendarInitialView: string;
 		zimbraPrefCalendarApptReminderWarningTime: string;
+		zimbraPrefCalendarApptVisibility: string;
 		zimbraPrefUseTimeZoneListInCalendar: string;
 		zimbraPrefCalendarForwardInvitesTo: string;
 		zimbraPrefAppleIcalDelegationEnabled: string;

--- a/src/commons/editor-generator.ts
+++ b/src/commons/editor-generator.ts
@@ -63,7 +63,8 @@ export const createEmptyEditor = (id: string, folders: Folders): Editor => {
 	const {
 		zimbraPrefCalendarDefaultApptDuration,
 		zimbraPrefCalendarApptReminderWarningTime,
-		zimbraPrefDefaultCalendarId
+		zimbraPrefDefaultCalendarId,
+		zimbraPrefCalendarApptVisibility
 	} = getPrefs();
 	const account = getUserAccount();
 	const defaultOrganizerIdentity = find(identities, ['identityName', 'DEFAULT']);
@@ -107,7 +108,7 @@ export const createEmptyEditor = (id: string, folders: Folders): Editor => {
 		optionalAttendees: [],
 		allDay: false,
 		freeBusy: EVENT_DISPLAY_STATUS.BUSY,
-		class: 'PUB',
+		class: zimbraPrefCalendarApptVisibility === 'private' ? 'PRI' : 'PUB',
 		originalStart: new Date(new Date().setSeconds(0, 0)).getTime(),
 		originalEnd: getEndTime({
 			start: new Date(new Date().setSeconds(0, 0)).getTime(),

--- a/src/commons/tests/editor-generator.test.ts
+++ b/src/commons/tests/editor-generator.test.ts
@@ -92,6 +92,22 @@ describe('Editor generator', () => {
 			expect(editor.title).toBe('');
 			expect(editor.compNum).toBe(0);
 		});
+		test('default visibility follows the zimbraPrefCalendarApptVisibility setting', () => {
+			shell.getUserSettings.mockImplementationOnce(() => ({
+				...defaultSettings,
+				prefs: {
+					...defaultSettings.prefs,
+					zimbraPrefCalendarApptVisibility: 'private'
+				}
+			}));
+			const store = configureStore({ reducer: combineReducers(reducers) });
+			const context = { folders, dispatch: store.dispatch };
+			const editor = generateEditor({
+				context
+			});
+
+			expect(editor.class).toBe('PRI');
+		});
 		test('series appointment', () => {
 			const store = configureStore({ reducer: combineReducers(reducers) });
 			const event = mockedData.getEvent({


### PR DESCRIPTION
New appointments always defaulted to public visibility, ignoring the zimbraPrefCalendarApptVisibility user preference set in Settings.
refs: CO-3616