### PR TITLE
fix(CO-3619): include subject and description when forwarding an appointment

### DIFF
--- a/src/soap/forward-appointment-request.ts
+++ b/src/soap/forward-appointment-request.ts
@@ -10,10 +10,12 @@ import { ForwardAppointmentRequest, ForwardAppointmentResponse } from '../types/
 export const forwardAppointmentRequest = async ({
 	id,
 	attendees,
+	subject,
 	messageParts
 }: {
 	id: string;
 	attendees: Array<string>;
+	subject: string;
 	messageParts: Array<{ ct: string; content: string }>;
 }): Promise<ForwardAppointmentResponse | ErrorSoapResponse> =>
 	legacySoapFetch<ForwardAppointmentRequest, ForwardAppointmentResponse>('ForwardAppointment', {
@@ -21,6 +23,7 @@ export const forwardAppointmentRequest = async ({
 		id,
 		m: {
 			e: attendees.map((attendee) => ({ a: attendee, t: 't' })),
+			su: subject,
 			...(messageParts.length > 0
 				? {
 						mp: {

--- a/src/types/soap/soap-actions.ts
+++ b/src/types/soap/soap-actions.ts
@@ -83,6 +83,7 @@ export type ForwardAppointmentRequest = ZimbraRequest & {
 	id: string;
 	m: {
 		e: Array<{ a: string; t: string }>;
+		su?: string;
 		mp?: {
 			ct: string;
 			mp: Array<{ ct: string; content: string }>;

--- a/src/view/modals/forward-appointment/forward-appointment-modal.tsx
+++ b/src/view/modals/forward-appointment/forward-appointment-modal.tsx
@@ -44,6 +44,7 @@ export const ForwardAppointmentModal = ({
 
 	const forwardAppointment = useForwardAppointment({
 		eventId: event.resource.id,
+		subject: event.title,
 		onSuccess: showSuccessSnackbar,
 		onError: showErrorSnackbar,
 		onComplete: onClose

--- a/src/view/modals/forward-appointment/message-parts-builder.ts
+++ b/src/view/modals/forward-appointment/message-parts-builder.ts
@@ -4,19 +4,32 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { MessageData } from 'view/modals/forward-appointment/types';
+import { MessageData, RawMimePart } from 'view/modals/forward-appointment/types';
 
 export type MessagePart = {
 	ct: string;
 	content: string;
 };
 
+/**
+ * Recursively looks for a MIME part with the given content type inside the raw
+ * Zimbra `mp` tree, returning its content, or an empty string if not found.
+ */
+const findMimeTextContent = (parts: RawMimePart[] | undefined, ct: string): string => {
+	if (!parts) return '';
+	const directMatch = parts.find((part) => part.ct === ct && part.content);
+	if (directMatch?.content) return directMatch.content;
+	return parts.reduce((found, part) => found || findMimeTextContent(part.mp, ct), '');
+};
+
 export const buildMessageParts = (messageData: MessageData | null): MessagePart[] => {
 	if (!messageData) return [];
 
 	const invite = messageData?.inv?.[0]?.comp?.[0];
-	const plainText = invite?.desc?.[0]?._content ?? '';
-	const htmlContent = invite?.descHtml?.[0]?._content ?? '';
+	const plainText =
+		invite?.desc?.[0]?._content ?? findMimeTextContent(messageData.mp, 'text/plain');
+	const htmlContent =
+		invite?.descHtml?.[0]?._content ?? findMimeTextContent(messageData.mp, 'text/html');
 
 	const parts: MessagePart[] = [];
 

--- a/src/view/modals/forward-appointment/tests/forward-appointment-modal.test.tsx
+++ b/src/view/modals/forward-appointment/tests/forward-appointment-modal.test.tsx
@@ -27,6 +27,7 @@ async function inputAttendee(user: UserEvent, input: HTMLElement, attendee: stri
 
 describe('ForwardAppointmentModal', () => {
 	const event = {
+		title: 'Test event title',
 		resource: {
 			id: '123'
 		}
@@ -81,6 +82,7 @@ describe('ForwardAppointmentModal', () => {
 			const request = await interceptor;
 
 			expect(request.id).toBe('123');
+			expect(request.m.su).toBe('Test event title');
 			expect(request.m.e).toEqual([{ a: attendee, t: 't' }]);
 		});
 

--- a/src/view/modals/forward-appointment/tests/message-parts-builder.test.ts
+++ b/src/view/modals/forward-appointment/tests/message-parts-builder.test.ts
@@ -246,4 +246,95 @@ describe('buildMessageParts', () => {
 			}
 		]);
 	});
+
+	it('should fall back to raw mp plain text part when comp has no desc', () => {
+		const messageData = {
+			inv: [{ comp: [{}] }],
+			mp: [{ ct: 'text/plain', content: 'Plain text from mp' }]
+		};
+
+		const result = buildMessageParts(messageData);
+
+		expect(result).toEqual([
+			{
+				ct: 'text/plain',
+				content: 'Plain text from mp'
+			}
+		]);
+	});
+
+	it('should fall back to raw mp html part when comp has no descHtml', () => {
+		const messageData = {
+			inv: [{ comp: [{}] }],
+			mp: [{ ct: 'text/html', content: '<p>HTML from mp</p>' }]
+		};
+
+		const result = buildMessageParts(messageData);
+
+		expect(result).toEqual([
+			{
+				ct: 'text/html',
+				content: '<p>HTML from mp</p>'
+			}
+		]);
+	});
+
+	it('should find both text and html parts nested inside a multipart/alternative mp tree', () => {
+		const messageData = {
+			inv: [{ comp: [{}] }],
+			mp: [
+				{
+					ct: 'multipart/alternative',
+					mp: [
+						{ ct: 'text/plain', content: 'Nested plain text' },
+						{ ct: 'text/html', content: '<p>Nested HTML</p>' }
+					]
+				}
+			]
+		};
+
+		const result = buildMessageParts(messageData);
+
+		expect(result).toEqual([
+			{ ct: 'text/plain', content: 'Nested plain text' },
+			{ ct: 'text/html', content: '<p>Nested HTML</p>' }
+		]);
+	});
+
+	it('should prefer comp desc/descHtml over the raw mp fallback', () => {
+		const messageData = {
+			inv: [
+				{
+					comp: [
+						{
+							desc: [{ _content: 'Component text' }],
+							descHtml: [{ _content: '<p>Component html</p>' }]
+						}
+					]
+				}
+			],
+			mp: [
+				{ ct: 'text/plain', content: 'Should not be used' },
+				{ ct: 'text/html', content: '<p>Should not be used</p>' }
+			]
+		};
+
+		const result = buildMessageParts(messageData);
+
+		expect(result).toEqual([
+			{ ct: 'text/plain', content: 'Component text' },
+			{ ct: 'text/html', content: '<p>Component html</p>' }
+		]);
+	});
+
+	it('should return empty array when neither comp nor mp have description content', () => {
+		const messageData = {
+			inv: [{ comp: [{}] }],
+			mp: [{ ct: 'application/pdf', content: '', filename: 'document.pdf' }]
+		};
+
+		const result = buildMessageParts(messageData);
+
+		expect(result).toEqual([]);
+	});
 });

--- a/src/view/modals/forward-appointment/tests/use-forward-appointment.test.ts
+++ b/src/view/modals/forward-appointment/tests/use-forward-appointment.test.ts
@@ -25,6 +25,7 @@ describe('useForwardAppointment', () => {
 
 	const defaultParams = {
 		eventId: 'event-123',
+		subject: 'Test event subject',
 		onSuccess: mockOnSuccess,
 		onError: mockOnError,
 		onComplete: mockOnComplete
@@ -54,6 +55,7 @@ describe('useForwardAppointment', () => {
 		const request = await interceptor;
 
 		expect(request.id).toBe('event-123');
+		expect(request.m.su).toBe('Test event subject');
 		expect(request.m.e).toEqual([
 			{ a: EMAIL_1, t: 't' },
 			{ a: EMAIL_2, t: 't' }
@@ -161,6 +163,20 @@ describe('useForwardAppointment', () => {
 		const firstHandler = result.current;
 
 		rerender({ ...defaultParams, eventId: 'event-456' });
+
+		const secondHandler = result.current;
+
+		expect(firstHandler).not.toBe(secondHandler);
+	});
+
+	it('should create new handler when subject changes', () => {
+		const { result, rerender } = renderHook((props) => useForwardAppointment(props), {
+			initialProps: defaultParams
+		});
+
+		const firstHandler = result.current;
+
+		rerender({ ...defaultParams, subject: 'A different subject' });
 
 		const secondHandler = result.current;
 

--- a/src/view/modals/forward-appointment/types.ts
+++ b/src/view/modals/forward-appointment/types.ts
@@ -17,6 +17,13 @@ interface MessageInv {
 	comp?: MessageComp[];
 }
 
+export interface RawMimePart {
+	ct?: string;
+	content?: string;
+	mp?: RawMimePart[];
+}
+
 export interface MessageData {
 	inv?: MessageInv[];
+	mp?: RawMimePart[];
 }

--- a/src/view/modals/forward-appointment/use-forward-appointment.ts
+++ b/src/view/modals/forward-appointment/use-forward-appointment.ts
@@ -13,6 +13,7 @@ import { forwardAppointmentRequest } from 'soap/forward-appointment-request';
 
 type UseForwardAppointmentParams = {
 	eventId: string;
+	subject: string;
 	onSuccess: () => void;
 	onError: () => void;
 	onComplete: () => void;
@@ -25,6 +26,7 @@ type ForwardAppointmentHandler = (
 
 export const useForwardAppointment = ({
 	eventId,
+	subject,
 	onSuccess,
 	onError,
 	onComplete
@@ -35,6 +37,7 @@ export const useForwardAppointment = ({
 				const response = await forwardAppointmentRequest({
 					id: eventId,
 					attendees: contacts.map((contact) => contact.value.email),
+					subject,
 					messageParts
 				});
 
@@ -50,5 +53,5 @@ export const useForwardAppointment = ({
 				onComplete();
 			}
 		},
-		[eventId, onSuccess, onError, onComplete]
+		[eventId, subject, onSuccess, onError, onComplete]
 	);


### PR DESCRIPTION
The forward-appointment flow never sent the event title as the email subject, and only read the invite's iCal description fields, missing cases where the body text only lives in the message's raw MIME parts.