### PR TITLE
feat(CO-4077): prevent duplicate notifications when accepting a proposed new time

### DIFF
--- a/src/shared/invite-response/invite-response.tsx
+++ b/src/shared/invite-response/invite-response.tsx
@@ -18,6 +18,7 @@ import InviteHeaderPart from './parts/invite-header-part';
 import InviteReplyPart from './parts/invite-reply-part';
 import { ParticipantsList } from './parts/participants-list';
 import ProposedTimeReply from './parts/proposed-time-reply';
+import { isProposalAlreadyApplied } from './proposal-status';
 import { useFetchInvite } from './useFetchInvite';
 import { BodyMessageRenderer } from '../../commons/body-message-renderer';
 import { MESSAGE_METHOD } from '../../constants/api';
@@ -72,6 +73,12 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 	const proposedStartTime = mailMsg.invite[0]?.comp?.[0]?.s?.[0]?.d;
 	const proposedEndTime = mailMsg.invite[0]?.comp?.[0]?.e?.[0]?.d;
 
+	// a proposal accepted in an earlier session is only visible in the appointment itself
+	const proposalApplied = useMemo(
+		() => isProposalAlreadyApplied({ fetchedInvites: fetchedInv, counterInvite: mailMsg.invite }),
+		[fetchedInv, mailMsg.invite]
+	);
+
 	const inviteId =
 		invite.apptId && !includes(invite.id, ':') ? `${invite.apptId}-${invite.id}` : invite.id;
 
@@ -124,6 +131,7 @@ export const InviteResponse: FC<InviteResponseArguments> = ({
 						to={to}
 						msg={mailMsg}
 						fragment={invite?.fragment}
+						proposalApplied={proposalApplied}
 					/>
 				)}
 				{method !== MESSAGE_METHOD.COUNTER && isAttendee && (

--- a/src/shared/invite-response/parts/invite-header-part.tsx
+++ b/src/shared/invite-response/parts/invite-header-part.tsx
@@ -129,25 +129,15 @@ export const InviteHeaderPart: FC<InviteHeaderPartProps> = ({
 				<>
 					{showOriginalTime && (
 						<Row width="100%" mainAlignment="flex-start" padding={{ bottom: 'small' }}>
-							<Text color="gray1" weight="bold" size="small">
-								{t('label.original', 'Original')}:
+							<Text overflow="break-word" color="gray1" weight="bold" size="small">
+								{`${t('label.original', 'Original')}: ${originalDate}`}
 							</Text>
-							<Padding left="extrasmall">
-								<Text overflow="ellipsis" color="gray1" weight="bold" size="small">
-									{originalDate}
-								</Text>
-							</Padding>
 						</Row>
 					)}
-					<Row width="100%" mainAlignment="flex-start">
-						<Text color="warning.focus" size="small">
-							{t('label.proposed', 'Proposed')}:
+					<Row width="100%" mainAlignment="flex-start" crossAlignment="flex-start">
+						<Text overflow="break-word" color="warning.focus" size="small">
+							{`${t('label.proposed', 'Proposed')}: ${counterDate}`}
 						</Text>
-						<Padding left="extrasmall">
-							<Text overflow="ellipsis" color="warning.focus" size="small">
-								{counterDate}
-							</Text>
-						</Padding>
 						{showTimezoneIndicator && (
 							<Tooltip label={timezoneTooltip}>
 								<Padding left="small">

--- a/src/shared/invite-response/parts/invite-header-part.tsx
+++ b/src/shared/invite-response/parts/invite-header-part.tsx
@@ -6,6 +6,7 @@
 
 import React, { FC, ReactElement, useMemo } from 'react';
 
+import styled from '@emotion/styled';
 import { Icon, Padding, Row, Tooltip, Text } from '@zextras/carbonio-design-system';
 import { FOLDERS } from '@zextras/carbonio-ui-commons';
 import { Trans, useTranslation } from 'react-i18next';
@@ -15,6 +16,13 @@ import { useGetDateRangeConvertedToTimezone } from 'hooks/use-get-date-range-con
 import { Invite } from 'types/store/invite';
 import { parseDateFromICS } from 'utils/dates';
 import { isSentOnBehalfOf } from 'utils/organizer';
+
+// keeps the indicator in the text flow, so it follows the last line instead of dropping below it
+const InlineTimezoneIndicator = styled.span`
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: ${({ theme }): string => theme.sizes.padding.extrasmall};
+`;
 
 type InviteHeaderPartProps = {
 	mailMsg: any;
@@ -134,17 +142,17 @@ export const InviteHeaderPart: FC<InviteHeaderPartProps> = ({
 							</Text>
 						</Row>
 					)}
-					<Row width="100%" mainAlignment="flex-start" crossAlignment="flex-start">
+					<Row width="100%" mainAlignment="flex-start">
 						<Text overflow="break-word" color="warning.focus" size="small">
 							{`${t('label.proposed', 'Proposed')}: ${counterDate}`}
+							{showTimezoneIndicator && (
+								<Tooltip label={timezoneTooltip}>
+									<InlineTimezoneIndicator>
+										<Icon icon="GlobeOutline" color="gray1" />
+									</InlineTimezoneIndicator>
+								</Tooltip>
+							)}
 						</Text>
-						{showTimezoneIndicator && (
-							<Tooltip label={timezoneTooltip}>
-								<Padding left="small">
-									<Icon icon="GlobeOutline" color="gray1" />
-								</Padding>
-							</Tooltip>
-						)}
 					</Row>
 				</>
 			)}

--- a/src/shared/invite-response/parts/proposed-time-reply.tsx
+++ b/src/shared/invite-response/parts/proposed-time-reply.tsx
@@ -3,9 +3,16 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import React, { FC, ReactElement, useCallback } from 'react';
+import React, { FC, ReactElement, useCallback, useRef, useState } from 'react';
 
-import { Container, Padding, Button, Divider, useSnackbar } from '@zextras/carbonio-design-system';
+import {
+	Container,
+	Padding,
+	Button,
+	Divider,
+	Text,
+	useSnackbar
+} from '@zextras/carbonio-design-system';
 import { useIntegratedFunction } from '@zextras/carbonio-shell-ui';
 import { useFoldersMap } from '@zextras/carbonio-ui-commons';
 import { find, map } from 'lodash';
@@ -32,6 +39,8 @@ function resolveCompTimestamp(
 	return fallback;
 }
 
+type SubmissionStatus = 'idle' | 'submitting' | 'accepted';
+
 const ProposedTimeReply: FC<ProposedTimeReplyArguments> = ({
 	id,
 	moveToTrash,
@@ -48,9 +57,38 @@ const ProposedTimeReply: FC<ProposedTimeReplyArguments> = ({
 	const calendarFolders = useFoldersMap();
 	const [openComposer, available] = useIntegratedFunction('compose');
 
+	// Accepting spans three chained requests and sends a notification to the attendee, so a
+	// second click must be impossible. A ref is set synchronously before the first request,
+	// while a state update could still be uncommitted when the second click arrives. It is
+	// released only on failure: after a successful accept the proposal cannot be replied to again.
+	const submissionLock = useRef(false);
+	const [status, setStatus] = useState<SubmissionStatus>('idle');
+
 	const acceptProposedTime = useCallback(() => {
-		getAppointment(id).then((res) => {
-			if (res?.appt?.[0]) {
+		if (submissionLock.current) {
+			return;
+		}
+		submissionLock.current = true;
+		setStatus('submitting');
+
+		const handleFailure = (): void => {
+			submissionLock.current = false;
+			setStatus('idle');
+			createSnackbar({
+				key: 'proposedTimeAcceptFailed',
+				replace: true,
+				severity: 'error',
+				hideButton: true,
+				label: t('label.error_try_again', 'Something went wrong, please try again'),
+				autoHideTimeout: 3000
+			});
+		};
+
+		getAppointment(id)
+			.then((res) => {
+				if (!res?.appt?.[0]) {
+					throw new Error('Appointment not found');
+				}
 				const inviteToNormalize =
 					find(
 						res.appt[0]?.inv,
@@ -65,57 +103,58 @@ const ProposedTimeReply: FC<ProposedTimeReplyArguments> = ({
 					inviteId
 				};
 
-				dispatch(
+				return dispatch(
 					getInvite({
 						inviteId,
 						ridZ
 					})
 				).then((res2) => {
 					const calendar = find(calendarFolders, ['id', folderId]);
-					if (calendar && res2?.payload?.m) {
-						const invite = normalizeInvite(res2?.payload.m[0]);
-						const appointment = normalizeFromGetAppointment(appointmentToNormalize);
-						const event = normalizeCalendarEvent({ appointment, invite, calendar });
-						const startComp = appointmentToNormalize?.inv?.[0]?.comp?.[0].s?.[0];
-						const endComp = appointmentToNormalize?.inv?.[0]?.comp?.[0].e?.[0];
-						const editor = generateEditor({
-							event,
-							invite,
-							context: {
-								attendees: map(invite.attendees, (attendee) => ({ email: attendee.a })),
-								isInstance: !!ridZ,
-								originalStart: resolveCompTimestamp(startComp, start),
-								originalEnd: resolveCompTimestamp(endComp, end),
-								exceptId: msg?.invite?.[0]?.comp?.[0]?.exceptId,
-								start,
-								end,
-								folders: calendarFolders,
-								dispatch,
-								panel: false
-							}
-						});
-
-						dispatch(modifyAppointment({ draft: false, editor })).then(({ payload }) => {
-							const { response, error } = payload;
-							if (response && !error) {
-								dispatch(updateEditor({ id: payload.editor.id, editor: payload.editor }));
-							}
-							createSnackbar({
-								key: error ? 'proposedTimeDeclined' : 'proposedTimeAccepted',
-								replace: true,
-								severity: error ? 'error' : 'success',
-								hideButton: true,
-								label: error
-									? t('label.error_try_again', 'Something went wrong, please try again')
-									: t('snackbar.proposed_time_accepted', 'You accepted the proposed time'),
-								autoHideTimeout: 3000
-							});
-							moveToTrash?.();
-						});
+					if (!calendar || !res2?.payload?.m) {
+						throw new Error('Calendar or invite not available');
 					}
+					const invite = normalizeInvite(res2?.payload.m[0]);
+					const appointment = normalizeFromGetAppointment(appointmentToNormalize);
+					const event = normalizeCalendarEvent({ appointment, invite, calendar });
+					const startComp = appointmentToNormalize?.inv?.[0]?.comp?.[0].s?.[0];
+					const endComp = appointmentToNormalize?.inv?.[0]?.comp?.[0].e?.[0];
+					const editor = generateEditor({
+						event,
+						invite,
+						context: {
+							attendees: map(invite.attendees, (attendee) => ({ email: attendee.a })),
+							isInstance: !!ridZ,
+							originalStart: resolveCompTimestamp(startComp, start),
+							originalEnd: resolveCompTimestamp(endComp, end),
+							exceptId: msg?.invite?.[0]?.comp?.[0]?.exceptId,
+							start,
+							end,
+							folders: calendarFolders,
+							dispatch,
+							panel: false
+						}
+					});
+
+					return dispatch(modifyAppointment({ draft: false, editor })).then(({ payload }) => {
+						// payload is undefined when the request throws, and carries error: true on a fault
+						if (!payload?.response || payload.error) {
+							throw new Error('Modify appointment failed');
+						}
+						dispatch(updateEditor({ id: payload.editor.id, editor: payload.editor }));
+						setStatus('accepted');
+						createSnackbar({
+							key: 'proposedTimeAccepted',
+							replace: true,
+							severity: 'success',
+							hideButton: true,
+							label: t('snackbar.proposed_time_accepted', 'You accepted the proposed time'),
+							autoHideTimeout: 3000
+						});
+						moveToTrash?.();
+					});
 				});
-			}
-		});
+			})
+			.catch(handleFailure);
 	}, [calendarFolders, createSnackbar, dispatch, end, id, moveToTrash, msg?.invite, start, t]);
 
 	const declineProposedTime = useCallback(() => {
@@ -144,6 +183,8 @@ const ProposedTimeReply: FC<ProposedTimeReplyArguments> = ({
 						icon="CheckmarkOutline"
 						color="success"
 						onClick={acceptProposedTime}
+						disabled={status !== 'idle'}
+						loading={status === 'submitting'}
 					/>
 				</Padding>
 				<Padding right="small" vertical="medium">
@@ -153,9 +194,17 @@ const ProposedTimeReply: FC<ProposedTimeReplyArguments> = ({
 						icon="Close"
 						color="error"
 						onClick={declineProposedTime}
+						disabled={status !== 'idle'}
 					/>
 				</Padding>
 			</Container>
+			{status === 'accepted' && (
+				<Padding bottom="small">
+					<Text color="secondary" size="small">
+						{t('label.proposed_time_accepted', 'You accepted the proposed time')}
+					</Text>
+				</Padding>
+			)}
 			<Divider />
 		</>
 	);

--- a/src/shared/invite-response/parts/proposed-time-reply.tsx
+++ b/src/shared/invite-response/parts/proposed-time-reply.tsx
@@ -52,7 +52,8 @@ const ProposedTimeReply: FC<ProposedTimeReplyArguments> = ({
 	start,
 	end,
 	msg,
-	to
+	to,
+	proposalApplied = false
 }): ReactElement => {
 	const [t] = useTranslation();
 	const createSnackbar = useSnackbar();
@@ -68,8 +69,9 @@ const ProposedTimeReply: FC<ProposedTimeReplyArguments> = ({
 	});
 	// Acceptance is kept in a store rather than in component state: the mails module re-creates
 	// this panel once the counter mail is trashed, and mount-scoped state would come back reset,
-	// re-enabling the button and letting the attendee receive a duplicate notification.
-	const isAccepted = useIsProposalAccepted(proposalKey);
+	// re-enabling the button and letting the attendee receive a duplicate notification. The store
+	// is gone after a reload, so the appointment itself is the fallback source of truth.
+	const isAccepted = useIsProposalAccepted(proposalKey) || proposalApplied;
 	// A ref set synchronously before the first request is what stops a second click landing
 	// while the chain is in flight, since a state update may not be committed yet.
 	const submissionLock = useRef(false);

--- a/src/shared/invite-response/parts/proposed-time-reply.tsx
+++ b/src/shared/invite-response/parts/proposed-time-reply.tsx
@@ -10,6 +10,7 @@ import {
 	Padding,
 	Button,
 	Divider,
+	Icon,
 	Text,
 	useSnackbar
 } from '@zextras/carbonio-design-system';
@@ -192,47 +193,52 @@ const ProposedTimeReply: FC<ProposedTimeReplyArguments> = ({
 
 	return (
 		<>
-			<Container
-				orientation="horizontal"
-				crossAlignment="flex-start"
-				mainAlignment="flex-start"
-				width="fill"
-				height="fit"
-				padding={{ vertical: 'small' }}
-			>
-				<Padding right="small" vertical="medium">
-					<Button
-						type="outlined"
-						label={t('event.action.accept', 'Accept')}
-						icon="CheckmarkOutline"
-						color="success"
-						onClick={acceptProposedTime}
-						disabled={isAccepted || isSubmitting}
-						loading={isSubmitting}
-					/>
-				</Padding>
-				<Padding right="small" vertical="medium">
-					<Button
-						type="outlined"
-						label={t('event.action.decline', 'Decline')}
-						icon="Close"
-						color="error"
-						onClick={declineProposedTime}
-						disabled={isAccepted || isSubmitting}
-					/>
-				</Padding>
-			</Container>
-			{isAccepted && (
+			{isAccepted ? (
 				<Container
+					orientation="horizontal"
+					crossAlignment="center"
+					mainAlignment="flex-start"
+					width="fill"
+					height="fit"
+					padding={{ vertical: 'small' }}
+				>
+					<Padding right="small">
+						<Icon icon="CheckmarkOutline" color="success" size="large" />
+					</Padding>
+					<Text color="success" weight="bold" size="small">
+						{t('label.proposed_time_accepted', 'You have accepted the proposed new time.')}
+					</Text>
+				</Container>
+			) : (
+				<Container
+					orientation="horizontal"
 					crossAlignment="flex-start"
 					mainAlignment="flex-start"
 					width="fill"
 					height="fit"
-					padding={{ bottom: 'small' }}
+					padding={{ vertical: 'small' }}
 				>
-					<Text color="secondary" size="small">
-						{t('label.proposed_time_accepted', 'You accepted the proposed time')}
-					</Text>
+					<Padding right="small" vertical="medium">
+						<Button
+							type="outlined"
+							label={t('event.action.accept', 'Accept')}
+							icon="CheckmarkOutline"
+							color="success"
+							onClick={acceptProposedTime}
+							disabled={isSubmitting}
+							loading={isSubmitting}
+						/>
+					</Padding>
+					<Padding right="small" vertical="medium">
+						<Button
+							type="outlined"
+							label={t('event.action.decline', 'Decline')}
+							icon="Close"
+							color="error"
+							onClick={declineProposedTime}
+							disabled={isSubmitting}
+						/>
+					</Padding>
 				</Container>
 			)}
 			<Divider />

--- a/src/shared/invite-response/parts/proposed-time-reply.tsx
+++ b/src/shared/invite-response/parts/proposed-time-reply.tsx
@@ -26,6 +26,11 @@ import { getInvite } from '../../../store/actions/get-invite';
 import { modifyAppointment } from '../../../store/actions/new-modify-appointment';
 import { useAppDispatch } from '../../../store/redux/hooks';
 import { updateEditor } from '../../../store/slices/editor-slice';
+import {
+	getProposalKey,
+	markProposalAsAccepted,
+	useIsProposalAccepted
+} from '../../../store/zustand/accepted-proposals-store';
 import { ProposedTimeReplyArguments } from '../../../types/integrations';
 import { parseDateFromICS } from '../../../utils/dates';
 
@@ -38,8 +43,6 @@ function resolveCompTimestamp(
 	if (comp.d) return parseDateFromICS(comp.d).getTime();
 	return fallback;
 }
-
-type SubmissionStatus = 'idle' | 'submitting' | 'accepted';
 
 const ProposedTimeReply: FC<ProposedTimeReplyArguments> = ({
 	id,
@@ -57,23 +60,31 @@ const ProposedTimeReply: FC<ProposedTimeReplyArguments> = ({
 	const calendarFolders = useFoldersMap();
 	const [openComposer, available] = useIntegratedFunction('compose');
 
-	// Accepting spans three chained requests and sends a notification to the attendee, so a
-	// second click must be impossible. A ref is set synchronously before the first request,
-	// while a state update could still be uncommitted when the second click arrives. It is
-	// released only on failure: after a successful accept the proposal cannot be replied to again.
+	const proposalKey = getProposalKey({
+		messageId: msg?.id,
+		ridZ: msg?.invite?.[0]?.comp?.[0]?.ridZ,
+		start,
+		end
+	});
+	// Acceptance is kept in a store rather than in component state: the mails module re-creates
+	// this panel once the counter mail is trashed, and mount-scoped state would come back reset,
+	// re-enabling the button and letting the attendee receive a duplicate notification.
+	const isAccepted = useIsProposalAccepted(proposalKey);
+	// A ref set synchronously before the first request is what stops a second click landing
+	// while the chain is in flight, since a state update may not be committed yet.
 	const submissionLock = useRef(false);
-	const [status, setStatus] = useState<SubmissionStatus>('idle');
+	const [isSubmitting, setIsSubmitting] = useState(false);
 
 	const acceptProposedTime = useCallback(() => {
 		if (submissionLock.current) {
 			return;
 		}
 		submissionLock.current = true;
-		setStatus('submitting');
+		setIsSubmitting(true);
 
 		const handleFailure = (): void => {
 			submissionLock.current = false;
-			setStatus('idle');
+			setIsSubmitting(false);
 			createSnackbar({
 				key: 'proposedTimeAcceptFailed',
 				replace: true,
@@ -141,7 +152,7 @@ const ProposedTimeReply: FC<ProposedTimeReplyArguments> = ({
 							throw new Error('Modify appointment failed');
 						}
 						dispatch(updateEditor({ id: payload.editor.id, editor: payload.editor }));
-						setStatus('accepted');
+						markProposalAsAccepted(proposalKey);
 						createSnackbar({
 							key: 'proposedTimeAccepted',
 							replace: true,
@@ -155,7 +166,18 @@ const ProposedTimeReply: FC<ProposedTimeReplyArguments> = ({
 				});
 			})
 			.catch(handleFailure);
-	}, [calendarFolders, createSnackbar, dispatch, end, id, moveToTrash, msg?.invite, start, t]);
+	}, [
+		calendarFolders,
+		createSnackbar,
+		dispatch,
+		end,
+		id,
+		moveToTrash,
+		msg?.invite,
+		proposalKey,
+		start,
+		t
+	]);
 
 	const declineProposedTime = useCallback(() => {
 		if (available)
@@ -183,8 +205,8 @@ const ProposedTimeReply: FC<ProposedTimeReplyArguments> = ({
 						icon="CheckmarkOutline"
 						color="success"
 						onClick={acceptProposedTime}
-						disabled={status !== 'idle'}
-						loading={status === 'submitting'}
+						disabled={isAccepted || isSubmitting}
+						loading={isSubmitting}
 					/>
 				</Padding>
 				<Padding right="small" vertical="medium">
@@ -194,16 +216,22 @@ const ProposedTimeReply: FC<ProposedTimeReplyArguments> = ({
 						icon="Close"
 						color="error"
 						onClick={declineProposedTime}
-						disabled={status !== 'idle'}
+						disabled={isAccepted || isSubmitting}
 					/>
 				</Padding>
 			</Container>
-			{status === 'accepted' && (
-				<Padding bottom="small">
+			{isAccepted && (
+				<Container
+					crossAlignment="flex-start"
+					mainAlignment="flex-start"
+					width="fill"
+					height="fit"
+					padding={{ bottom: 'small' }}
+				>
 					<Text color="secondary" size="small">
 						{t('label.proposed_time_accepted', 'You accepted the proposed time')}
 					</Text>
-				</Padding>
+				</Container>
 			)}
 			<Divider />
 		</>

--- a/src/shared/invite-response/proposal-status.ts
+++ b/src/shared/invite-response/proposal-status.ts
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { find } from 'lodash';
+
+type InviteComponentTime = { d?: string; u?: number; tz?: string };
+
+const isSameTime = (applied?: InviteComponentTime, proposed?: InviteComponentTime): boolean => {
+	if (!applied || !proposed) {
+		return false;
+	}
+	if (applied.u !== undefined && proposed.u !== undefined) {
+		return applied.u === proposed.u;
+	}
+	// all day components carry only the date
+	return !!applied.d && applied.d === proposed.d && applied.tz === proposed.tz;
+};
+
+/**
+ * Tells whether the appointment already sits at the time a counter proposal asks for, which
+ * means the proposal has been accepted at some point — possibly in an earlier session or from
+ * another client.
+ *
+ * The invite to compare against cannot be taken from index 0: for a recurring appointment that
+ * is the series master, while a proposal targets a single instance. The instance is matched by
+ * recurrence id, exactly as accepting does. Before acceptance a series instance has no exception
+ * of its own, so the lookup falls back to the master and the times will not match.
+ */
+export const isProposalAlreadyApplied = ({
+	fetchedInvites,
+	counterInvite
+}: {
+	// TODO: type this properly once the mail message has a real type
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	fetchedInvites: any;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	counterInvite: any;
+}): boolean => {
+	// the fetch seeds its state with the counter mail's own invite, whose times are the proposed
+	// ones: comparing then would always report a match
+	if (!fetchedInvites || fetchedInvites === counterInvite) {
+		return false;
+	}
+	const counterComponent = counterInvite?.[0]?.comp?.[0];
+	if (!counterComponent) {
+		return false;
+	}
+	const appliedComponent = (
+		find(fetchedInvites, (inv) => inv?.comp?.[0]?.ridZ === counterComponent.ridZ) ??
+		fetchedInvites?.[0]
+	)?.comp?.[0];
+
+	return (
+		isSameTime(appliedComponent?.s?.[0], counterComponent?.s?.[0]) &&
+		isSameTime(appliedComponent?.e?.[0], counterComponent?.e?.[0])
+	);
+};

--- a/src/shared/invite-response/tests/invite-response.test.tsx
+++ b/src/shared/invite-response/tests/invite-response.test.tsx
@@ -33,6 +33,7 @@ import * as moveAppointmentHandler from 'store/actions/move-appointment';
 import * as modifyAppointmentHandler from 'store/actions/new-modify-appointment';
 import * as sendInviteResponseHandler from 'store/actions/send-invite-response';
 import { reducers } from 'store/redux';
+import { useAcceptedProposalsStore } from 'store/zustand/accepted-proposals-store';
 import mockedData from 'test/generators';
 import {
 	exceptionAppointmentAllDayResponse,
@@ -65,6 +66,11 @@ const setupFoldersStore = (): void => {
 };
 
 describe('invite response component', () => {
+	beforeEach(() => {
+		// the store is module scoped on purpose, so it has to be cleared between tests
+		useAcceptedProposalsStore.setState({ acceptedProposals: {} });
+	});
+
 	describe('case invitation email', () => {
 		test('have a container with border of 0.0625rem solid regular', async () => {
 			setupFoldersStore();
@@ -1256,6 +1262,43 @@ describe('invite response component', () => {
 							expect(screen.getAllByText('You accepted the proposed time').length).toBeGreaterThan(
 								0
 							);
+						});
+						test('stays accepted when the panel is re-created after the counter mail is trashed', async () => {
+							setupServerSingleEventResponse(singleAppointmentResponse, singleGetMsgResponse);
+							setupFoldersStore();
+							const modifyAppointmentSpy = vi.spyOn(modifyAppointmentHandler, 'modifyAppointment');
+							const mailMsg = buildMailMessageType(
+								MESSAGE_METHOD.COUNTER,
+								MESSAGE_TYPE.SINGLE,
+								false
+							);
+							const store = configureStore({ reducer: combineReducers(reducers) });
+							const { user, unmount } = setupTest(
+								<InviteResponse mailMsg={mailMsg} moveToTrash={vi.fn()} />,
+								{
+									store
+								}
+							);
+
+							await act(async () => {
+								await user.click(await screen.findByRole('button', { name: /Accept/i }));
+							});
+							expect(modifyAppointmentSpy).toHaveBeenCalledTimes(1);
+
+							// the mails module re-creates the panel once the mail is moved to trash
+							unmount();
+							setupTest(<InviteResponse mailMsg={mailMsg} moveToTrash={vi.fn()} />, {
+								store
+							});
+
+							const acceptAfterRemount = await screen.findByRole('button', { name: /Accept/i });
+							await waitFor(() => {
+								expect(acceptAfterRemount).toBeDisabled();
+							});
+							expect(screen.getByRole('button', { name: /Decline/i })).toBeDisabled();
+							expect(modifyAppointmentSpy).toHaveBeenCalledTimes(1);
+
+							modifyAppointmentSpy.mockClear();
 						});
 						test('shows an error and keeps the counter mail when the appointment cannot be retrieved', async () => {
 							setupFoldersStore();

--- a/src/shared/invite-response/tests/invite-response.test.tsx
+++ b/src/shared/invite-response/tests/invite-response.test.tsx
@@ -7,13 +7,15 @@
 import React from 'react';
 
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
-import { act, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { useFolderStore } from '@zextras/carbonio-ui-commons';
 import { parse } from 'date-fns';
 import { keyBy, values } from 'lodash';
+import { http, HttpResponse } from 'msw';
 
 import * as handler from '../../../commons/get-appointment';
 import { CALENDAR_BOARD_ID } from '../../../constants';
+import { getSetupServer } from '@jest-setup';
 import * as mockshell from '@test-mocks/@zextras/carbonio-shell-ui';
 import { setupTest } from '@test-setup';
 import { generateRoots } from '@test-utils/folders/roots-generator';
@@ -46,6 +48,7 @@ import {
 	singleGetMsgAllDayResponse,
 	singleGetMsgResponse
 } from 'test/mocks/network/msw/handle-get-invite';
+import { handleModifyAppointmentRequest } from 'test/mocks/network/msw/handle-modify-appointment';
 
 const roots = generateRoots();
 const folder = mockedData.calendars.defaultCalendar;
@@ -1087,7 +1090,7 @@ describe('invite response component', () => {
 					test.todo('has text color green');
 					// icon: CheckmarkOutline
 					test.todo('has a checkmark icon');
-					test('it is always enabled', async () => {
+					test('it is enabled before any action is taken', async () => {
 						setupFoldersStore();
 						const mailMsg = buildMailMessageType(
 							MESSAGE_METHOD.COUNTER,
@@ -1189,6 +1192,143 @@ describe('invite response component', () => {
 							expect(modifyAppointmentSpy).toHaveBeenCalledTimes(1);
 
 							modifyAppointmentSpy.mockClear();
+						});
+						test('clicking twice in rapid succession sends a single ModifyAppointment request', async () => {
+							setupServerSingleEventResponse(singleAppointmentResponse, singleGetMsgResponse);
+							setupFoldersStore();
+							const modifyAppointmentSpy = vi.spyOn(modifyAppointmentHandler, 'modifyAppointment');
+							const mailMsg = buildMailMessageType(
+								MESSAGE_METHOD.COUNTER,
+								MESSAGE_TYPE.SINGLE,
+								false
+							);
+							const store = configureStore({ reducer: combineReducers(reducers) });
+							setupTest(<InviteResponse mailMsg={mailMsg} moveToTrash={vi.fn()} />, {
+								store
+							});
+
+							const acceptProposedTimeButton = await screen.findByRole('button', {
+								name: /Accept/i
+							});
+
+							// fireEvent instead of user.click: both clicks must land in the same tick,
+							// before React can commit the disabled state, otherwise the test would pass
+							// even without the guard
+							/* eslint-disable testing-library/no-unnecessary-act, testing-library/prefer-user-event */
+							await act(async () => {
+								fireEvent.click(acceptProposedTimeButton);
+								fireEvent.click(acceptProposedTimeButton);
+							});
+							/* eslint-enable testing-library/no-unnecessary-act, testing-library/prefer-user-event */
+
+							expect(modifyAppointmentSpy).toHaveBeenCalledTimes(1);
+
+							modifyAppointmentSpy.mockClear();
+						});
+						test('both buttons are disabled and a confirmation is shown once accepted', async () => {
+							setupServerSingleEventResponse(singleAppointmentResponse, singleGetMsgResponse);
+							setupFoldersStore();
+							const mailMsg = buildMailMessageType(
+								MESSAGE_METHOD.COUNTER,
+								MESSAGE_TYPE.SINGLE,
+								false
+							);
+							const store = configureStore({ reducer: combineReducers(reducers) });
+							const { user } = setupTest(
+								<InviteResponse mailMsg={mailMsg} moveToTrash={vi.fn()} />,
+								{
+									store
+								}
+							);
+
+							const acceptProposedTimeButton = await screen.findByRole('button', {
+								name: /Accept/i
+							});
+							await act(async () => {
+								await user.click(acceptProposedTimeButton);
+							});
+
+							await waitFor(() => {
+								expect(acceptProposedTimeButton).toBeDisabled();
+							});
+							expect(screen.getByRole('button', { name: /Decline/i })).toBeDisabled();
+							// the snackbar carries the same label, so more than one match is expected
+							expect(screen.getAllByText('You accepted the proposed time').length).toBeGreaterThan(
+								0
+							);
+						});
+						test('shows an error and keeps the counter mail when the appointment cannot be retrieved', async () => {
+							setupFoldersStore();
+							const moveToTrash = vi.fn();
+							const mailMsg = buildMailMessageType(
+								MESSAGE_METHOD.COUNTER,
+								MESSAGE_TYPE.SINGLE,
+								false
+							);
+							createSoapAPIInterceptor('GetAppointment', {});
+							const store = configureStore({ reducer: combineReducers(reducers) });
+							const { user } = setupTest(
+								<InviteResponse mailMsg={mailMsg} moveToTrash={moveToTrash} />,
+								{
+									store
+								}
+							);
+
+							const acceptProposedTimeButton = await screen.findByRole('button', {
+								name: /Accept/i
+							});
+							await act(async () => {
+								await user.click(acceptProposedTimeButton);
+							});
+
+							expect(
+								await screen.findByText('Something went wrong, please try again')
+							).toBeVisible();
+							expect(moveToTrash).not.toHaveBeenCalled();
+							// the button must not stay stuck in the submitting state
+							await waitFor(() => {
+								expect(acceptProposedTimeButton).toBeEnabled();
+							});
+						});
+						test('does not move the counter mail to trash when the modify request fails', async () => {
+							setupServerSingleEventResponse(singleAppointmentResponse, singleGetMsgResponse);
+							getSetupServer().use(
+								http.post('/service/soap/ModifyAppointmentRequest', async () =>
+									HttpResponse.json({ Body: { Fault: {} } })
+								)
+							);
+							setupFoldersStore();
+							const moveToTrash = vi.fn();
+							const mailMsg = buildMailMessageType(
+								MESSAGE_METHOD.COUNTER,
+								MESSAGE_TYPE.SINGLE,
+								false
+							);
+							const store = configureStore({ reducer: combineReducers(reducers) });
+							const { user } = setupTest(
+								<InviteResponse mailMsg={mailMsg} moveToTrash={moveToTrash} />,
+								{
+									store
+								}
+							);
+
+							const acceptProposedTimeButton = await screen.findByRole('button', {
+								name: /Accept/i
+							});
+							await act(async () => {
+								await user.click(acceptProposedTimeButton);
+							});
+
+							expect(
+								await screen.findByText('Something went wrong, please try again')
+							).toBeVisible();
+							expect(moveToTrash).not.toHaveBeenCalled();
+
+							// runtime handlers are only reset in afterAll, so the failing one must be
+							// replaced here or it would leak into every following test
+							getSetupServer().use(
+								http.post('/service/soap/ModifyAppointmentRequest', handleModifyAppointmentRequest)
+							);
 						});
 						test('if the event is non recurrent a non recurrent editor is created', async () => {
 							setupFoldersStore();
@@ -1396,7 +1536,7 @@ describe('invite response component', () => {
 					test.todo('has text color red');
 					// icon: CloseOutline
 					test.todo('has a close icon');
-					test('it is always enabled', async () => {
+					test('it is enabled before any action is taken', async () => {
 						setupFoldersStore();
 						const mailMsg = buildMailMessageType(
 							MESSAGE_METHOD.COUNTER,

--- a/src/shared/invite-response/tests/invite-response.test.tsx
+++ b/src/shared/invite-response/tests/invite-response.test.tsx
@@ -1265,7 +1265,7 @@ describe('invite response component', () => {
 
 							modifyAppointmentSpy.mockClear();
 						});
-						test('both buttons are disabled and a confirmation is shown once accepted', async () => {
+						test('the buttons are replaced by a confirmation once accepted', async () => {
 							setupServerSingleEventResponse(singleAppointmentResponse, singleGetMsgResponse);
 							setupFoldersStore();
 							const mailMsg = buildMailMessageType(
@@ -1289,13 +1289,10 @@ describe('invite response component', () => {
 							});
 
 							await waitFor(() => {
-								expect(acceptProposedTimeButton).toBeDisabled();
+								expect(screen.queryByRole('button', { name: /Accept/i })).not.toBeInTheDocument();
 							});
-							expect(screen.getByRole('button', { name: /Decline/i })).toBeDisabled();
-							// the snackbar carries the same label, so more than one match is expected
-							expect(screen.getAllByText('You accepted the proposed time').length).toBeGreaterThan(
-								0
-							);
+							expect(screen.queryByRole('button', { name: /Decline/i })).not.toBeInTheDocument();
+							expect(screen.getByText('You have accepted the proposed new time.')).toBeVisible();
 						});
 						test('stays accepted when the panel is re-created after the counter mail is trashed', async () => {
 							setupServerSingleEventResponse(singleAppointmentResponse, singleGetMsgResponse);
@@ -1325,11 +1322,11 @@ describe('invite response component', () => {
 								store
 							});
 
-							const acceptAfterRemount = await screen.findByRole('button', { name: /Accept/i });
-							await waitFor(() => {
-								expect(acceptAfterRemount).toBeDisabled();
-							});
-							expect(screen.getByRole('button', { name: /Decline/i })).toBeDisabled();
+							expect(
+								await screen.findByText('You have accepted the proposed new time.')
+							).toBeVisible();
+							expect(screen.queryByRole('button', { name: /Accept/i })).not.toBeInTheDocument();
+							expect(screen.queryByRole('button', { name: /Decline/i })).not.toBeInTheDocument();
 							expect(modifyAppointmentSpy).toHaveBeenCalledTimes(1);
 
 							modifyAppointmentSpy.mockClear();
@@ -1357,12 +1354,11 @@ describe('invite response component', () => {
 								store
 							});
 
-							const accept = await screen.findByRole('button', { name: /Accept/i });
-							await waitFor(() => {
-								expect(accept).toBeDisabled();
-							});
-							expect(screen.getByRole('button', { name: /Decline/i })).toBeDisabled();
-							expect(screen.getByText('You accepted the proposed time')).toBeVisible();
+							expect(
+								await screen.findByText('You have accepted the proposed new time.')
+							).toBeVisible();
+							expect(screen.queryByRole('button', { name: /Accept/i })).not.toBeInTheDocument();
+							expect(screen.queryByRole('button', { name: /Decline/i })).not.toBeInTheDocument();
 						});
 						test('shows an error and keeps the counter mail when the appointment cannot be retrieved', async () => {
 							setupFoldersStore();

--- a/src/shared/invite-response/tests/invite-response.test.tsx
+++ b/src/shared/invite-response/tests/invite-response.test.tsx
@@ -1300,6 +1300,36 @@ describe('invite response component', () => {
 
 							modifyAppointmentSpy.mockClear();
 						});
+						test('is already accepted when the appointment sits at the proposed time', async () => {
+							setupServerSingleEventResponse(singleAppointmentResponse, singleGetMsgResponse);
+							setupFoldersStore();
+							const appointmentComp = singleAppointmentResponse.appt[0].inv[0].comp[0];
+							// a proposal accepted before this session shows up only in the appointment
+							const mailMsg = buildMailMessageType(
+								MESSAGE_METHOD.COUNTER,
+								MESSAGE_TYPE.SINGLE,
+								false,
+								{
+									invite: [
+										{
+											tz: [],
+											comp: [{ apptId: '1484', s: appointmentComp.s, e: appointmentComp.e }]
+										}
+									]
+								} as never
+							);
+							const store = configureStore({ reducer: combineReducers(reducers) });
+							setupTest(<InviteResponse mailMsg={mailMsg} moveToTrash={vi.fn()} />, {
+								store
+							});
+
+							const accept = await screen.findByRole('button', { name: /Accept/i });
+							await waitFor(() => {
+								expect(accept).toBeDisabled();
+							});
+							expect(screen.getByRole('button', { name: /Decline/i })).toBeDisabled();
+							expect(screen.getByText('You accepted the proposed time')).toBeVisible();
+						});
 						test('shows an error and keeps the counter mail when the appointment cannot be retrieved', async () => {
 							setupFoldersStore();
 							const moveToTrash = vi.fn();

--- a/src/shared/invite-response/tests/invite-response.test.tsx
+++ b/src/shared/invite-response/tests/invite-response.test.tsx
@@ -1024,7 +1024,9 @@ describe('invite response component', () => {
 				expect(titleString).toHaveStyleRule('font-size', '1.125rem');
 
 				expect(
-					screen.getByText('Tuesday, January 30, 2024, 9:00 – 9:30 AM GMT+01:00 Europe/Berlin')
+					screen.getByText(
+						'Proposed: Tuesday, January 30, 2024, 9:00 – 9:30 AM GMT+01:00 Europe/Berlin'
+					)
 				).toBeVisible();
 			});
 			test('a string with the user local time of the event', async () => {
@@ -1037,7 +1039,7 @@ describe('invite response component', () => {
 				});
 
 				const localTimeString = await screen.findByText(
-					'Tuesday, January 30, 2024, 9:00 – 9:30 AM GMT+01:00 Europe/Berlin'
+					'Proposed: Tuesday, January 30, 2024, 9:00 – 9:30 AM GMT+01:00 Europe/Berlin'
 				);
 
 				expect(localTimeString).toBeVisible();
@@ -1053,14 +1055,15 @@ describe('invite response component', () => {
 					store
 				});
 
-				expect(await screen.findByText('Original:')).toBeVisible();
 				expect(
-					screen.getByText('Monday, February 05, 2024, 4:00 – 4:30 PM GMT+01:00 Europe/Berlin')
+					await screen.findByText(
+						'Original: Monday, February 05, 2024, 4:00 – 4:30 PM GMT+01:00 Europe/Berlin'
+					)
 				).toBeVisible();
-
-				expect(screen.getByText('Proposed:')).toBeVisible();
 				expect(
-					screen.getByText('Tuesday, January 30, 2024, 9:00 – 9:30 AM GMT+01:00 Europe/Berlin')
+					screen.getByText(
+						'Proposed: Tuesday, January 30, 2024, 9:00 – 9:30 AM GMT+01:00 Europe/Berlin'
+					)
 				).toBeVisible();
 			});
 			test('does not show the original time when the appointment details are unavailable', async () => {
@@ -1072,9 +1075,9 @@ describe('invite response component', () => {
 					store
 				});
 
-				await screen.findByText('Proposed:');
+				await screen.findByText(/^Proposed:/);
 
-				expect(screen.queryByText('Original:')).not.toBeInTheDocument();
+				expect(screen.queryByText(/^Original:/)).not.toBeInTheDocument();
 			});
 			test('if the event is created with a different timezone there is an icon with a tooltip showing the local timezone', async () => {
 				setupFoldersStore();
@@ -1097,14 +1100,14 @@ describe('invite response component', () => {
 
 				await user.hover(timezoneIcon);
 
-				const tooltipTitleString = await screen.findByText(/Date and time on creation/i);
-
-				const tooltipLocalTime = await screen.findByText(
-					'Tuesday, January 30, 2024, 1:30 – 2:00 PM GMT+05:30 Asia/Kolkata'
+				// the proposed date is rendered inline in the same timezone, so the tooltip has to be
+				// matched by its title and date together to avoid matching that row instead
+				const creationDate = 'Tuesday, January 30, 2024, 1:30 – 2:00 PM GMT\\+05:30 Asia/Kolkata';
+				const tooltip = await screen.findByText(
+					new RegExp(`Date and time on creation timezone:.*${creationDate}`)
 				);
 
-				expect(tooltipTitleString).toBeVisible();
-				expect(tooltipLocalTime).toBeVisible();
+				expect(tooltip).toBeVisible();
 			});
 			describe('two different buttons to reply to the counter appointment: ', () => {
 				describe('a button to accept the counter appointment', () => {

--- a/src/store/zustand/accepted-proposals-store.ts
+++ b/src/store/zustand/accepted-proposals-store.ts
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { create } from 'zustand';
+
+export type AcceptedProposalsAppState = {
+	acceptedProposals: Record<string, true>;
+};
+
+/**
+ * Counter proposals accepted during this session.
+ *
+ * The mails module re-creates the invite panel once the counter mail is moved to trash, which
+ * wipes any component state. Without this store the accept button would come back enabled and a
+ * second click would send the attendee a duplicate notification.
+ */
+export const useAcceptedProposalsStore = create<AcceptedProposalsAppState>(() => ({
+	acceptedProposals: {}
+}));
+
+/**
+ * Build the identifier of a counter proposal.
+ *
+ * The mail id identifies the proposal on its own, the rest guards against a message being
+ * replaced by a newer proposal for the same appointment. The appointment id alone would not do:
+ * it is shared by a series and all of its exceptions.
+ */
+export const getProposalKey = ({
+	messageId,
+	ridZ,
+	start,
+	end
+}: {
+	messageId: string;
+	ridZ?: string;
+	start: number;
+	end: number;
+}): string => `${messageId}|${ridZ ?? ''}|${start}|${end}`;
+
+export const markProposalAsAccepted = (key: string): void => {
+	useAcceptedProposalsStore.setState((state) => ({
+		acceptedProposals: { ...state.acceptedProposals, [key]: true }
+	}));
+};
+
+export const useIsProposalAccepted = (key: string): boolean =>
+	useAcceptedProposalsStore((state) => state.acceptedProposals[key] ?? false);

--- a/src/types/integrations.ts
+++ b/src/types/integrations.ts
@@ -25,4 +25,6 @@ export type ProposedTimeReplyArguments = {
 	end: number;
 	msg: InviteResponseArguments['mailMsg'];
 	to: Array<{ address: string; fullName: string; name: string; type: string }>;
+	/** the appointment already sits at the proposed time, so the proposal was accepted before */
+	proposalApplied?: boolean;
 };


### PR DESCRIPTION
### What
When an attendee proposes a new time and the organizer clicks Accept, the appointment is updated and the attendee is notified — but the buttons stayed active and the panel looked unchanged. Organizers clicked again and the attendee received duplicate notifications.
  
Accept can now only be actioned once. After accepting, the buttons are replaced by a confirmation, and it stays that way if the view is reopened or the page is reloaded.

### Why
Nothing stopped a second click, and the "already accepted" state was lost every time the mail view was re-created after the message moved to Trash.

### How it looks
Once accepted, the Accept and Decline buttons are replaced by a greenconfirmation: "You have accepted the proposed new time." The original and proposed times stay visible. 

### Also fixed
A failed accept used to move the counter proposal to Trash anyway, losing it with nothing applied. It is now kept, with an error message.

