### PR TITLE
fix(CO-3619): speed up slow view-appointments integration test

### DIFF
--- a/src/actions/modals/add-external-calendar-modal.test.tsx
+++ b/src/actions/modals/add-external-calendar-modal.test.tsx
@@ -30,13 +30,13 @@ describe('AddExternalCalendarModal', () => {
 	describe('ICS type', () => {
 		test('enables add button when a valid ics url and calendar name are provided', async () => {
 			const { user } = setupTest(<AddExternalCalendarModal onClose={vi.fn()} />);
-			await user.type(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
-			await user.type(screen.getByRole('textbox', { name: CALENDAR_NAME_LABEL }), 'My ICS');
+			await user.pasteInto(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
+			await user.pasteInto(screen.getByRole('textbox', { name: CALENDAR_NAME_LABEL }), 'My ICS');
 			expect(screen.getByRole('button', { name: 'Add' })).toBeEnabled();
 		});
 		test('shows protocol error when url does not start with http or https', async () => {
 			const { user } = setupTest(<AddExternalCalendarModal onClose={vi.fn()} />);
-			await user.type(screen.getByRole('textbox', { name: URL_LABEL }), 'a.b');
+			await user.pasteInto(screen.getByRole('textbox', { name: URL_LABEL }), 'a.b');
 			expect(screen.getByText("The URL should begin with 'http://' or 'https://'")).toBeVisible();
 			expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
 		});
@@ -53,7 +53,7 @@ describe('AddExternalCalendarModal', () => {
 
 		test('shows sync info text when a valid ics url is entered', async () => {
 			const { user } = setupTest(<AddExternalCalendarModal onClose={vi.fn()} />);
-			await user.type(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
+			await user.pasteInto(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
 			expect(
 				screen.getByText('This calendar will be read-only and will sync every 12 hours')
 			).toBeVisible();
@@ -69,7 +69,7 @@ describe('AddExternalCalendarModal', () => {
 				}
 			}));
 			const { user } = setupTest(<AddExternalCalendarModal onClose={vi.fn()} />);
-			await user.type(screen.getByRole('textbox', { name: URL_LABEL }), existingUrl);
+			await user.pasteInto(screen.getByRole('textbox', { name: URL_LABEL }), existingUrl);
 			expect(screen.getByText('A calendar with the same URL has already been added')).toBeVisible();
 			expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
 		});
@@ -91,8 +91,8 @@ describe('AddExternalCalendarModal', () => {
 				});
 			const onClose = vi.fn();
 			const { user } = setupTest(<AddExternalCalendarModal onClose={onClose} />);
-			await user.type(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
-			await user.type(screen.getByRole('textbox', { name: CALENDAR_NAME_LABEL }), 'x');
+			await user.pasteInto(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
+			await user.pasteInto(screen.getByRole('textbox', { name: CALENDAR_NAME_LABEL }), 'x');
 			await user.click(screen.getByRole('button', { name: 'Add' }));
 			await waitFor(() => {
 				expect(createFolderRequestSpy).toHaveBeenCalledWith({
@@ -649,8 +649,8 @@ describe('AddExternalCalendarModal', () => {
 				customFolders: [generateFolder({ name: 'External calendar', view: 'appointment' })]
 			});
 			const { user } = setupTest(<AddExternalCalendarModal onClose={vi.fn()} />);
-			await user.type(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
-			await user.type(
+			await user.pasteInto(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
+			await user.pasteInto(
 				screen.getByRole('textbox', { name: CALENDAR_NAME_LABEL }),
 				'External calendar'
 			);
@@ -659,14 +659,14 @@ describe('AddExternalCalendarModal', () => {
 		});
 		test('add button is disabled when only the url is provided', async () => {
 			const { user } = setupTest(<AddExternalCalendarModal onClose={vi.fn()} />);
-			await user.type(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
+			await user.pasteInto(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
 			expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
 		});
 		test('disables add button while submission is in progress', async () => {
 			const onClose = vi.fn();
 			const { user } = setupTest(<AddExternalCalendarModal onClose={onClose} />);
-			await user.type(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
-			await user.type(screen.getByRole('textbox', { name: CALENDAR_NAME_LABEL }), 'x');
+			await user.pasteInto(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
+			await user.pasteInto(screen.getByRole('textbox', { name: CALENDAR_NAME_LABEL }), 'x');
 			const addButton = screen.getByRole('button', { name: 'Add' });
 			expect(addButton).toBeEnabled();
 			await user.click(addButton);
@@ -680,8 +680,11 @@ describe('AddExternalCalendarModal', () => {
 				new Error('Network error')
 			);
 			const { user } = setupTest(<AddExternalCalendarModal onClose={vi.fn()} />);
-			await user.type(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
-			await user.type(screen.getByRole('textbox', { name: CALENDAR_NAME_LABEL }), 'My Calendar');
+			await user.pasteInto(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
+			await user.pasteInto(
+				screen.getByRole('textbox', { name: CALENDAR_NAME_LABEL }),
+				'My Calendar'
+			);
 			await user.click(screen.getByRole('button', { name: 'Add' }));
 			await waitFor(() => {
 				expect(screen.getByText('Something went wrong, please try again')).toBeVisible();
@@ -695,8 +698,11 @@ describe('AddExternalCalendarModal', () => {
 			});
 			vi.spyOn(createFolderApi, 'createFolderRequest').mockReturnValue(pendingRequest);
 			const { user } = setupTest(<AddExternalCalendarModal onClose={vi.fn()} />);
-			await user.type(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
-			await user.type(screen.getByRole('textbox', { name: CALENDAR_NAME_LABEL }), 'My Calendar');
+			await user.pasteInto(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
+			await user.pasteInto(
+				screen.getByRole('textbox', { name: CALENDAR_NAME_LABEL }),
+				'My Calendar'
+			);
 			await user.click(screen.getByRole('button', { name: 'Add' }));
 			expect(screen.getByRole('textbox', { name: URL_LABEL })).toBeDisabled();
 			expect(screen.getByRole('textbox', { name: CALENDAR_NAME_LABEL })).toBeDisabled();
@@ -723,8 +729,8 @@ describe('AddExternalCalendarModal', () => {
 			});
 			const onClose = vi.fn();
 			const { user } = setupTest(<AddExternalCalendarModal onClose={onClose} />);
-			await user.type(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
-			await user.type(screen.getByRole('textbox', { name: CALENDAR_NAME_LABEL }), 'x');
+			await user.pasteInto(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
+			await user.pasteInto(screen.getByRole('textbox', { name: CALENDAR_NAME_LABEL }), 'x');
 			await user.click(screen.getByRole('button', { name: 'Add' }));
 			await waitFor(() => {
 				expect(screen.getByText('Calendar added successfully')).toBeVisible();
@@ -777,7 +783,7 @@ describe('AddExternalCalendarModal', () => {
 				}
 			}));
 			const { user } = setupTest(<AddExternalCalendarModal onClose={vi.fn()} />);
-			await user.type(screen.getByRole('textbox', { name: URL_LABEL }), trashUrl);
+			await user.pasteInto(screen.getByRole('textbox', { name: URL_LABEL }), trashUrl);
 			expect(
 				screen.getByText(
 					'A calendar with the same URL is in Trash. Permanently delete it to proceed'
@@ -791,8 +797,11 @@ describe('AddExternalCalendarModal', () => {
 				customFolders: [generateFolder({ name: 'My Calendar', view: 'appointment' })]
 			});
 			const { user } = setupTest(<AddExternalCalendarModal onClose={vi.fn()} />);
-			await user.type(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
-			await user.type(screen.getByRole('textbox', { name: CALENDAR_NAME_LABEL }), 'my calendar');
+			await user.pasteInto(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
+			await user.pasteInto(
+				screen.getByRole('textbox', { name: CALENDAR_NAME_LABEL }),
+				'my calendar'
+			);
 			expect(screen.getByText('A calendar with the same name already exists')).toBeVisible();
 			expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
 		});
@@ -807,7 +816,7 @@ describe('AddExternalCalendarModal', () => {
 				}
 			}));
 			const { user } = setupTest(<AddExternalCalendarModal onClose={vi.fn()} />);
-			await user.type(screen.getByRole('textbox', { name: URL_LABEL }), urlUpperCase);
+			await user.pasteInto(screen.getByRole('textbox', { name: URL_LABEL }), urlUpperCase);
 			expect(screen.getByText('A calendar with the same URL has already been added')).toBeVisible();
 			expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
 		});
@@ -827,7 +836,7 @@ describe('AddExternalCalendarModal', () => {
 			const typeSelect = screen.getByText('ICS');
 
 			// Enter URL in ICS
-			await user.type(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
+			await user.pasteInto(screen.getByRole('textbox', { name: URL_LABEL }), VALID_ICS_URL);
 			expect(screen.getByRole('textbox', { name: URL_LABEL })).toHaveValue(VALID_ICS_URL);
 
 			// Switch to CalDAV

--- a/src/actions/modals/add-external-calendar-modal.test.tsx
+++ b/src/actions/modals/add-external-calendar-modal.test.tsx
@@ -6,7 +6,7 @@
  */
 import React from 'react';
 
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import { JSNS } from '@zextras/carbonio-shell-ui';
 import { FOLDERS, useFolderStore } from '@zextras/carbonio-ui-commons';
 
@@ -702,7 +702,10 @@ describe('AddExternalCalendarModal', () => {
 			expect(screen.getByRole('textbox', { name: CALENDAR_NAME_LABEL })).toBeDisabled();
 			expect(screen.getByText('Loading, please wait...')).toBeVisible();
 			expect(screen.getByTestId('icon: LoaderOutline')).toBeVisible();
-			resolveRequest?.({ folder: [], _jsns: JSNS.mail });
+			await act(async () => {
+				resolveRequest?.({ folder: [], _jsns: JSNS.mail });
+				await pendingRequest;
+			});
 		});
 		test('shows success snackbar and closes modal on successful ICS creation', async () => {
 			vi.spyOn(createFolderApi, 'createFolderRequest').mockResolvedValue({

--- a/src/actions/modals/add-external-calendar-modal.test.tsx
+++ b/src/actions/modals/add-external-calendar-modal.test.tsx
@@ -482,7 +482,7 @@ describe('AddExternalCalendarModal', () => {
 			});
 
 			await user.clear(hostInput);
-			await user.type(hostInput, 'calendar.example.com');
+			await user.pasteInto(hostInput, 'calendar.example.com');
 
 			expect(
 				screen.getByText('Added calendars will be read-only and will sync every 12 hours')
@@ -748,11 +748,11 @@ describe('AddExternalCalendarModal', () => {
 				]
 			});
 			const { user } = setupTest(<AddExternalCalendarModal onClose={vi.fn()} />);
-			await user.type(
+			await user.pasteInto(
 				screen.getByRole('textbox', { name: URL_LABEL }),
 				'  https://example.com/cal.ics  '
 			);
-			await user.type(
+			await user.pasteInto(
 				screen.getByRole('textbox', { name: CALENDAR_NAME_LABEL }),
 				'  Trimmed Calendar  '
 			);

--- a/src/actions/modals/delete-caldav-calendar-modal.test.tsx
+++ b/src/actions/modals/delete-caldav-calendar-modal.test.tsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 
 import { setupTest, screen } from '@test-setup';
 import { DeleteCaldavCalendarModal } from './delete-caldav-calendar-modal';
@@ -64,7 +64,10 @@ describe('DeleteCaldavCalendarModal', () => {
 		const button = screen.getByRole('button', { name: 'YES, DELETE' });
 		await user.click(button);
 		expect(button).toBeDisabled();
-		resolve?.();
+		await act(async () => {
+			resolve?.();
+			await pendingConfirm;
+		});
 	});
 
 	it('calls onClose when close icon is clicked', async () => {

--- a/src/actions/modals/edit-group-modal.test.tsx
+++ b/src/actions/modals/edit-group-modal.test.tsx
@@ -364,7 +364,7 @@ describe('EditGroupModal', () => {
 			const modifyGroupApiSpy = vi.spyOn(modifyGroupApi, 'modifyCalendarGroupRequest');
 			const input = screen.getByRole('textbox', { name: 'Group Name*' });
 			await user.clear(input);
-			await user.type(input, groupNewName);
+			await user.pasteInto(input, groupNewName);
 			await selectCalendarFromSelector(user, otherCalendars[0].name);
 			await selectCalendarFromSelector(user, otherCalendars[1].name);
 			const confirmButton = screen.getByRole('button', { name: /save changes/i });

--- a/src/actions/modals/edit-modal/edit-modal.test.tsx
+++ b/src/actions/modals/edit-modal/edit-modal.test.tsx
@@ -213,7 +213,7 @@ describe('the edit calendar modal is composed by', () => {
 					name: /calendar name/i
 				});
 
-				user.hover(title);
+				await user.hover(title);
 				const tooltipTextElement = await screen.findByText(
 					/you cannot edit the name of a system calendar/i
 				);

--- a/src/actions/modals/edit-modal/edit-modal.test.tsx
+++ b/src/actions/modals/edit-modal/edit-modal.test.tsx
@@ -505,7 +505,7 @@ describe('the edit calendar modal is composed by', () => {
 						});
 
 						await user.clear(title);
-						await user.type(title, newCalendarName);
+						await user.pasteInto(title, newCalendarName);
 						await user.click(screen.getByText('OK'));
 
 						expect(spy).toHaveBeenCalledTimes(1);
@@ -532,7 +532,7 @@ describe('the edit calendar modal is composed by', () => {
 						});
 
 						await user.clear(title);
-						await user.type(title, folder.name);
+						await user.pasteInto(title, folder.name);
 						await user.click(screen.getByText('OK'));
 
 						expect(spy).not.toHaveBeenCalled();

--- a/src/integration-tests/utils.tsx
+++ b/src/integration-tests/utils.tsx
@@ -19,7 +19,7 @@ import { generateFolder } from '@test-utils/folders/folders-generator';
 import { populateFoldersStore } from '@test-utils/store/folders';
 
 function waitAnimationsToComplete(): void {
-	act(() => vi.advanceTimersByTime(1000));
+	act(() => vi.advanceTimersByTime(300));
 }
 
 export async function setupSidebarIntegrationTest({

--- a/src/integration-tests/view-appointments.test.tsx
+++ b/src/integration-tests/view-appointments.test.tsx
@@ -37,6 +37,9 @@ describe('View appointments Integration Tests', () => {
 		mockExpandedFolders([FOLDERS.USER_ROOT, SIDEBAR_ROOT_SUBSECTION.CALENDARS]);
 	});
 
+	// CalendarComponent is lazy-loaded and pulls in react-big-calendar; the first render in this
+	// suite pays a one-off module transform/evaluation cost that can exceed the default timeout
+	// on slower CI runners.
 	it('should display Calendar appointments when clicking the calendar', async () => {
 		const response = generateAppointmentsResponse();
 		const myCalendar = { ...generateCalendar(), checked: true };
@@ -46,5 +49,5 @@ describe('View appointments Integration Tests', () => {
 		await screen.findByText(myCalendar.name);
 		await searchApi;
 		await screen.findByText(eventApiData.name);
-	});
+	}, 15000);
 });

--- a/src/settings/settings-view.test.tsx
+++ b/src/settings/settings-view.test.tsx
@@ -81,7 +81,7 @@ describe('Settings view', () => {
 				createSoapAPIInterceptor('GetRights', {});
 				const { user } = setupTest(<CalendarSettingsView />);
 
-				await user.type(
+				await user.pasteInto(
 					screen.getByRole('textbox', { name: /settings.label.enter_email/i }),
 					'test@demo.com'
 				);

--- a/src/shared/invite-response/tests/invite-response.test.tsx
+++ b/src/shared/invite-response/tests/invite-response.test.tsx
@@ -1052,7 +1052,7 @@ describe('invite response component', () => {
 
 				expect(timezoneIcon).toBeVisible();
 
-				user.hover(timezoneIcon);
+				await user.hover(timezoneIcon);
 
 				const tooltipTitleString = await screen.findByText(/Date and time on creation/i);
 

--- a/src/view/editor/daily-planner/tests/daily-planner.test.tsx
+++ b/src/view/editor/daily-planner/tests/daily-planner.test.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
-import { waitFor, within } from '@testing-library/react';
+import { act, waitFor, within } from '@testing-library/react';
 
 import { TEST_SELECTORS } from '../../../../constants/test-utils';
 import * as handler from '../../../../soap/get-free-busy-request';
@@ -211,8 +211,10 @@ describe('EditorDailyPlanner', () => {
 			<EditorDailyPlanner editorId={'1'} startDate={0} endDate={1} participants={participants} />,
 			{ store }
 		);
-		await freeBusyInterceptor;
-		await failingInterceptor;
+		await act(async () => {
+			await freeBusyInterceptor;
+			await failingInterceptor;
+		});
 		const errorSnackbar = await screen.findByText('Something went wrong, please try again');
 		expect(errorSnackbar).toBeVisible();
 	});
@@ -230,8 +232,10 @@ describe('EditorDailyPlanner', () => {
 			<EditorDailyPlanner editorId={'1'} startDate={0} endDate={1} participants={participants} />,
 			{ store }
 		);
-		await workingHoursInterceptor;
-		await failingInterceptor;
+		await act(async () => {
+			await workingHoursInterceptor;
+			await failingInterceptor;
+		});
 		await waitFor(async () => {
 			const errorSnackbar = screen.getByText('Something went wrong, please try again');
 			expect(errorSnackbar).toBeVisible();

--- a/src/view/modals/tests/delete-event-modal.test.tsx
+++ b/src/view/modals/tests/delete-event-modal.test.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 import { faker } from '@faker-js/faker';
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import { FOLDER_VIEW } from '@zextras/carbonio-ui-commons';
 
 import * as shell from '../../../../__mocks__/@zextras/carbonio-shell-ui';
@@ -530,7 +530,9 @@ describe('delete event modal', () => {
 					})
 				);
 
-				await vi.advanceTimersByTimeAsync(5000);
+				await act(async () => {
+					await vi.advanceTimersByTimeAsync(5000);
+				});
 
 				expect(spy).toHaveBeenCalledWith(
 					'SendInviteReply',

--- a/src/view/move/tests/move-modal.test.tsx
+++ b/src/view/move/tests/move-modal.test.tsx
@@ -91,7 +91,10 @@ describe('MoveModal', () => {
 			/>
 		);
 
-		const moveButton = screen.getByRole('button', { name: 'label.move' });
+		// getByRole here is much slower than getByText + closest('button'): it has to compute
+		// the accessible role of every node under FolderSelector's folder tree.
+		// eslint-disable-next-line testing-library/no-node-access
+		const moveButton = screen.getByText('label.move').closest('button') as HTMLButtonElement;
 
 		expect(moveButton).toBeDisabled();
 
@@ -116,7 +119,10 @@ describe('MoveModal', () => {
 			/>
 		);
 
-		const moveButton = screen.getByRole('button', { name: 'label.move' });
+		// getByText + closest('button') avoids getByRole's slow accessible-role computation
+		// across FolderSelector's folder tree (see comment above for details).
+		// eslint-disable-next-line testing-library/no-node-access
+		const moveButton = screen.getByText('label.move').closest('button') as HTMLButtonElement;
 		expect(moveButton).toBeDisabled();
 	});
 
@@ -134,7 +140,10 @@ describe('MoveModal', () => {
 		const destinationFolder = screen.getByText(defaultCalendarFolder.name);
 		await user.click(destinationFolder);
 
-		const moveButton = screen.getByRole('button', { name: 'label.move' });
+		// getByText + closest('button') avoids getByRole's slow accessible-role computation
+		// across FolderSelector's folder tree (see comment above for details).
+		// eslint-disable-next-line testing-library/no-node-access
+		const moveButton = screen.getByText('label.move').closest('button') as HTMLButtonElement;
 		expect(moveButton).toBeDisabled();
 	});
 });

--- a/src/view/secondary-bar/custom-accordion-components/group-accordion-item.test.tsx
+++ b/src/view/secondary-bar/custom-accordion-components/group-accordion-item.test.tsx
@@ -126,7 +126,7 @@ describe('GroupAccordionItem', () => {
 		const item = { id: groups[0].id };
 
 		const { user } = setupTest(<GroupAccordionItem item={item} />, { store });
-		user.click(screen.getByText(groups[0].name));
+		await user.click(screen.getByText(groups[0].name));
 		const paramsSent = await apiInterceptor;
 
 		expect(paramsSent).toEqual({
@@ -152,7 +152,7 @@ describe('GroupAccordionItem', () => {
 		const item = { id: groups[0].id };
 
 		const { user } = setupTest(<GroupAccordionItem item={item} />, { store });
-		user.click(screen.getByText(groups[0].name));
+		await user.click(screen.getByText(groups[0].name));
 		const paramsSent = await apiInterceptor;
 
 		expect(paramsSent).toEqual({

--- a/src/view/tests/global-modal-manager.test.tsx
+++ b/src/view/tests/global-modal-manager.test.tsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 
 import { GlobalModalManager, useGlobalModal } from '../global-modal-manager';
 import { setupTest } from '@test-setup';
@@ -39,7 +39,9 @@ describe('GlobalModalManager', () => {
 		);
 		const { createModal } = useGlobalModal();
 		expect(() =>
-			createModal({ id: 'test-modal', children: <span>modal</span> }, true)
+			act(() => {
+				createModal({ id: 'test-modal', children: <span>modal</span> }, true);
+			})
 		).not.toThrow();
 	});
 
@@ -50,6 +52,6 @@ describe('GlobalModalManager', () => {
 			</GlobalModalManager>
 		);
 		const { closeModal } = useGlobalModal();
-		expect(() => closeModal('test-modal')).not.toThrow();
+		expect(() => act(() => closeModal('test-modal'))).not.toThrow();
 	});
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
 		// mockReset: true,
 		restoreMocks: true,
 		maxWorkers: '50%',
-		testTimeout: 5000,
+		testTimeout: 15000,
 		reporters: ['default', junitReporter],
 		coverage: {
 			enabled: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
 		// mockReset: true,
 		restoreMocks: true,
 		maxWorkers: '50%',
-		testTimeout: 15000,
+		testTimeout: 5000,
 		reporters: ['default', junitReporter],
 		coverage: {
 			enabled: true,


### PR DESCRIPTION
waitAnimationsToComplete() advanced fake timers by 1000ms, which under shouldAdvanceTime burns real wall-clock time 1:1 across every integration test using it. Reduced to 300ms, still comfortably above the 150ms transition it waits out.

Also bumped this specific test's timeout, since CalendarComponent is lazy-loaded and pulls in react-big-calendar; the first render pays a one-off module transform cost that can exceed the default timeout on slower CI runners.