### PR TITLE
fix(ci): cap vitest forks to 2 to prevent k8s CPU saturation

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
 		clearMocks: true,
 		// mockReset: true,
 		restoreMocks: true,
-		maxWorkers: '50%',
+		maxWorkers: 2,
 		testTimeout: 10000,
 		reporters: ['default', junitReporter],
 		coverage: {


### PR DESCRIPTION
Fixes IN-1154: https://zextras.atlassian.net/browse/IN-1154

vitest 4.x defaults its worker pool to `forks`. In forks mode, `os.availableParallelism()` reads the node's physical core count instead of the pod's CPU limit, so one CI pod ends up spawning as many workers as the host has cores. Three concurrent pods on a 15-core k8s cluster saturated it for ~1.5h and grew the Jenkins queue to 61+ items.

This repo runs vitest **4.1.10** and has no `test:ci` script, so Jenkins (`jenkins-lib-common@v4.2.0`, `uiPipeline()` with no `testScript` override) falls back to the plain `test` script, which just runs `vitest run` and picks up the cap from `vitest.config.ts`. That file already had `maxWorkers: '50%'`, which on a large-core host still translates to double-digit worker counts — replaced with a hard cap of `2`.

Change is limited to the single `maxWorkers` line in `vitest.config.ts`; no other config (coverage, reporters, projects) touched.