### PR TITLE
fix(CO-3633): align primary account sidebar label to displayName, avatar color and font size

### DIFF
--- a/src/view/secondary-bar/custom-accordion-components/account-accordion-item.test.tsx
+++ b/src/view/secondary-bar/custom-accordion-components/account-accordion-item.test.tsx
@@ -35,4 +35,28 @@ describe('AccountAccordionItem', () => {
 
 		expect(screen.getByTestId(TEST_SELECTORS.AVATAR)).toBeVisible();
 	});
+
+	it('should render the account avatar with the same color regardless of the account label', () => {
+		const { rerender } = setupTest(<AccountAccordionItem item={item} />);
+		const firstColor = window.getComputedStyle(
+			screen.getByTestId(TEST_SELECTORS.AVATAR)
+		).backgroundColor;
+
+		rerender(<AccountAccordionItem item={{ ...item, label: 'a-different-label@example.com' }} />);
+		const secondColor = window.getComputedStyle(
+			screen.getByTestId(TEST_SELECTORS.AVATAR)
+		).backgroundColor;
+
+		expect(firstColor).not.toBe('');
+		expect(firstColor).toBe(secondColor);
+	});
+
+	it('should render the account label at the small font size', () => {
+		setupTest(<AccountAccordionItem item={item} />);
+
+		expect(screen.getByText(primaryIdentity.identity.email)).toHaveStyleRule(
+			'font-size',
+			'0.875rem'
+		);
+	});
 });

--- a/src/view/secondary-bar/custom-accordion-components/account-accordion-item.tsx
+++ b/src/view/secondary-bar/custom-accordion-components/account-accordion-item.tsx
@@ -13,13 +13,15 @@ import {
 	Container,
 	Avatar
 } from '@zextras/carbonio-design-system';
+import { ZIMBRA_STANDARD_COLORS } from '@zextras/carbonio-ui-commons';
 
 export const AccountAccordionItem: FC<AccordionItemProps> = (props) => {
 	const { id, label } = props.item;
 
 	const item: AccordionItemType = {
 		id,
-		label
+		label,
+		textProps: { size: 'small' }
 	};
 
 	return (
@@ -29,7 +31,7 @@ export const AccountAccordionItem: FC<AccordionItemProps> = (props) => {
 			mainAlignment="flex-start"
 			padding={{ vertical: 'extrasmall' }}
 		>
-			<Avatar label={label ?? ''} colorLabel={item.iconColor} size="medium" />
+			<Avatar label={label ?? ''} colorLabel={ZIMBRA_STANDARD_COLORS[0].hex} size="medium" />
 			<Tooltip label={label}>
 				<AccordionItem {...props} item={item} />
 			</Tooltip>

--- a/src/view/secondary-bar/expanded-secondary-bar.test.tsx
+++ b/src/view/secondary-bar/expanded-secondary-bar.test.tsx
@@ -30,7 +30,7 @@ describe('ExpandedSecondaryBar', () => {
 
 		setupTest(<ExpandedSecondaryBar />, { store });
 
-		expect(screen.getByText(primaryIdentity.identity.email)).toBeVisible();
+		expect(screen.getByText(primaryIdentity.identity.fullName)).toBeVisible();
 	});
 
 	it('should render the shared accounts accordion items', () => {

--- a/src/view/secondary-bar/primary-account-accordion.test.tsx
+++ b/src/view/secondary-bar/primary-account-accordion.test.tsx
@@ -15,7 +15,7 @@ import { getMocksContext } from '@test-utils/utils/mocks-context';
 import { reducers } from 'store/redux';
 
 describe('PrimaryAccountAccordion', () => {
-	it('should render the primary account email', () => {
+	it('should render the primary account display name', () => {
 		useLocalStorage.mockReturnValue([[], vi.fn()]);
 		populateFoldersStore();
 		const mockedContext = getMocksContext();
@@ -25,6 +25,6 @@ describe('PrimaryAccountAccordion', () => {
 
 		setupTest(<PrimaryAccountAccordion />, { store });
 
-		expect(screen.getByText(mockedContext.identities.primary.identity.email)).toBeVisible();
+		expect(screen.getByText(mockedContext.identities.primary.identity.fullName)).toBeVisible();
 	});
 });

--- a/src/view/secondary-bar/use-secondary-bar-tree-primary-account.test.ts
+++ b/src/view/secondary-bar/use-secondary-bar-tree-primary-account.test.ts
@@ -33,7 +33,7 @@ describe('useSecondaryBarTreePrimaryAccount', () => {
 
 		const expectedResult = {
 			id: primaryAccountRoot.id,
-			label: account?.name,
+			label: account?.displayName,
 			CustomComponent: AccountAccordionItem,
 			items: [
 				{

--- a/src/view/secondary-bar/use-secondary-bar-tree-primary-account.ts
+++ b/src/view/secondary-bar/use-secondary-bar-tree-primary-account.ts
@@ -20,6 +20,7 @@ import { SIDEBAR_ROOT_SUBSECTION } from '../../constants/sidebar';
 export const useSecondaryBarTreePrimaryAccount = (): AccordionItemType => {
 	const [t] = useTranslation();
 	const account = useUserAccount();
+	const accountName = account?.displayName ?? account?.name;
 	const groupsItems = useSecondaryBarTreeGroups();
 	const calendarsItems = useSecondaryBarTreePrimaryCalendars(FOLDERS.USER_ROOT);
 	const { isOpen, setOpenStatus } = useAccordionItemOpenStatusStorage();
@@ -41,7 +42,7 @@ export const useSecondaryBarTreePrimaryAccount = (): AccordionItemType => {
 	return useMemo(
 		() => ({
 			id: FOLDERS.USER_ROOT,
-			label: account?.name,
+			label: accountName,
 			CustomComponent: AccountAccordionItem,
 			open: isOpen(FOLDERS.USER_ROOT),
 			onOpen: onPrimaryAccountOpen(FOLDERS.USER_ROOT),
@@ -66,7 +67,7 @@ export const useSecondaryBarTreePrimaryAccount = (): AccordionItemType => {
 			]
 		}),
 		[
-			account?.name,
+			accountName,
 			isOpen,
 			onPrimaryAccountOpen,
 			onPrimaryAccountClose,


### PR DESCRIPTION
The primary account root in the calendars sidebar showed the raw email address instead of the account displayName, unlike mails-ui and contacts-ui. It also rendered the avatar with a color hashed from the label (varying per account) and at the wrong font size, instead of matching the fixed color and small font size used by the other modules.

refs: CO-3633