### PR TITLE
feat(CO-3662): show original time alongside proposed new time in counter proposals

### DIFF
--- a/src/shared/invite-response/parts/invite-header-part.tsx
+++ b/src/shared/invite-response/parts/invite-header-part.tsx
@@ -55,14 +55,28 @@ export const InviteHeaderPart: FC<InviteHeaderPartProps> = ({
 		allDay
 	});
 
-	const counterDate = useGetDateRangeConvertedToTimezone(
-		proposedStartTime ? parseDateFromICS(proposedStartTime).getTime() : 0,
-		proposedEndTime ? parseDateFromICS(proposedEndTime).getTime() : 0,
-		{
-			allDay,
-			timeZone
-		}
+	const proposedStart = useMemo(
+		() => (proposedStartTime ? parseDateFromICS(proposedStartTime).getTime() : 0),
+		[proposedStartTime]
 	);
+
+	const proposedEnd = useMemo(
+		() => (proposedEndTime ? parseDateFromICS(proposedEndTime).getTime() : 0),
+		[proposedEndTime]
+	);
+
+	const counterDate = useGetDateRangeConvertedToTimezone(proposedStart, proposedEnd, {
+		allDay,
+		timeZone
+	});
+
+	// In a counter proposal the invite holds the current appointment times, while the
+	// mail message holds the attendee's proposed ones: show both when they differ.
+	const showOriginalTime =
+		method === MESSAGE_METHOD.COUNTER &&
+		mailMsg.parent !== FOLDERS.SENT &&
+		localStartTime !== 0 &&
+		(proposedStart !== localStartTime || proposedEnd !== localEndTime);
 
 	const showTimezoneIndicator = convertedDate !== originalDate;
 
@@ -80,11 +94,7 @@ export const InviteHeaderPart: FC<InviteHeaderPartProps> = ({
 	return (
 		<>
 			<Row width="fill" mainAlignment="flex-start" padding={{ bottom: 'extrasmall' }}>
-				{method === MESSAGE_METHOD.COUNTER && (
-					<Text weight="light" size="large">
-						{mailMsg.subject}
-					</Text>
-				)}
+				{method === MESSAGE_METHOD.COUNTER && <Text size="medium">{mailMsg.subject}</Text>}
 				{method !== MESSAGE_METHOD.COUNTER &&
 					(isSentOnBehalfOf(invite.organizer) ? (
 						<Trans
@@ -111,26 +121,54 @@ export const InviteHeaderPart: FC<InviteHeaderPartProps> = ({
 						/>
 					))}
 			</Row>
-			<Row width="100%" mainAlignment="flex-start">
-				{method === MESSAGE_METHOD.COUNTER && mailMsg.parent !== FOLDERS.SENT && (
-					<Text overflow="ellipsis" color="secondary" weight="bold" size="small">
-						{counterDate}
-					</Text>
-				)}
-				{method !== MESSAGE_METHOD.COUNTER && (
+			{method === MESSAGE_METHOD.COUNTER && mailMsg.parent !== FOLDERS.SENT && (
+				<>
+					{showOriginalTime && (
+						<Row width="100%" mainAlignment="flex-start" padding={{ bottom: 'small' }}>
+							<Text color="gray1" weight="bold" size="small">
+								{t('label.original', 'Original')}:
+							</Text>
+							<Padding left="extrasmall">
+								<Text overflow="ellipsis" color="gray1" weight="bold" size="small">
+									{originalDate}
+								</Text>
+							</Padding>
+						</Row>
+					)}
+					<Row width="100%" mainAlignment="flex-start">
+						<Text color="warning.focus" size="small">
+							{t('label.proposed', 'Proposed')}:
+						</Text>
+						<Padding left="extrasmall">
+							<Text overflow="ellipsis" color="warning.focus" size="small">
+								{counterDate}
+							</Text>
+						</Padding>
+						{showTimezoneIndicator && (
+							<Tooltip label={timezoneTooltip}>
+								<Padding left="small">
+									<Icon icon="GlobeOutline" color="gray1" />
+								</Padding>
+							</Tooltip>
+						)}
+					</Row>
+				</>
+			)}
+			{method !== MESSAGE_METHOD.COUNTER && (
+				<Row width="100%" mainAlignment="flex-start">
 					<Text overflow="ellipsis" color="secondary" weight="bold" size="small">
 						{convertedDate}
 					</Text>
-				)}
 
-				{showTimezoneIndicator && (
-					<Tooltip label={timezoneTooltip}>
-						<Padding left="small">
-							<Icon icon="GlobeOutline" color="gray1" />
-						</Padding>
-					</Tooltip>
-				)}
-			</Row>
+					{showTimezoneIndicator && (
+						<Tooltip label={timezoneTooltip}>
+							<Padding left="small">
+								<Icon icon="GlobeOutline" color="gray1" />
+							</Padding>
+						</Tooltip>
+					)}
+				</Row>
+			)}
 		</>
 	);
 };

--- a/src/shared/invite-response/parts/invite-header-part.tsx
+++ b/src/shared/invite-response/parts/invite-header-part.tsx
@@ -94,7 +94,11 @@ export const InviteHeaderPart: FC<InviteHeaderPartProps> = ({
 	return (
 		<>
 			<Row width="fill" mainAlignment="flex-start" padding={{ bottom: 'extrasmall' }}>
-				{method === MESSAGE_METHOD.COUNTER && <Text size="medium">{mailMsg.subject}</Text>}
+				{method === MESSAGE_METHOD.COUNTER && (
+					<Text weight="light" size="large">
+						{mailMsg.subject}
+					</Text>
+				)}
 				{method !== MESSAGE_METHOD.COUNTER &&
 					(isSentOnBehalfOf(invite.organizer) ? (
 						<Trans

--- a/src/shared/invite-response/tests/invite-response.test.tsx
+++ b/src/shared/invite-response/tests/invite-response.test.tsx
@@ -1000,7 +1000,7 @@ describe('invite response component', () => {
 				});
 				const titleString = await screen.findByText(mailMsg.subject);
 				expect(titleString).toBeVisible();
-				expect(titleString).toHaveStyleRule('font-size', '1rem');
+				expect(titleString).toHaveStyleRule('font-size', '1.125rem');
 			});
 			test('should show the correct start and end time', async () => {
 				setupFoldersStore();
@@ -1012,7 +1012,7 @@ describe('invite response component', () => {
 				});
 				const titleString = await screen.findByText(mailMsg.subject);
 				expect(titleString).toBeVisible();
-				expect(titleString).toHaveStyleRule('font-size', '1rem');
+				expect(titleString).toHaveStyleRule('font-size', '1.125rem');
 
 				expect(
 					screen.getByText('Tuesday, January 30, 2024, 9:00 – 9:30 AM GMT+01:00 Europe/Berlin')

--- a/src/shared/invite-response/tests/invite-response.test.tsx
+++ b/src/shared/invite-response/tests/invite-response.test.tsx
@@ -1054,28 +1054,6 @@ describe('invite response component', () => {
 					screen.getByText('Tuesday, January 30, 2024, 9:00 – 9:30 AM GMT+01:00 Europe/Berlin')
 				).toBeVisible();
 			});
-			test('the original time is bold gray and the proposed time has the warning color', async () => {
-				setupFoldersStore();
-				setupServerSingleEventResponse(singleAppointmentResponse, singleGetMsgResponse);
-				const mailMsg = buildMailMessageType(MESSAGE_METHOD.COUNTER, MESSAGE_TYPE.SINGLE, false, {
-					invite: [{ tz: [], comp: [{ apptId: '1484' }] }]
-				} as never);
-				const store = configureStore({ reducer: combineReducers(reducers) });
-				setupTest(<InviteResponse mailMsg={mailMsg} moveToTrash={vi.fn()} />, {
-					store
-				});
-
-				const originalTime = await screen.findByText(
-					'Monday, February 05, 2024, 4:00 – 4:30 PM GMT+01:00 Europe/Berlin'
-				);
-				const proposedTime = screen.getByText(
-					'Tuesday, January 30, 2024, 9:00 – 9:30 AM GMT+01:00 Europe/Berlin'
-				);
-
-				expect(originalTime).toHaveStyleRule('color', '#828282');
-				expect(originalTime).toHaveStyleRule('font-weight', '700');
-				expect(proposedTime).toHaveStyleRule('color', '#d39e00');
-			});
 			test('does not show the original time when the appointment details are unavailable', async () => {
 				setupFoldersStore();
 				const mailMsg = buildMailMessageType(MESSAGE_METHOD.COUNTER, MESSAGE_TYPE.SINGLE, false);

--- a/src/shared/invite-response/tests/invite-response.test.tsx
+++ b/src/shared/invite-response/tests/invite-response.test.tsx
@@ -1000,7 +1000,7 @@ describe('invite response component', () => {
 				});
 				const titleString = await screen.findByText(mailMsg.subject);
 				expect(titleString).toBeVisible();
-				expect(titleString).toHaveStyleRule('font-size', '1.125rem');
+				expect(titleString).toHaveStyleRule('font-size', '1rem');
 			});
 			test('should show the correct start and end time', async () => {
 				setupFoldersStore();
@@ -1012,7 +1012,7 @@ describe('invite response component', () => {
 				});
 				const titleString = await screen.findByText(mailMsg.subject);
 				expect(titleString).toBeVisible();
-				expect(titleString).toHaveStyleRule('font-size', '1.125rem');
+				expect(titleString).toHaveStyleRule('font-size', '1rem');
 
 				expect(
 					screen.getByText('Tuesday, January 30, 2024, 9:00 – 9:30 AM GMT+01:00 Europe/Berlin')
@@ -1032,6 +1032,62 @@ describe('invite response component', () => {
 				);
 
 				expect(localTimeString).toBeVisible();
+			});
+			test('shows the proposed new time and the original time of the appointment when they differ', async () => {
+				setupFoldersStore();
+				setupServerSingleEventResponse(singleAppointmentResponse, singleGetMsgResponse);
+				const mailMsg = buildMailMessageType(MESSAGE_METHOD.COUNTER, MESSAGE_TYPE.SINGLE, false, {
+					invite: [{ tz: [], comp: [{ apptId: '1484' }] }]
+				} as never);
+				const store = configureStore({ reducer: combineReducers(reducers) });
+				setupTest(<InviteResponse mailMsg={mailMsg} moveToTrash={vi.fn()} />, {
+					store
+				});
+
+				expect(await screen.findByText('Original:')).toBeVisible();
+				expect(
+					screen.getByText('Monday, February 05, 2024, 4:00 – 4:30 PM GMT+01:00 Europe/Berlin')
+				).toBeVisible();
+
+				expect(screen.getByText('Proposed:')).toBeVisible();
+				expect(
+					screen.getByText('Tuesday, January 30, 2024, 9:00 – 9:30 AM GMT+01:00 Europe/Berlin')
+				).toBeVisible();
+			});
+			test('the original time is bold gray and the proposed time has the warning color', async () => {
+				setupFoldersStore();
+				setupServerSingleEventResponse(singleAppointmentResponse, singleGetMsgResponse);
+				const mailMsg = buildMailMessageType(MESSAGE_METHOD.COUNTER, MESSAGE_TYPE.SINGLE, false, {
+					invite: [{ tz: [], comp: [{ apptId: '1484' }] }]
+				} as never);
+				const store = configureStore({ reducer: combineReducers(reducers) });
+				setupTest(<InviteResponse mailMsg={mailMsg} moveToTrash={vi.fn()} />, {
+					store
+				});
+
+				const originalTime = await screen.findByText(
+					'Monday, February 05, 2024, 4:00 – 4:30 PM GMT+01:00 Europe/Berlin'
+				);
+				const proposedTime = screen.getByText(
+					'Tuesday, January 30, 2024, 9:00 – 9:30 AM GMT+01:00 Europe/Berlin'
+				);
+
+				expect(originalTime).toHaveStyleRule('color', '#828282');
+				expect(originalTime).toHaveStyleRule('font-weight', '700');
+				expect(proposedTime).toHaveStyleRule('color', '#d39e00');
+			});
+			test('does not show the original time when the appointment details are unavailable', async () => {
+				setupFoldersStore();
+				const mailMsg = buildMailMessageType(MESSAGE_METHOD.COUNTER, MESSAGE_TYPE.SINGLE, false);
+				createSoapAPIInterceptor('GetAppointment', {});
+				const store = configureStore({ reducer: combineReducers(reducers) });
+				setupTest(<InviteResponse mailMsg={mailMsg} moveToTrash={vi.fn()} />, {
+					store
+				});
+
+				await screen.findByText('Proposed:');
+
+				expect(screen.queryByText('Original:')).not.toBeInTheDocument();
 			});
 			test('if the event is created with a different timezone there is an icon with a tooltip showing the local timezone', async () => {
 				setupFoldersStore();


### PR DESCRIPTION
### What
When an attendee proposes a new time for a meeting, the organizer now sees both the original time and the proposed time in the invite, clearly distinguished.

### Why
Previously only one date was shown with no label, so the organizer couldn't tell which time was the original and which was the proposed one.

### How it looks
- Original: shown in bold gray
- Proposed: shown in warning yellow
  
