### PR TITLE
chore(deps): update dependency zextras/jenkins-lib-common to v4.2.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 library(
-    identifier: 'jenkins-lib-common@v4.1.4',
+    identifier: 'jenkins-lib-common@v4.2.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-lib-common.git',


### PR DESCRIPTION
Bumps `jenkins-lib-common` from `v4.1.4` to `v4.2.0`.

This picks up the `gitleaksStage` fix (zextras/jenkins-lib-common#157): when the scan has findings,
`gitleaksStage` writes `gitleaks-report.json` into the workspace root; since the scan moved in-pod at
v3.0.0 that file survived into the 'License checks' stage, where `reuse lint` walked the git file list,
found an untracked file with no SPDX header, and failed the build for a file the pipeline itself
created. v4.2.0 appends the report path to `.git/info/exclude`, fixing it centrally.

Pin-only change, no other pipeline parameters needed migration.

Ref: https://zextras.atlassian.net/browse/IN-1168
